### PR TITLE
Cisco ISR4331 added missing usb-mini-b console-port

### DIFF
--- a/device-types/Cisco/ISR4331.yaml
+++ b/device-types/Cisco/ISR4331.yaml
@@ -16,6 +16,8 @@ interfaces:
 console-ports:
   - name: con 0
     type: rj-45
+  - name: usb
+    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14


### PR DESCRIPTION
Cisco ISR4331 added missing usb-mini-b console-port
