### PR TITLE
Add netbox script to automatically build device type

### DIFF
--- a/device-types/Arista/CCS-720XP-24ZY4.yaml
+++ b/device-types/Arista/CCS-720XP-24ZY4.yaml
@@ -54,7 +54,7 @@ interfaces:
     type: 5gbase-t
   - name: Ethernet18
     type: 5gbase-t
-  - name: Ethernet18
+  - name: Ethernet19
     type: 5gbase-t
   - name: Ethernet20
     type: 5gbase-t

--- a/device-types/TrendNet/TEW-WLC100.yaml
+++ b/device-types/TrendNet/TEW-WLC100.yaml
@@ -15,8 +15,6 @@ interfaces:
     type: 1000base-t
   - name: Port 4
     type: 1000base-t
-  - name: Port 4
-    type: 1000base-t
   - name: Port 5
     type: 1000base-t
 console-ports:

--- a/device-types/TrippLite/B096-016.yaml
+++ b/device-types/TrippLite/B096-016.yaml
@@ -1,4 +1,4 @@
-manufacturer: Tripp-Lite
+manufacturer: TrippLite
 model: B096-016
 slug: b096-016
 part_number: 037332148902

--- a/device-types/TrippLite/B096-032.yaml
+++ b/device-types/TrippLite/B096-032.yaml
@@ -1,4 +1,4 @@
-manufacturer: Tripp-Lite
+manufacturer: TrippLite
 model: B096-032
 slug: b096-032
 part_number: 037332181183

--- a/device-types/TrippLite/B097-016.yaml
+++ b/device-types/TrippLite/B097-016.yaml
@@ -1,4 +1,4 @@
-manufacturer: Tripp-Lite
+manufacturer: TrippLite
 model: B097-016
 slug: b097-016
 part_number: 037332218025

--- a/device-types/TrippLite/PDUMH15AT.yaml
+++ b/device-types/TrippLite/PDUMH15AT.yaml
@@ -1,4 +1,4 @@
-manufacturer: Tripp-Lite
+manufacturer: TrippLite
 model: PDUMH15AT
 slug: pdumh15at
 part_number: 037332126658


### PR DESCRIPTION
Add netbox script to automatically build device type，and fix errors when calling through automated scripts.
<img width="1619" alt="netbox-device-type-auto-init" src="https://user-images.githubusercontent.com/24425335/89168143-fafafd00-d5ae-11ea-9b4e-64511c3013b3.png">
