### PR TITLE
Add Juniper EX2300-C-12P/T

### DIFF
--- a/device-types/Juniper/EX2300-C-12P.yaml
+++ b/device-types/Juniper/EX2300-C-12P.yaml
@@ -1,0 +1,47 @@
+manufacturer: Juniper
+model: EX2300-C-12P
+slug: ex2300-c-12p
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/0/4
+    type: 1000base-t
+  - name: ge-0/0/5
+    type: 1000base-t
+  - name: ge-0/0/6
+    type: 1000base-t
+  - name: ge-0/0/7
+    type: 1000base-t
+  - name: ge-0/0/8
+    type: 1000base-t
+  - name: ge-0/0/9
+    type: 1000base-t
+  - name: ge-0/0/10
+    type: 1000base-t
+  - name: ge-0/0/11
+    type: 1000base-t
+  - name: ge-0/1/0
+    type: 1000base-x-sfp
+  - name: ge-0/1/1
+    type: 1000base-x-sfp
+  - name: xe-0/1/0
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/1
+    type: 10gbase-x-sfpp
+  - name: vme
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 170
+console-ports:
+  - name: Console
+    type: rj-45
+

--- a/device-types/Juniper/EX2300-C-12P.yaml
+++ b/device-types/Juniper/EX2300-C-12P.yaml
@@ -44,4 +44,6 @@ power-ports:
 console-ports:
   - name: Console
     type: rj-45
+  - name: Console
+    type: usb-mini-b
 

--- a/device-types/Juniper/EX2300-C-12T.yaml
+++ b/device-types/Juniper/EX2300-C-12T.yaml
@@ -44,4 +44,5 @@ power-ports:
 console-ports:
   - name: Console
     type: rj-45
-
+  - name: Console
+    type: usb-mini-b

--- a/device-types/Juniper/EX2300-C-12T.yaml
+++ b/device-types/Juniper/EX2300-C-12T.yaml
@@ -1,0 +1,47 @@
+manufacturer: Juniper
+model: EX2300-C-12T
+slug: ex2300-c-12t
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/0/4
+    type: 1000base-t
+  - name: ge-0/0/5
+    type: 1000base-t
+  - name: ge-0/0/6
+    type: 1000base-t
+  - name: ge-0/0/7
+    type: 1000base-t
+  - name: ge-0/0/8
+    type: 1000base-t
+  - name: ge-0/0/9
+    type: 1000base-t
+  - name: ge-0/0/10
+    type: 1000base-t
+  - name: ge-0/0/11
+    type: 1000base-t
+  - name: ge-0/1/0
+    type: 1000base-x-sfp
+  - name: ge-0/1/1
+    type: 1000base-x-sfp
+  - name: xe-0/1/0
+    type: 10gbase-x-sfpp
+  - name: xe-0/1/1
+    type: 10gbase-x-sfpp
+  - name: vme
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 40
+console-ports:
+  - name: Console
+    type: rj-45
+


### PR DESCRIPTION
Adding support for the EX2300-C-12P and 12T (PoE and Non PoE)

Spec sheet: https://www.juniper.net/assets/us/en/local/pdf/datasheets/1000580-en.pdf