### PR TITLE
Infoblox add device-types

### DIFF
--- a/device-types/Infoblox/IB-1410.yaml
+++ b/device-types/Infoblox/IB-1410.yaml
@@ -1,0 +1,26 @@
+manufacturer: Infoblox
+model: IB-1410
+slug: IB-1410
+is_full_depth: False
+u_height: 1
+interfaces:
+  - name: LOM
+    type: 1000base-t
+  - name: MGMT
+    type: 1000base-t
+  - name: LAN1
+    type: 1000base-t
+  - name: LAN2
+    type: 1000base-t
+  - name: HA
+    type: 1000base-t
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS0
+    type: iec-60320-c14
+    maximum_draw: 450
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 450

--- a/device-types/Infoblox/IB-1420.yaml
+++ b/device-types/Infoblox/IB-1420.yaml
@@ -1,0 +1,26 @@
+manufacturer: Infoblox
+model: IB-1420
+slug: IB-1420
+is_full_depth: False
+u_height: 1
+interfaces:
+  - name: LOM
+    type: 1000base-t
+  - name: MGMT
+    type: 1000base-t
+  - name: LAN1
+    type: 1000base-t
+  - name: LAN2
+    type: 1000base-t
+  - name: HA
+    type: 1000base-t
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS0
+    type: iec-60320-c14
+    maximum_draw: 450
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 450

--- a/device-types/Infoblox/TE-1415-NS1GD-AC.yaml
+++ b/device-types/Infoblox/TE-1415-NS1GD-AC.yaml
@@ -1,0 +1,26 @@
+manufacturer: Infoblox
+model: TE-1415-NS1GD-AC
+slug: TE-1415-NS1GD-AC
+is_full_depth: False
+u_height: 1
+interfaces:
+  - name: LOM
+    type: 1000base-t
+  - name: MGMT
+    type: 1000base-t
+  - name: LAN1
+    type: 1000base-t
+  - name: LAN2
+    type: 1000base-t
+  - name: HA
+    type: 1000base-t
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS0
+    type: iec-60320-c14
+    maximum_draw: 600
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 600

--- a/device-types/Infoblox/TE-815-NS1GD-AC.yaml
+++ b/device-types/Infoblox/TE-815-NS1GD-AC.yaml
@@ -1,0 +1,25 @@
+manufacturer: Infoblox
+model: TE-815-NS1GD-AC
+slug: TE-815-NS1GD-AC
+is_full_depth: False
+u_height: 1
+interfaces:
+  - name: LOM
+    type: 1000base-t
+  - name: MGMT
+    type: 1000base-t
+  - name: LAN1
+    type: 1000base-t
+  - name: LAN2
+    type: 1000base-t
+  - name: HA
+    type: 1000base-t
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS0
+    type: iec-60320-c14
+    maximum_draw: 350
+
+


### PR DESCRIPTION
Created 4 devicetypes for Infoblox:

- IB-1410
- IB-1420
- TE-1415-NS1GD-AC
- TE-815-NS1GD-AC