### PR TITLE
Add FS.com CWDM 8Ch MUX + Chassis

### DIFF
--- a/device-types/FS/FMU-1UFMX-N.yaml
+++ b/device-types/FS/FMU-1UFMX-N.yaml
@@ -1,0 +1,11 @@
+manufacturer: FS
+model: FMU-1UFMX-N
+slug: fmu-1ufmx-n
+comment: 'FMU 2-Slot 1U Rack-Chassis'
+part_number: FMU-1UFMX-N
+u_height: 1
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+- name: '1'
+- name: '2'

--- a/device-types/FS/FMU-MC082745.yaml
+++ b/device-types/FS/FMU-MC082745.yaml
@@ -1,0 +1,45 @@
+manufacturer: FS
+model: FMU-MC082745
+slug: fmu-mc082745
+comment: '8Ch CWDM MUX 1270-1450 (Skip 1390,1410)'
+part_number: '42937'
+u_height: 0
+is_full_depth: false
+subdevice_role: child
+front-ports:
+- name: '1270'
+  type: lc
+  rear_port: Line
+  rear_port_position: 1
+- name: '1290'
+  type: lc
+  rear_port: Line
+  rear_port_position: 2
+- name: '1310'
+  type: lc
+  rear_port: Line
+  rear_port_position: 3
+- name: '1330'
+  type: lc
+  rear_port: Line
+  rear_port_position: 4
+- name: '1350'
+  type: lc
+  rear_port: Line
+  rear_port_position: 5
+- name: '1370'
+  type: lc
+  rear_port: Line
+  rear_port_position: 6
+- name: '1430'
+  type: lc
+  rear_port: Line
+  rear_port_position: 7
+- name: '1450'
+  type: lc
+  rear_port: Line
+  rear_port_position: 8
+rear-ports:
+- name: Line
+  type: lc
+  positions: 8


### PR DESCRIPTION
Hi!

This PR adds

- FS.com 2-Slot 1U Rack-Chassis FMU-1UFMX-N
- FS.com 8Ch CWDM MUX 1270-1450 (Skip 1390,1410) FMU-MC082745

The PR uses manufacturer "FS". Other options would be "FS.com" or "Fibrestore". All options have pros and cons. If you have opinions on the manufacturer, please let me know.

Best
Max