### PR TITLE
Add Cisco C1000-24P-4X-L switch

### DIFF
--- a/device-types/Cisco/C1000-24P-4X-L.yaml
+++ b/device-types/Cisco/C1000-24P-4X-L.yaml
@@ -62,10 +62,10 @@ interfaces:
   - name: TenGigabitEthernet1/0/4
     type: 10gbase-x-sfpp
 console-ports:
-- name: con0
-  type: rj-45
-- name: USB con0
-  type: usb-mini-a
+  - name: con0
+    type: rj-45
+  - name: USB con0
+    type: usb-mini-a
 power-ports:
   - name: Built-in
     type: iec-60320-c14

--- a/device-types/Cisco/C1000-24P-4X-L.yaml
+++ b/device-types/Cisco/C1000-24P-4X-L.yaml
@@ -1,0 +1,72 @@
+manufacturer: Cisco
+model: C1000-24P-4X-L
+slug: c1000-24p-4x-l
+part_number: C1000-24P-4X-L
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/4
+    type: 10gbase-x-sfpp
+console-ports:
+- name: con0
+  type: rj-45
+- name: USB con0
+  type: usb-mini-a
+power-ports:
+  - name: Built-in
+    type: iec-60320-c14
+    maximum_draw: 300


### PR DESCRIPTION
Adding support for Cisco Cisco C1000-24P-4X-L switch, schema doesn't currently support noting interfaces which support PoE.