### PR TITLE
Add Juniper MX10003 chassis

### DIFF
--- a/device-types/Juniper/MX10003-BASE.yaml
+++ b/device-types/Juniper/MX10003-BASE.yaml
@@ -1,0 +1,24 @@
+manufacturer: Juniper
+model: MX10003-BASE
+slug: mx10003-base
+u_height: 3
+interfaces:
+  - name: fxp0
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 1600
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 1600
+  - name: PEM2
+    type: iec-60320-c14
+    maximum_draw: 1600
+  - name: PEM3
+    type: iec-60320-c14
+    maximum_draw: 1600
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Juniper/MX10003-PREMIUM.yaml
+++ b/device-types/Juniper/MX10003-PREMIUM.yaml
@@ -1,0 +1,33 @@
+manufacturer: Juniper
+model: MX10003-PREMIUM
+slug: mx10003-premium
+u_height: 3
+interfaces:
+  - name: fxp0 (re0)
+    type: 1000base-t
+    mgmt_only: true
+  - name: fxp0 (re1)
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 1600
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 1600
+  - name: PEM2
+    type: iec-60320-c14
+    maximum_draw: 1600
+  - name: PEM3
+    type: iec-60320-c14
+    maximum_draw: 1600
+  - name: PEM4
+    type: iec-60320-c14
+    maximum_draw: 1600
+  - name: PEM5
+    type: iec-60320-c14
+    maximum_draw: 1600
+console-ports:
+  - name: Console
+    type: rj-45


### PR DESCRIPTION
Add both chassis configurations as sold by Juniper.

Note: They are both the same chassis, the -PREMIUM bundle just has more components installed by the factory. As they are separate SKUs I included both configurations.