### PR TITLE
Add Juniper MX104 chassis

### DIFF
--- a/device-types/Juniper/MX104-BASE.yaml
+++ b/device-types/Juniper/MX104-BASE.yaml
@@ -17,10 +17,10 @@ interfaces:
     type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
-    type: iec-60320-c14
+    type: iec-60320-c15
     maximum_draw: 800
   - name: PEM1
-    type: iec-60320-c14
+    type: iec-60320-c15
     maximum_draw: 800
 console-ports:
   - name: Console

--- a/device-types/Juniper/MX104-BASE.yaml
+++ b/device-types/Juniper/MX104-BASE.yaml
@@ -1,0 +1,27 @@
+manufacturer: Juniper
+model: MX104-BASE
+slug: mx104-base
+is_full_depth: false
+u_height: 4
+interfaces:
+  - name: fxp0
+    type: 1000base-t
+    mgmt_only: true
+  - name: xe-2/0/0
+    type: 10gbase-x-sfpp
+  - name: xe-2/0/1
+    type: 10gbase-x-sfpp
+  - name: xe-2/0/2
+    type: 10gbase-x-sfpp
+  - name: xe-2/0/3
+    type: 10gbase-x-sfpp
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 800
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 800
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Juniper/MX104-BASE.yaml
+++ b/device-types/Juniper/MX104-BASE.yaml
@@ -17,10 +17,10 @@ interfaces:
     type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
-    type: iec-60320-c15
+    type: iec-60320-c16
     maximum_draw: 800
   - name: PEM1
-    type: iec-60320-c15
+    type: iec-60320-c16
     maximum_draw: 800
 console-ports:
   - name: Console

--- a/device-types/Juniper/MX104-PREMIUM.yaml
+++ b/device-types/Juniper/MX104-PREMIUM.yaml
@@ -20,10 +20,10 @@ interfaces:
     type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
-    type: iec-60320-c15
+    type: iec-60320-c16
     maximum_draw: 800
   - name: PEM1
-    type: iec-60320-c15
+    type: iec-60320-c16
     maximum_draw: 800
 console-ports:
   - name: Console (re0)

--- a/device-types/Juniper/MX104-PREMIUM.yaml
+++ b/device-types/Juniper/MX104-PREMIUM.yaml
@@ -1,0 +1,32 @@
+manufacturer: Juniper
+model: MX104-PREMIUM
+slug: mx104-premium
+is_full_depth: false
+u_height: 4
+interfaces:
+  - name: fxp0 (re0)
+    type: 1000base-t
+    mgmt_only: true
+  - name: fxp0 (re1)
+    type: 1000base-t
+    mgmt_only: true
+  - name: xe-2/0/0
+    type: 10gbase-x-sfpp
+  - name: xe-2/0/1
+    type: 10gbase-x-sfpp
+  - name: xe-2/0/2
+    type: 10gbase-x-sfpp
+  - name: xe-2/0/3
+    type: 10gbase-x-sfpp
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 800
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 800
+console-ports:
+  - name: Console (re0)
+    type: rj-45
+  - name: Console (re1)
+    type: rj-45

--- a/device-types/Juniper/MX104-PREMIUM.yaml
+++ b/device-types/Juniper/MX104-PREMIUM.yaml
@@ -20,10 +20,10 @@ interfaces:
     type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
-    type: iec-60320-c14
+    type: iec-60320-c15
     maximum_draw: 800
   - name: PEM1
-    type: iec-60320-c14
+    type: iec-60320-c15
     maximum_draw: 800
 console-ports:
   - name: Console (re0)


### PR DESCRIPTION
This PR adds two new device types for MX104 BASE and PREMIUM chassis.

Note that a MX104 is not actually a 4U device, it's 3.5U (thanks Juniper). 4U seems the better matching usable height value given the circumstances.