### PR TITLE
Fixing interface port 43 numbering

### DIFF
--- a/device-types/Arista/DCS-7280SR2-48YC6.yaml
+++ b/device-types/Arista/DCS-7280SR2-48YC6.yaml
@@ -88,7 +88,7 @@ interfaces:
     type: 25gbase-x-sfp28
   - name: Ethernet42
     type: 25gbase-x-sfp28
-  - name: Ethernet33
+  - name: Ethernet43
     type: 25gbase-x-sfp28
   - name: Ethernet44
     type: 25gbase-x-sfp28


### PR DESCRIPTION
Port 43 is mis-numbered which causes an error when trying to import