### PR TITLE
Add Juniper ACX1100-AC

### DIFF
--- a/device-types/Juniper/ACX1100-AC.yaml
+++ b/device-types/Juniper/ACX1100-AC.yaml
@@ -1,0 +1,48 @@
+manufacturer: Juniper
+model: ACX1100-AC
+slug: acx1100-ac
+part_number: ACX1100-AC
+u_height: 1
+is_full_depth: false
+console-ports:
+- name: Console
+  type: rj-45
+power-ports:
+- name: PSU0
+  type: iec-60320-c14
+  maximum_draw: 35
+- name: PSU1
+  type: iec-60320-c14
+  maximum_draw: 35
+interfaces:
+- name: ge-0/0/0
+  type: 1000base-t
+- name: ge-0/0/1
+  type: 1000base-t
+- name: ge-0/0/2
+  type: 1000base-t
+- name: ge-0/0/3
+  type: 1000base-t
+- name: ge-0/0/4
+  type: 1000base-t
+- name: ge-0/0/5
+  type: 1000base-t
+- name: ge-0/0/6
+  type: 1000base-t
+- name: ge-0/0/7
+  type: 1000base-t
+- name: ge-0/1/0
+  type: 1000base-x-sfp
+  # comments: shared media (You can use 1 of the 2 ports **WITH** this name. 1 is 1000base-x-sfp & the other is 1000base-t.)
+- name: ge-0/1/1
+  type: 1000base-x-sfp
+  # comments: shared media (You can use 1 of the 2 ports **WITH** this name. 1 is 1000base-x-sfp & the other is 1000base-t.)
+- name: ge-0/1/2
+  type: 1000base-x-sfp
+  # comments: shared media (You can use 1 of the 2 ports **WITH** this name. 1 is 1000base-x-sfp & the other is 1000base-t.)
+- name: ge-0/1/3
+  type: 1000base-x-sfp
+  # comments: shared media (You can use 1 of the 2 ports **WITH** this name. 1 is 1000base-x-sfp & the other is 1000base-t.)
+- name: fxp0
+  type: 1000base-t
+  mgmt_only: true


### PR DESCRIPTION
This PR adds device type for [Juniper Networks ACX1000 Universal Metro Router](https://www.juniper.net/us/en/products-services/routing/acx-series/acx1000/), or more specifically it's AC version. It would be great to add DC version as well, but I'm not sure how to represent DC termination block connector as a Netbox power port.
