### PR TITLE
Dell S4048 - Added missing TenGigabitEthernet ports (10,20,30,40)

### DIFF
--- a/device-types/Dell/Networking_S4048-ON.yaml
+++ b/device-types/Dell/Networking_S4048-ON.yaml
@@ -31,6 +31,8 @@ interfaces:
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/9
     type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet 1/10
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/11
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/12
@@ -48,6 +50,8 @@ interfaces:
   - name: TenGigabitEthernet 1/18
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/19
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet 1/20
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/21
     type: 10gbase-x-sfpp
@@ -67,6 +71,8 @@ interfaces:
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/29
     type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet 1/30
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/31
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/32
@@ -84,6 +90,8 @@ interfaces:
   - name: TenGigabitEthernet 1/38
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/39
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet 1/40
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet 1/41
     type: 10gbase-x-sfpp


### PR DESCRIPTION
In the existing Dell S4048 template, the ports TenGigabitEthernet 1/10, TenGigabitEthernet 1/20, TenGigabitEthernet 1/30, and TenGigabitEthernet 1/40 are not in the template. This added them in