### PR TITLE
Added Cisco WS-2960CG-8TL device-type definition

### DIFF
--- a/cisco/ws-2960cg-8tl.yaml
+++ b/cisco/ws-2960cg-8tl.yaml
@@ -1,0 +1,37 @@
+manufacturer: Cisco
+model: WS-2960CG-8TL
+slug: ws-2960cg-8tl
+u_height: 1
+is_full_depth: false
+console_ports:
+  - name: con 0
+power_ports:
+  - name: Built-In
+interfaces:
+  - name: GigabitEthernet0/1
+    type: 1000BASE-T
+    mgmt_only: false
+  - name: GigabitEthernet0/2
+    type: 1000BASE-T
+    mgmt_only: false
+  - name: GigabitEthernet0/3
+    type: 1000BASE-T
+    mgmt_only: false
+  - name: GigabitEthernet0/4
+    type: 1000BASE-T
+    mgmt_only: false
+  - name: GigabitEthernet0/5
+    type: 1000BASE-T
+    mgmt_only: false
+  - name: GigabitEthernet0/6
+    type: 1000BASE-T
+    mgmt_only: false
+  - name: GigabitEthernet0/7
+    type: 1000BASE-T
+    mgmt_only: false
+  - name: GigabitEthernet0/9
+    type: 1000BASE-T
+    mgmt_only: false
+  - name: GigabitEthernet0/10
+    type: 1000BASE-T
+    mgmt_only: false


### PR DESCRIPTION
Hey Jeremy, 

I added a directory for Cisco devices and created a device-type definition for a [Cisco Catalyst 2960CG-8TC-L](https://www.cisco.com/c/en/us/support/switches/catalyst-2960cg-8tc-l-compact-switch/model.html). 

I hope to add more device-types in the future. Let me know if you need me to change anything up.

Thanks!
-Marcus