### PR TITLE
Give Juniper EX2300 console ports unique names

### DIFF
--- a/device-types/Juniper/EX2300-C-12P.yaml
+++ b/device-types/Juniper/EX2300-C-12P.yaml
@@ -44,6 +44,6 @@ power-ports:
 console-ports:
   - name: Console
     type: rj-45
-  - name: Console
+  - name: Console (USB)
     type: usb-mini-b
 

--- a/device-types/Juniper/EX2300-C-12T.yaml
+++ b/device-types/Juniper/EX2300-C-12T.yaml
@@ -44,5 +44,5 @@ power-ports:
 console-ports:
   - name: Console
     type: rj-45
-  - name: Console
+  - name: Console (USB)
     type: usb-mini-b


### PR DESCRIPTION
Both the RJ-45 and USB consoles were named "Console" which causes NetBox to throw an error on import.

This fixes #173, though it'd still be good to extend tests to check for this.