### PR TITLE
Correct interface GigabitEthernet1/0/39

### DIFF
--- a/device-types/Cisco/ws-c2960x-48fps-l.yaml
+++ b/device-types/Cisco/ws-c2960x-48fps-l.yaml
@@ -85,7 +85,7 @@ interfaces:
   - name: GigabitEthernet1/0/38
     type: 1000base-t
   - name: GigabitEthernet1/0/39
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/0/40
     type: 1000base-t
   - name: GigabitEthernet1/0/41


### PR DESCRIPTION
GigabitEthernet1/0/39 was marked as an SFP port, but it is a 1000base-t port