### PR TITLE
Add Juniper QFX5110-48S-4C

### DIFF
--- a/device-types/Juniper/QFX5110-48S-4C.yaml
+++ b/device-types/Juniper/QFX5110-48S-4C.yaml
@@ -1,0 +1,121 @@
+manufacturer: Juniper
+model: QFX5110-48S-4C
+slug: qfx5110-48s-4c
+interfaces:
+  - name: fxp0
+    type: 1000base-t
+    mgmt_only: true
+  - name: xe-0/0/0
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/1
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/2
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/3
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/4
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/5
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/6
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/7
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/8
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/9
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/10
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/11
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/12
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/13
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/14
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/15
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/16
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/17
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/18
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/19
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/20
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/21
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/22
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/23
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/24
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/25
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/26
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/27
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/28
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/29
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/30
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/31
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/32
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/33
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/34
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/35
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/36
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/37
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/38
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/39
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/40
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/41
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/42
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/43
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/44
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/45
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/46
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/47
+    type: 10gbase-x-sfpp
+  - name: xe-0/0/48
+    type: 100gbase-x-qsfp28
+  - name: xe-0/0/49
+    type: 100gbase-x-qsfp28
+  - name: xe-0/0/50
+    type: 100gbase-x-qsfp28
+  - name: xe-0/0/51
+    type: 100gbase-x-qsfp28
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 650
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 650
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Juniper/QFX5110-48S-4C.yaml
+++ b/device-types/Juniper/QFX5110-48S-4C.yaml
@@ -101,13 +101,13 @@ interfaces:
     type: 10gbase-x-sfpp
   - name: xe-0/0/47
     type: 10gbase-x-sfpp
-  - name: xe-0/0/48
+  - name: et-0/0/48
     type: 100gbase-x-qsfp28
-  - name: xe-0/0/49
+  - name: et-0/0/49
     type: 100gbase-x-qsfp28
-  - name: xe-0/0/50
+  - name: et-0/0/50
     type: 100gbase-x-qsfp28
-  - name: xe-0/0/51
+  - name: et-0/0/51
     type: 100gbase-x-qsfp28
 power-ports:
   - name: PSU0


### PR DESCRIPTION
Juniper automatically renames interfaces based on the transceiver installed. A 10G `xe-` port will therefore automatically be renamed to `ge-` the moment a 1G transceiver is plugged in. I included the default names for transceivers with the maximum speed installed, assuming that someone who buys an 48x10G switch will actually use it as 10G.