### PR TITLE
Add Cisco Catalyst 3560CX series

### DIFF
--- a/device-types/Cisco/ws-c3560cx-12pc-s.yaml
+++ b/device-types/Cisco/ws-c3560cx-12pc-s.yaml
@@ -1,0 +1,47 @@
+manufacturer: Cisco
+model: Catalyst 3560-CX-12PC-S
+slug: ws-c3560cx-12pc-s
+part_number: WS-C3560CX-12PC-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/16
+    type: 1000base-x-sfp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: con1
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3560cx-12pd-s.yaml
+++ b/device-types/Cisco/ws-c3560cx-12pd-s.yaml
@@ -1,0 +1,47 @@
+manufacturer: Cisco
+model: Catalyst 3560-CX-12PD-S
+slug: ws-c3560cx-12pd-s
+part_number: WS-C3560CX-12PD-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: con1
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3560cx-12tc-s.yaml
+++ b/device-types/Cisco/ws-c3560cx-12tc-s.yaml
@@ -1,0 +1,47 @@
+manufacturer: Cisco
+model: Catalyst 3560-CX-12TC-S
+slug: ws-c3560cx-12tc-s
+part_number: WS-C3560CX-12TC-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/16
+    type: 1000base-x-sfp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: con1
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3560cx-8pc-s.yaml
+++ b/device-types/Cisco/ws-c3560cx-8pc-s.yaml
@@ -1,0 +1,39 @@
+manufacturer: Cisco
+model: Catalyst 3560-CX-8PC-S
+slug: ws-c3560cx-8pc-s
+part_number: WS-C3560CX-8PC-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/12
+    type: 1000base-x-sfp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: con1
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3560cx-8pt-s.yaml
+++ b/device-types/Cisco/ws-c3560cx-8pt-s.yaml
@@ -1,0 +1,35 @@
+manufacturer: Cisco
+model: Catalyst 3560-CX-8PT-S
+slug: ws-c3560cx-8pt-s
+part_number: WS-C3560CX-8PT-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: con1
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3560cx-8tc-s.yaml
+++ b/device-types/Cisco/ws-c3560cx-8tc-s.yaml
@@ -1,0 +1,39 @@
+manufacturer: Cisco
+model: Catalyst 3560-CX-8TC-S
+slug: ws-c3560cx-8tc-s
+part_number: WS-C3560CX-8TC-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/12
+    type: 1000base-x-sfp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: con1
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3560cx-8xpd-s.yaml
+++ b/device-types/Cisco/ws-c3560cx-8xpd-s.yaml
@@ -1,0 +1,35 @@
+manufacturer: Cisco
+model: Catalyst 3560-CX-8XPD-S
+slug: ws-c3560cx-8xpd-s
+part_number: WS-C3560CX-8XPD-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: TenGigabitEthernet1/0/7
+    type: 10gbase-t
+  - name: TenGigabitEthernet1/0/8
+    type: 10gbase-t
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: con1
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c16


### PR DESCRIPTION
The seemingly off ordering on the 3560-CX-8XPD-S corresponds to the
actual ordering of the OS output in the interface list.

Signed-off-by: Felix Kaechele <fkaechel@cisco.com>