### PR TITLE
Aruba 7000 & MobilityMaster

### DIFF
--- a/device-types/Aruba/Aruba7030.yaml
+++ b/device-types/Aruba/Aruba7030.yaml
@@ -1,0 +1,28 @@
+manufacturer: Aruba
+model: Aruba7030
+slug: Aruba7030
+is_full_depth: no
+u_height: 1
+interfaces:
+  - name: gigabitethernet 0/0/0
+    type: 1000base-t
+  - name: gigabitethernet 0/0/1
+    type: 1000base-t
+  - name: gigabitethernet 0/0/2
+    type: 1000base-t
+  - name: gigabitethernet 0/0/3
+    type: 1000base-t
+  - name: gigabitethernet 0/0/4
+    type: 1000base-t
+  - name: gigabitethernet 0/0/5
+    type: 1000base-t
+  - name: gigabitethernet 0/0/6
+    type: 1000base-t
+  - name: gigabitethernet 0/0/7
+    type: 1000base-t
+power-ports:
+  - name: PEM0
+    maximum_draw: 55
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Aruba/Aruba7030.yaml
+++ b/device-types/Aruba/Aruba7030.yaml
@@ -1,6 +1,6 @@
 manufacturer: Aruba
 model: Aruba7030
-slug: Aruba7030
+slug: aruba7030
 is_full_depth: no
 u_height: 1
 interfaces:

--- a/device-types/Aruba/Aruba7030.yaml
+++ b/device-types/Aruba/Aruba7030.yaml
@@ -22,6 +22,7 @@ interfaces:
     type: 1000base-t
 power-ports:
   - name: PEM0
+    type: iec-60320-c14 
     maximum_draw: 55
 console-ports:
   - name: Console

--- a/device-types/Aruba/Aruba7210.yaml
+++ b/device-types/Aruba/Aruba7210.yaml
@@ -1,6 +1,6 @@
 manufacturer: Aruba
 model: Aruba7210
-slug: Aruba7210
+slug: aruba7210
 is_full_depth: yes
 u_height: 1
 interfaces:

--- a/device-types/Aruba/Aruba7210.yaml
+++ b/device-types/Aruba/Aruba7210.yaml
@@ -9,13 +9,13 @@ interfaces:
   - name: gigabitethernet 0/0/1
     type: 1000base-t
   - name: gigabitethernet 0/0/2
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/3
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/4
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/5
-    type: sfp+
+    type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
     type: iec-60320-c14

--- a/device-types/Aruba/Aruba7210.yaml
+++ b/device-types/Aruba/Aruba7210.yaml
@@ -1,0 +1,30 @@
+manufacturer: Aruba
+model: Aruba7210
+slug: Aruba7210
+is_full_depth: yes
+u_height: 1
+interfaces:
+  - name: gigabitethernet 0/0/0
+    type: 1000base-t
+  - name: gigabitethernet 0/0/1
+    type: 1000base-t
+  - name: gigabitethernet 0/0/2
+    type: sfp+
+  - name: gigabitethernet 0/0/3
+    type: sfp+
+  - name: gigabitethernet 0/0/4
+    type: sfp+
+  - name: gigabitethernet 0/0/5
+    type: sfp+
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 110
+    allocated_draw: 350
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 110
+    allocated_draw: 350
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Aruba/Aruba7220.yaml
+++ b/device-types/Aruba/Aruba7220.yaml
@@ -1,6 +1,6 @@
 manufacturer: Aruba
 model: Aruba7220
-slug: Aruba7220
+slug: aruba7220
 is_full_depth: yes
 u_height: 1
 interfaces:

--- a/device-types/Aruba/Aruba7220.yaml
+++ b/device-types/Aruba/Aruba7220.yaml
@@ -9,13 +9,13 @@ interfaces:
   - name: gigabitethernet 0/0/1
     type: 1000base-t
   - name: gigabitethernet 0/0/2
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/3
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/4
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/5
-    type: sfp+
+    type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
     type: iec-60320-c14

--- a/device-types/Aruba/Aruba7220.yaml
+++ b/device-types/Aruba/Aruba7220.yaml
@@ -1,0 +1,30 @@
+manufacturer: Aruba
+model: Aruba7220
+slug: Aruba7220
+is_full_depth: yes
+u_height: 1
+interfaces:
+  - name: gigabitethernet 0/0/0
+    type: 1000base-t
+  - name: gigabitethernet 0/0/1
+    type: 1000base-t
+  - name: gigabitethernet 0/0/2
+    type: sfp+
+  - name: gigabitethernet 0/0/3
+    type: sfp+
+  - name: gigabitethernet 0/0/4
+    type: sfp+
+  - name: gigabitethernet 0/0/5
+    type: sfp+
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 110
+    allocated_draw: 350
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 110
+    allocated_draw: 350
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Aruba/ArubaMM-HW-10K.yaml
+++ b/device-types/Aruba/ArubaMM-HW-10K.yaml
@@ -8,9 +8,9 @@ interfaces:
     type: 1000base-t
     mgmt_only: true
   - name: gigabitethernet 0/0/0
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/1
-    type: sfp+
+    type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
     type: iec-60320-c14

--- a/device-types/Aruba/ArubaMM-HW-10K.yaml
+++ b/device-types/Aruba/ArubaMM-HW-10K.yaml
@@ -1,0 +1,25 @@
+manufacturer: Aruba
+model: ArubaMM-HW-10K
+slug: arubamm-hw-10k
+is_full_depth: yes
+u_height: 1
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: gigabitethernet 0/0/0
+    type: sfp+
+  - name: gigabitethernet 0/0/1
+    type: sfp+
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 120
+    allocated_draw: 400
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 120
+    allocated_draw: 400
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Aruba/ArubaMM-HW-1K.yaml
+++ b/device-types/Aruba/ArubaMM-HW-1K.yaml
@@ -8,9 +8,9 @@ interfaces:
     type: 1000base-t
     mgmt_only: true
   - name: gigabitethernet 0/0/0
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/1
-    type: sfp+
+    type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
     type: iec-60320-c14

--- a/device-types/Aruba/ArubaMM-HW-1K.yaml
+++ b/device-types/Aruba/ArubaMM-HW-1K.yaml
@@ -1,0 +1,25 @@
+manufacturer: Aruba
+model: ArubaMM-HW-1K
+slug: arubamm-hw-1k
+is_full_depth: yes
+u_height: 1
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: gigabitethernet 0/0/0
+    type: sfp+
+  - name: gigabitethernet 0/0/1
+    type: sfp+
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 120
+    allocated_draw: 400
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 120
+    allocated_draw: 400
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Aruba/ArubaMM-HW-5K.yaml
+++ b/device-types/Aruba/ArubaMM-HW-5K.yaml
@@ -1,0 +1,25 @@
+manufacturer: Aruba
+model: ArubaMM-HW-5K
+slug: arubamm-hw-5k
+is_full_depth: yes
+u_height: 1
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: gigabitethernet 0/0/0
+    type: sfp+
+  - name: gigabitethernet 0/0/1
+    type: sfp+
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14
+    maximum_draw: 120
+    allocated_draw: 400
+  - name: PEM1
+    type: iec-60320-c14
+    maximum_draw: 120
+    allocated_draw: 400
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Aruba/ArubaMM-HW-5K.yaml
+++ b/device-types/Aruba/ArubaMM-HW-5K.yaml
@@ -8,9 +8,9 @@ interfaces:
     type: 1000base-t
     mgmt_only: true
   - name: gigabitethernet 0/0/0
-    type: sfp+
+    type: 10gbase-x-sfpp
   - name: gigabitethernet 0/0/1
-    type: sfp+
+    type: 10gbase-x-sfpp
 power-ports:
   - name: PEM0
     type: iec-60320-c14


### PR DESCRIPTION
Adding device templates for Aruba wireless controllers (7030, 7210, 7220) and Hardware Mobility Masters (1,5,&10k)