### PR TITLE
Add Device Type for the Ubiquiti ER-X

### DIFF
--- a/device-types/Ubiquiti/er-x.yaml
+++ b/device-types/Ubiquiti/er-x.yaml
@@ -6,6 +6,7 @@ u_height: 1
 is_full_depth: false
 power-ports:
 - name: 12V Power Supply
+  type: None
   maximum_draw: 5
 interfaces:
 - name: eth0

--- a/device-types/Ubiquiti/er-x.yaml
+++ b/device-types/Ubiquiti/er-x.yaml
@@ -24,3 +24,6 @@ interfaces:
 - name: eth4
   type: 1000base-t
   mgmt_only: false
+- name: switch0
+  type: virtual
+  mgmt_only: false

--- a/device-types/Ubiquiti/er-x.yaml
+++ b/device-types/Ubiquiti/er-x.yaml
@@ -6,7 +6,7 @@ u_height: 1
 is_full_depth: false
 power-ports:
 - name: 12V Power Supply
-  type: None
+  type: ita-g
   maximum_draw: 5
 interfaces:
 - name: eth0


### PR DESCRIPTION
Adds support for the [Ubiquiti ER-X](https://www.ui.com/edgemax/edgerouter-x/)

Passes pytest on my local machine as GitHub Actions and branches don't play well with each other.