### PR TITLE
Aruba 2530

### DIFF
--- a/device-types/Aruba/Aruba2530-24G-PoEP.yaml
+++ b/device-types/Aruba/Aruba2530-24G-PoEP.yaml
@@ -1,0 +1,98 @@
+manufacturer: Aruba
+model: 2530-24G-PoEP Switch
+slug:  2530-24g-poep
+part_number: J9773A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14 
+    maximum_draw: 247
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+- name: '1'
+  type: 1000base-t
+  mgmt_only: false
+- name: '2'
+  type: 1000base-t
+  mgmt_only: false
+- name: '3'
+  type: 1000base-t
+  mgmt_only: false
+- name: '4'
+  type: 1000base-t
+  mgmt_only: false
+- name: '5'
+  type: 1000base-t
+  mgmt_only: false
+- name: '6'
+  type: 1000base-t
+  mgmt_only: false
+- name: '7'
+  type: 1000base-t
+  mgmt_only: false
+- name: '8'
+  type: 1000base-t
+  mgmt_only: false
+- name: '9'
+  type: 1000base-t
+  mgmt_only: false
+- name: '10'
+  type: 1000base-t
+  mgmt_only: false
+- name: '11'
+  type: 1000base-t
+  mgmt_only: false
+- name: '12'
+  type: 1000base-t
+  mgmt_only: false
+- name: '13'
+  type: 1000base-t
+  mgmt_only: false
+- name: '14'
+  type: 1000base-t
+  mgmt_only: false
+- name: '15'
+  type: 1000base-t
+  mgmt_only: false
+- name: '16'
+  type: 1000base-t
+  mgmt_only: false
+- name: '17'
+  type: 1000base-t
+  mgmt_only: false
+- name: '18'
+  type: 1000base-t
+  mgmt_only: false
+- name: '19'
+  type: 1000base-t
+  mgmt_only: false
+- name: '20'
+  type: 1000base-t
+  mgmt_only: false
+- name: '21'
+  type: 1000base-t
+  mgmt_only: false
+- name: '22'
+  type: 1000base-t
+  mgmt_only: false
+- name: '23'
+  type: 1000base-t
+  mgmt_only: false
+- name: '24'
+  type: 1000base-t
+  mgmt_only: false
+- name: '25'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '26'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '27'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '28'
+  type: 1000base-x-sfp
+  mgmt_only: false

--- a/device-types/Aruba/Aruba2530-48G-PoEP.yaml
+++ b/device-types/Aruba/Aruba2530-48G-PoEP.yaml
@@ -168,4 +168,3 @@ interfaces:
   - name: 52
     type: 1000base-x-sfp
     mgmt_only: false
-    

--- a/device-types/Aruba/Aruba2530-48G-PoEP.yaml
+++ b/device-types/Aruba/Aruba2530-48G-PoEP.yaml
@@ -12,159 +12,159 @@ console-ports:
   - name: Console
     type: rj-45
 interfaces:
-  - name: 1
-    type: 1000base-t
-    mgmt_only: false
-  - name: 2
-    type: 1000base-t
-    mgmt_only: false
-  - name: 3
-    type: 1000base-t
-    mgmt_only: false
-  - name: 4
-    type: 1000base-t
-    mgmt_only: false
-  - name: 5
-    type: 1000base-t
-    mgmt_only: false
-  - name: 6
-    type: 1000base-t
-    mgmt_only: false
-  - name: 7
-    type: 1000base-t
-    mgmt_only: false
-  - name: 8
-    type: 1000base-t
-    mgmt_only: false
-  - name: 9
-    type: 1000base-t
-    mgmt_only: false
-  - name: 10
-    type: 1000base-t
-    mgmt_only: false
-  - name: 11
-    type: 1000base-t
-    mgmt_only: false
-  - name: 12
-    type: 1000base-t
-    mgmt_only: false
-  - name: 13
-    type: 1000base-t
-    mgmt_only: false
-  - name: 14
-    type: 1000base-t
-    mgmt_only: false
-  - name: 15
-    type: 1000base-t
-    mgmt_only: false
-  - name: 16
-    type: 1000base-t
-    mgmt_only: false
-  - name: 17
-    type: 1000base-t
-    mgmt_only: false
-  - name: 18
-    type: 1000base-t
-    mgmt_only: false
-  - name: 19
-    type: 1000base-t
-    mgmt_only: false
-  - name: 20
-    type: 1000base-t
-    mgmt_only: false
-  - name: 21
-    type: 1000base-t
-    mgmt_only: false
-  - name: 22
-    type: 1000base-t
-    mgmt_only: false
-  - name: 23
-    type: 1000base-t
-    mgmt_only: false
-  - name: 24
-    type: 1000base-t
-    mgmt_only: false
-  - name: 25
-    type: 1000base-t
-    mgmt_only: false
-  - name: 26
-    type: 1000base-t
-    mgmt_only: false
-  - name: 27
-    type: 1000base-t
-    mgmt_only: false
-  - name: 28
-    type: 1000base-t
-    mgmt_only: false
-  - name: 29
-    type: 1000base-t
-    mgmt_only: false
-  - name: 30
-    type: 1000base-t
-    mgmt_only: false
-  - name: 31
-    type: 1000base-t
-    mgmt_only: false
-  - name: 32
-    type: 1000base-t
-    mgmt_only: false
-  - name: 33
-    type: 1000base-t
-    mgmt_only: false
-  - name: 34
-    type: 1000base-t
-    mgmt_only: false
-  - name: 35
-    type: 1000base-t
-    mgmt_only: false
-  - name: 36
-    type: 1000base-t
-    mgmt_only: false
-  - name: 37
-    type: 1000base-t
-    mgmt_only: false
-  - name: 38
-    type: 1000base-t
-    mgmt_only: false
-  - name: 39
-    type: 1000base-t
-    mgmt_only: false
-  - name: 40
-    type: 1000base-t
-    mgmt_only: false
-  - name: 41
-    type: 1000base-t
-    mgmt_only: false
-  - name: 42
-    type: 1000base-t
-    mgmt_only: false
-  - name: 43
-    type: 1000base-t
-    mgmt_only: false
-  - name: 44
-    type: 1000base-t
-    mgmt_only: false
-  - name: 45
-    type: 1000base-t
-    mgmt_only: false
-  - name: 46
-    type: 1000base-t
-    mgmt_only: false
-  - name: 47
-    type: 1000base-t
-    mgmt_only: false
-  - name: 48
-    type: 1000base-t
-    mgmt_only: false
-  - name: 49
-    type: 1000base-x-sfp
-    mgmt_only: false
-  - name: 50
-    type: 1000base-x-sfp
-    mgmt_only: false
-  - name: 51
-    type: 1000base-x-sfp
-    mgmt_only: false
-  - name: 52
-    type: 1000base-x-sfp
-    mgmt_only: false
+- name: '1'
+  type: 1000base-t
+  mgmt_only: false
+- name: '2'
+  type: 1000base-t
+  mgmt_only: false
+- name: '3'
+  type: 1000base-t
+  mgmt_only: false
+- name: '4'
+  type: 1000base-t
+  mgmt_only: false
+- name: '5'
+  type: 1000base-t
+  mgmt_only: false
+- name: '6'
+  type: 1000base-t
+  mgmt_only: false
+- name: '7'
+  type: 1000base-t
+  mgmt_only: false
+- name: '8'
+  type: 1000base-t
+  mgmt_only: false
+- name: '9'
+  type: 1000base-t
+  mgmt_only: false
+- name: '10'
+  type: 1000base-t
+  mgmt_only: false
+- name: '11'
+  type: 1000base-t
+  mgmt_only: false
+- name: '12'
+  type: 1000base-t
+  mgmt_only: false
+- name: '13'
+  type: 1000base-t
+  mgmt_only: false
+- name: '14'
+  type: 1000base-t
+  mgmt_only: false
+- name: '15'
+  type: 1000base-t
+  mgmt_only: false
+- name: '16'
+  type: 1000base-t
+  mgmt_only: false
+- name: '17'
+  type: 1000base-t
+  mgmt_only: false
+- name: '18'
+  type: 1000base-t
+  mgmt_only: false
+- name: '19'
+  type: 1000base-t
+  mgmt_only: false
+- name: '20'
+  type: 1000base-t
+  mgmt_only: false
+- name: '21'
+  type: 1000base-t
+  mgmt_only: false
+- name: '22'
+  type: 1000base-t
+  mgmt_only: false
+- name: '23'
+  type: 1000base-t
+  mgmt_only: false
+- name: '24'
+  type: 1000base-t
+  mgmt_only: false
+- name: '25'
+  type: 1000base-t
+  mgmt_only: false
+- name: '26'
+  type: 1000base-t
+  mgmt_only: false
+- name: '27'
+  type: 1000base-t
+  mgmt_only: false
+- name: '28'
+  type: 1000base-t
+  mgmt_only: false
+- name: '29'
+  type: 1000base-t
+  mgmt_only: false
+- name: '30'
+  type: 1000base-t
+  mgmt_only: false
+- name: '31'
+  type: 1000base-t
+  mgmt_only: false
+- name: '32'
+  type: 1000base-t
+  mgmt_only: false
+- name: '33'
+  type: 1000base-t
+  mgmt_only: false
+- name: '34'
+  type: 1000base-t
+  mgmt_only: false
+- name: '35'
+  type: 1000base-t
+  mgmt_only: false
+- name: '36'
+  type: 1000base-t
+  mgmt_only: false
+- name: '37'
+  type: 1000base-t
+  mgmt_only: false
+- name: '38'
+  type: 1000base-t
+  mgmt_only: false
+- name: '39'
+  type: 1000base-t
+  mgmt_only: false
+- name: '40'
+  type: 1000base-t
+  mgmt_only: false
+- name: '41'
+  type: 1000base-t
+  mgmt_only: false
+- name: '42'
+  type: 1000base-t
+  mgmt_only: false
+- name: '43'
+  type: 1000base-t
+  mgmt_only: false
+- name: '44'
+  type: 1000base-t
+  mgmt_only: false
+- name: '45'
+  type: 1000base-t
+  mgmt_only: false
+- name: '46'
+  type: 1000base-t
+  mgmt_only: false
+- name: '47'
+  type: 1000base-t
+  mgmt_only: false
+- name: '48'
+  type: 1000base-t
+  mgmt_only: false
+- name: '49'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '50'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '51'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '52'
+  type: 1000base-x-sfp
+  mgmt_only: false

--- a/device-types/Aruba/Aruba2530-48G-PoEP.yaml
+++ b/device-types/Aruba/Aruba2530-48G-PoEP.yaml
@@ -168,3 +168,4 @@ interfaces:
   - name: 52
     type: 1000base-x-sfp
     mgmt_only: false
+    

--- a/device-types/Aruba/Aruba2530-48G-PoEP.yaml
+++ b/device-types/Aruba/Aruba2530-48G-PoEP.yaml
@@ -1,0 +1,170 @@
+manufacturer: Aruba
+model: 2530-48G-PoEP Switch
+slug:  2530-48g-poep
+part_number: J9772A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14 
+    maximum_draw: 476
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: 1
+    type: 1000base-t
+    mgmt_only: false
+  - name: 2
+    type: 1000base-t
+    mgmt_only: false
+  - name: 3
+    type: 1000base-t
+    mgmt_only: false
+  - name: 4
+    type: 1000base-t
+    mgmt_only: false
+  - name: 5
+    type: 1000base-t
+    mgmt_only: false
+  - name: 6
+    type: 1000base-t
+    mgmt_only: false
+  - name: 7
+    type: 1000base-t
+    mgmt_only: false
+  - name: 8
+    type: 1000base-t
+    mgmt_only: false
+  - name: 9
+    type: 1000base-t
+    mgmt_only: false
+  - name: 10
+    type: 1000base-t
+    mgmt_only: false
+  - name: 11
+    type: 1000base-t
+    mgmt_only: false
+  - name: 12
+    type: 1000base-t
+    mgmt_only: false
+  - name: 13
+    type: 1000base-t
+    mgmt_only: false
+  - name: 14
+    type: 1000base-t
+    mgmt_only: false
+  - name: 15
+    type: 1000base-t
+    mgmt_only: false
+  - name: 16
+    type: 1000base-t
+    mgmt_only: false
+  - name: 17
+    type: 1000base-t
+    mgmt_only: false
+  - name: 18
+    type: 1000base-t
+    mgmt_only: false
+  - name: 19
+    type: 1000base-t
+    mgmt_only: false
+  - name: 20
+    type: 1000base-t
+    mgmt_only: false
+  - name: 21
+    type: 1000base-t
+    mgmt_only: false
+  - name: 22
+    type: 1000base-t
+    mgmt_only: false
+  - name: 23
+    type: 1000base-t
+    mgmt_only: false
+  - name: 24
+    type: 1000base-t
+    mgmt_only: false
+  - name: 25
+    type: 1000base-t
+    mgmt_only: false
+  - name: 26
+    type: 1000base-t
+    mgmt_only: false
+  - name: 27
+    type: 1000base-t
+    mgmt_only: false
+  - name: 28
+    type: 1000base-t
+    mgmt_only: false
+  - name: 29
+    type: 1000base-t
+    mgmt_only: false
+  - name: 30
+    type: 1000base-t
+    mgmt_only: false
+  - name: 31
+    type: 1000base-t
+    mgmt_only: false
+  - name: 32
+    type: 1000base-t
+    mgmt_only: false
+  - name: 33
+    type: 1000base-t
+    mgmt_only: false
+  - name: 34
+    type: 1000base-t
+    mgmt_only: false
+  - name: 35
+    type: 1000base-t
+    mgmt_only: false
+  - name: 36
+    type: 1000base-t
+    mgmt_only: false
+  - name: 37
+    type: 1000base-t
+    mgmt_only: false
+  - name: 38
+    type: 1000base-t
+    mgmt_only: false
+  - name: 39
+    type: 1000base-t
+    mgmt_only: false
+  - name: 40
+    type: 1000base-t
+    mgmt_only: false
+  - name: 41
+    type: 1000base-t
+    mgmt_only: false
+  - name: 42
+    type: 1000base-t
+    mgmt_only: false
+  - name: 43
+    type: 1000base-t
+    mgmt_only: false
+  - name: 44
+    type: 1000base-t
+    mgmt_only: false
+  - name: 45
+    type: 1000base-t
+    mgmt_only: false
+  - name: 46
+    type: 1000base-t
+    mgmt_only: false
+  - name: 47
+    type: 1000base-t
+    mgmt_only: false
+  - name: 48
+    type: 1000base-t
+    mgmt_only: false
+  - name: 49
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: 50
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: 51
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: 52
+    type: 1000base-x-sfp
+    mgmt_only: false

--- a/device-types/Aruba/Aruba2530-8G-PoEP.yaml
+++ b/device-types/Aruba/Aruba2530-8G-PoEP.yaml
@@ -1,0 +1,50 @@
+manufacturer: Aruba
+model: 2530-8G-PoEP Switch
+slug:  2530-8g-poep
+part_number: J9774A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14 
+    maximum_draw: 86
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+- name: '1'
+  type: 1000base-t
+  mgmt_only: false
+- name: '2'
+  type: 1000base-t
+  mgmt_only: false
+- name: '3'
+  type: 1000base-t
+  mgmt_only: false
+- name: '4'
+  type: 1000base-t
+  mgmt_only: false
+- name: '5'
+  type: 1000base-t
+  mgmt_only: false
+- name: '6'
+  type: 1000base-t
+  mgmt_only: false
+- name: '7'
+  type: 1000base-t
+  mgmt_only: false
+- name: '8'
+  type: 1000base-t
+  mgmt_only: false
+- name: '9-RJ45'
+  type: 1000base-t
+  mgmt_only: false
+- name: '10-RJ45'
+  type: 1000base-t
+  mgmt_only: false
+- name: '9-SFP'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '10-SFP'
+  type: 1000base-x-sfp
+  mgmt_only: false


### PR DESCRIPTION
Add a description file for an Aruba 2530 48G-PoEP switch (48 ports BaseT, 4 ports SFP, 1 console port, 1 power supply)
Add a description file for an Aruba 2530 24G-PoEP switch (24 ports BaseT, 4 ports SFP, 1 console port, 1 power supply)
Add a description file for an Aruba 2530 8G-PoEP switch (8 ports BaseT, 2 dual-personnality ports RJ45/SFP, 1 console port, 1 power supply)