### PR TITLE
Add Netonix WISP switch WS-24-400A

### DIFF
--- a/device-types/Netonix/WS-24-400A.yaml
+++ b/device-types/Netonix/WS-24-400A.yaml
@@ -1,0 +1,91 @@
+manufacturer: Netonix
+model: WS-24-400A
+slug: ws-24-400a
+u_height: 1
+is_full_depth: false
+console-ports:
+- name: Console
+  type: de-9
+power-ports:
+- name: PSU1
+  type: iec-60320-c14
+  maximum_draw: 400
+interfaces:
+- name: '1'
+  type: 1000base-t
+  mgmt_only: false
+- name: '2'
+  type: 1000base-t
+  mgmt_only: false
+- name: '3'
+  type: 1000base-t
+  mgmt_only: false
+- name: '4'
+  type: 1000base-t
+  mgmt_only: false
+- name: '5'
+  type: 1000base-t
+  mgmt_only: false
+- name: '6'
+  type: 1000base-t
+  mgmt_only: false
+- name: '7'
+  type: 1000base-t
+  mgmt_only: false
+- name: '8'
+  type: 1000base-t
+  mgmt_only: false
+- name: '9'
+  type: 1000base-t
+  mgmt_only: false
+- name: '10'
+  type: 1000base-t
+  mgmt_only: false
+- name: '11'
+  type: 1000base-t
+  mgmt_only: false
+- name: '12'
+  type: 1000base-t
+  mgmt_only: false
+- name: '13'
+  type: 1000base-t
+  mgmt_only: false
+- name: '14'
+  type: 1000base-t
+  mgmt_only: false
+- name: '15'
+  type: 1000base-t
+  mgmt_only: false
+- name: '16'
+  type: 1000base-t
+  mgmt_only: false
+- name: '17'
+  type: 1000base-t
+  mgmt_only: false
+- name: '18'
+  type: 1000base-t
+  mgmt_only: false
+- name: '19'
+  type: 1000base-t
+  mgmt_only: false
+- name: '20'
+  type: 1000base-t
+  mgmt_only: false
+- name: '21'
+  type: 1000base-t
+  mgmt_only: false
+- name: '22'
+  type: 1000base-t
+  mgmt_only: false
+- name: '23'
+  type: 1000base-t
+  mgmt_only: false
+- name: '24'
+  type: 1000base-t
+  mgmt_only: false
+- name: '25'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '26'
+  type: 1000base-x-sfp
+  mgmt_only: false


### PR DESCRIPTION
This device has 4 dual-purpose ports (21-24) which can be 1000BaseT or SFP. I chose to model them as 1000BaseT as the default.

Are there any guidelines about that? Is there a better way?