### PR TITLE
Update ISR4331.yaml

### DIFF
--- a/device-types/Cisco/ISR4331.yaml
+++ b/device-types/Cisco/ISR4331.yaml
@@ -7,8 +7,10 @@ interfaces:
   - name: GigabitEthernet0
     type: 1000base-t
     mgmt_only: true
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
   - name: GigabitEthernet0/0/1
-    type: 1000base-t
+    type: 1000base-t    
   - name: GigabitEthernet0/0/2
     type: 1000base-x-sfp
 console-ports:


### PR DESCRIPTION
The ISR 4331 router has 3 interfaces as stock and they start numbering at 0. 
GigabitEthernet0/0/0 - Can either use the 1000base-T port or the corresponding SFP port
GigabitEthernet0/0/1 - Is only a 1000Base-T interface
GigabitEthernet0/0/2 - is only and SFP interface