### PR TITLE
Fix Arista duplicate keys: DCS-7150SC-64

### DIFF
--- a/device-types/Arista/DCS-7150SC-64.yaml
+++ b/device-types/Arista/DCS-7150SC-64.yaml
@@ -1,7 +1,7 @@
 manufacturer: Arista
 model: DCS-7150SC-64
 slug: dcs-7150sc-64
-is_full_depth: True
+part_number: DCS-7150SC-64
 u_height: 1
 is_full_depth: false
 comments: ''

--- a/device-types/Arista/DCS-7280SR2-48YC6.yaml
+++ b/device-types/Arista/DCS-7280SR2-48YC6.yaml
@@ -130,3 +130,4 @@ interfaces:
   - name: Management1
     type: 1000base-t
     mgmt_only: true
+


### PR DESCRIPTION
Removed duplicate keys "is_full_depth" and added "part_number".