### PR TITLE
Add Alpha Cordex DC plant management controllers

### DIFF
--- a/device-types/Alpha/CXC.yaml
+++ b/device-types/Alpha/CXC.yaml
@@ -1,0 +1,10 @@
+manufacturer: Alpha
+model: Cordex CXC
+slug: cxc
+part_number: CXC
+u_height: 0
+is_full_depth: false
+subdevice_role: child
+interfaces:
+- name: Ethernet
+  type: 100base-tx

--- a/device-types/Alpha/CXCM1-HP.yaml
+++ b/device-types/Alpha/CXCM1-HP.yaml
@@ -1,0 +1,10 @@
+manufacturer: Alpha
+model: Cordex CXCM1 HP
+slug: cxcm1-hp
+part_number: CXCM1-HP
+u_height: 0
+is_full_depth: false
+subdevice_role: child
+interfaces:
+- name: Ethernet/Front (1)
+  type: 100base-tx


### PR DESCRIPTION
Add new Alpha vendor and Cordex DC plant management cards that slot into UPS equipment.  Did not yet add the rack mounted hardware these management modules slot into, which would be useful for DCIM, but this is enough to model the networked device.