### PR TITLE
Add APC SmartUPS Management cards

### DIFF
--- a/device-types/APC/AP9617.yaml
+++ b/device-types/APC/AP9617.yaml
@@ -1,0 +1,12 @@
+manufacturer: APC
+model: AP9617
+slug: ap9617
+part_number: AP9617
+u_height: 0
+is_full_depth: false
+comments: UPS Network Management Card
+subdevice_role: child
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP9618.yaml
+++ b/device-types/APC/AP9618.yaml
@@ -1,0 +1,12 @@
+manufacturer: APC
+model: AP9618
+slug: ap9618
+part_number: AP9618
+u_height: 0
+is_full_depth: false
+comments: UPS Network Management Card w/ Environmental Monitoring & Out of Band Management
+subdevice_role: child
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP9619.yaml
+++ b/device-types/APC/AP9619.yaml
@@ -1,0 +1,12 @@
+manufacturer: APC
+model: AP9619
+slug: ap9619
+part_number: AP9619
+u_height: 0
+is_full_depth: false
+comments: UPS Network Management Card w/ Environmental Monitoring
+subdevice_role: child
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP9630.yaml
+++ b/device-types/APC/AP9630.yaml
@@ -1,0 +1,12 @@
+manufacturer: APC
+model: AP9630
+slug: ap9630
+part_number: AP9630
+u_height: 0
+is_full_depth: false
+comments: UPS Network Management Card 2
+subdevice_role: child
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP9631.yaml
+++ b/device-types/APC/AP9631.yaml
@@ -1,0 +1,12 @@
+manufacturer: APC
+model: AP9631
+slug: ap9631
+part_number: AP9631
+u_height: 0
+is_full_depth: false
+comments: UPS Network Management Card 2 with Environmental Monitoring
+subdevice_role: child
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP9640.yaml
+++ b/device-types/APC/AP9640.yaml
@@ -1,0 +1,12 @@
+manufacturer: APC
+model: AP9640
+slug: ap9640
+part_number: AP9640
+u_height: 0
+is_full_depth: false
+comments: UPS Network Management Card 3
+subdevice_role: child
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP9641.yaml
+++ b/device-types/APC/AP9641.yaml
@@ -1,0 +1,12 @@
+manufacturer: APC
+model: AP9641
+slug: ap9641
+part_number: AP9641
+u_height: 0
+is_full_depth: false
+comments: UPS Network Management Card 3 with Environmental Monitoring
+subdevice_role: child
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true


### PR DESCRIPTION
Add APC SmartUPS management cards generation 1,2,3 that can be inserted into various models of UPS.  Separately someone may wish to define different rack mount UPS models that these devices could be installed in for DCIM purposes, but this is enough to track the network device and its config.