### PR TITLE
Add Juniper MX204 router

### DIFF
--- a/device-types/Juniper/MX204.yaml
+++ b/device-types/Juniper/MX204.yaml
@@ -1,0 +1,41 @@
+manufacturer: Juniper
+model: MX204
+slug: mx204
+interfaces:
+  - name: fxp0
+    type: 1000base-t
+    mgmt_only: true
+  - name: et-0/0/0
+    type: 100gbase-x-qsfp28
+  - name: et-0/0/1
+    type: 100gbase-x-qsfp28
+  - name: et-0/0/2
+    type: 100gbase-x-qsfp28
+  - name: et-0/0/3
+    type: 100gbase-x-qsfp28
+  - name: xe-0/1/0
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/1
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/2
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/3
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/4
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/5
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/6
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/7
+    type: 10gbase-x-sfpp
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 650
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 650
+console-ports:
+  - name: Console
+    type: rj-45


### PR DESCRIPTION
Add device type for Juniper MX204 router (4 QSFP and 8 SFP+).