### PR TITLE
Updated existing FortiGate model & part_number

### DIFF
--- a/device-types/Fortinet/FG-100F.yaml
+++ b/device-types/Fortinet/FG-100F.yaml
@@ -1,7 +1,8 @@
 manufacturer: Fortinet
-model: FG-100F
+model: FortiGate 100F
+part_number: FG-100F
 slug: fg-100f
-#Comments: Same as FG-101F but without a 480GB SSD onboard.
+# comments: Same as FG-101F but without a 480GB SSD onboard.
 is_full_depth: False
 u_height: 1
 interfaces:

--- a/device-types/Fortinet/FG-101F.yaml
+++ b/device-types/Fortinet/FG-101F.yaml
@@ -1,7 +1,8 @@
 manufacturer: Fortinet
-model: FG-100F
-slug: fg-100f
-#Comments: Same as FG-100F but with a 480GB SSD onboard.
+model: FortiGate 101F
+part_number: FG-101F
+slug: fg-101f
+# comments: Same as FG-100F but with a 480GB SSD onboard.
 is_full_depth: False
 u_height: 1
 interfaces:

--- a/device-types/Fortinet/FG-1100E.yaml
+++ b/device-types/Fortinet/FG-1100E.yaml
@@ -1,7 +1,8 @@
 manufacturer: Fortinet
-model: FG-1100E
+model: FortiGate 1100E
+part_number: FG-1100E
 slug: fg-1100e
-#Comments: Same as FG-1101E but without 2 x 480GB SSDs onboard.
+# comments: Same as FG-1101E but without 2 x 480GB SSDs onboard.
 is_full_depth: False
 u_height: 2
 interfaces:

--- a/device-types/Fortinet/FG-1101E.yaml
+++ b/device-types/Fortinet/FG-1101E.yaml
@@ -1,7 +1,8 @@
 manufacturer: Fortinet
-model: FG-1101E
+model: FortiGate 1101E
+part_number: FG-1101E
 slug: fg-1101e
-#Comments: Same as FG-1100E but with 2 x 480GB SSDs onboard.
+# comments: Same as FG-1100E but with 2 x 480GB SSDs onboard.
 is_full_depth: False
 u_height: 2
 interfaces:

--- a/device-types/Fortinet/FG-300E.yaml
+++ b/device-types/Fortinet/FG-300E.yaml
@@ -1,7 +1,8 @@
 manufacturer: Fortinet
-model: FG-300E
+model: FortiGate 300E
+part_number: FG-300E
 slug: fg-300e
-#Comments: Same as FG-301E but without a 480GB SSD onboard.
+# comments: Same as FG-301E but without a 480GB SSD onboard.
 is_full_depth: False
 u_height: 1
 interfaces:

--- a/device-types/Fortinet/FG-301E.yaml
+++ b/device-types/Fortinet/FG-301E.yaml
@@ -1,7 +1,8 @@
 manufacturer: Fortinet
-model: FG-301E
+model: FortiGate 301E
+part_number: FG-301E
 slug: fg-301e
-#Comments: Same as FG-300E but with a 480GB SSD onboard.
+# comments: Same as FG-300E but with a 480GB SSD onboard.
 is_full_depth: False
 u_height: 1
 interfaces:

--- a/device-types/Fortinet/FG-600E.yaml
+++ b/device-types/Fortinet/FG-600E.yaml
@@ -1,7 +1,8 @@
 manufacturer: Fortinet
-model: FG-600E
+model: FortiGate 600E
+part_number: FG-600E
 slug: fg-600e
-#Comments: Same as FG-601E but without 2 x 240GB SSDs onboard.
+# comments: Same as FG-601E but without 2 x 240GB SSDs onboard.
 is_full_depth: False
 u_height: 1
 interfaces:

--- a/device-types/Fortinet/FG-601E.yaml
+++ b/device-types/Fortinet/FG-601E.yaml
@@ -1,7 +1,8 @@
 manufacturer: Fortinet
-model: FG-601E
+model: FortiGate 601E
+part_number: FG-601E
 slug: fg-601e
-#Comments: Same as FG-600E but with 2 x 240GB SSDs onboard.
+# comments: Same as FG-600E but with 2 x 240GB SSDs onboard.
 is_full_depth: False
 u_height: 1
 interfaces:


### PR DESCRIPTION
Followed the approach of the Catalyst series devices that specify the name (FortiGate 80E) for the model var and the actual part number (FG-80E) for the part_number var.