### PR TITLE
Add device-type for Aruba Mobility controller 3400

### DIFF
--- a/device-types/Aruba/ArubaMC-3400.yaml
+++ b/device-types/Aruba/ArubaMC-3400.yaml
@@ -4,22 +4,18 @@ slug: aruba3400
 is_full_depth: no
 u_height: 1
 interfaces:
-  - name: (BASE-T)gigabitethernet 0/0/0
-    type: 1000base-t
   - name: (BASE-X)gigabitethernet 0/0/0
     type: 1000base-x-sfp
-  - name: (BASE-T)gigabitethernet 0/0/1
-    type: 1000base-t
+    #comment: Combo port either 1000base-x-sfp or 1000base-t
   - name: (BASE-X)gigabitethernet 0/0/1
     type: 1000base-x-sfp
-  - name: (BASE-T)gigabitethernet 0/0/2
-    type: 1000base-t
+    #comment: Combo port either 1000base-x-sfp or 1000base-t
   - name: (BASE-X)gigabitethernet 0/0/2
     type: 1000base-x-sfp
-  - name: (BASE-T)gigabitethernet 0/0/3
-    type: 1000base-t
+    #comment: Combo port either 1000base-x-sfp or 1000base-t
   - name: (BASE-X)gigabitethernet 0/0/3
     type: 1000base-x-sfp
+    #comment: Combo port either 1000base-x-sfp or 1000base-t
 power-ports:
   - name: PEM0
     type: iec-60320-c14 

--- a/device-types/Aruba/ArubaMC-3400.yaml
+++ b/device-types/Aruba/ArubaMC-3400.yaml
@@ -1,0 +1,29 @@
+manufacturer: Aruba
+model: Aruba3400
+slug: aruba3400
+is_full_depth: no
+u_height: 1
+interfaces:
+  - name: (BASE-T)gigabitethernet 0/0/0
+    type: 1000base-t
+  - name: (BASE-X)gigabitethernet 0/0/0
+    type: 1000base-x-sfp
+  - name: (BASE-T)gigabitethernet 0/0/1
+    type: 1000base-t
+  - name: (BASE-X)gigabitethernet 0/0/1
+    type: 1000base-x-sfp
+  - name: (BASE-T)gigabitethernet 0/0/2
+    type: 1000base-t
+  - name: (BASE-X)gigabitethernet 0/0/2
+    type: 1000base-x-sfp
+  - name: (BASE-T)gigabitethernet 0/0/3
+    type: 1000base-t
+  - name: (BASE-X)gigabitethernet 0/0/3
+    type: 1000base-x-sfp
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14 
+    maximum_draw: 45
+console-ports:
+  - name: Console
+    type: rj-45


### PR DESCRIPTION
Add device-type for Aruba Mobility controller 3400 (4 ports gig0/0/0 to 0/0/3 dual personnality (Base T or Base X), 1 console port, 1 power supply)