### PR TITLE
Add Nexus fabric extenders

### DIFF
--- a/device-types/Cisco/N2K-2248TP-E-1GE.yaml
+++ b/device-types/Cisco/N2K-2248TP-E-1GE.yaml
@@ -1,0 +1,118 @@
+manufacturer: Cisco
+model: N2K-C2248TP-E-1GE 
+slug: n2k-c2248tp-3-1ge
+part_number: N2K-C2248TP-E-1GE 
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power Supply 1
+    type: iec-60320-c14
+    maximum_draw: 400
+  - name: Power Supply 2
+    type: iec-60320-c14
+    maximum_draw: 400
+interfaces:
+  - name: Ethernet1/1/1
+    type: 1000base-t
+  - name: Ethernet1/1/2
+    type: 1000base-t
+  - name: Ethernet1/1/3
+    type: 1000base-t
+  - name: Ethernet1/1/4
+    type: 1000base-t
+  - name: Ethernet1/1/5
+    type: 1000base-t
+  - name: Ethernet1/1/6
+    type: 1000base-t
+  - name: Ethernet1/1/7
+    type: 1000base-t
+  - name: Ethernet1/1/8
+    type: 1000base-t
+  - name: Ethernet1/1/9
+    type: 1000base-t
+  - name: Ethernet1/1/10
+    type: 1000base-t
+  - name: Ethernet1/1/11
+    type: 1000base-t
+  - name: Ethernet1/1/12
+    type: 1000base-t
+  - name: Ethernet1/1/13
+    type: 1000base-t
+  - name: Ethernet1/1/14
+    type: 1000base-t
+  - name: Ethernet1/1/15
+    type: 1000base-t
+  - name: Ethernet1/1/16
+    type: 1000base-t
+  - name: Ethernet1/1/17
+    type: 1000base-t
+  - name: Ethernet1/1/18
+    type: 1000base-t
+  - name: Ethernet1/1/19
+    type: 1000base-t
+  - name: Ethernet1/1/20
+    type: 1000base-t
+  - name: Ethernet1/1/21
+    type: 1000base-t
+  - name: Ethernet1/1/22
+    type: 1000base-t
+  - name: Ethernet1/1/23
+    type: 1000base-t
+  - name: Ethernet1/1/24
+    type: 1000base-t
+  - name: Ethernet1/1/25
+    type: 1000base-t
+  - name: Ethernet1/1/26
+    type: 1000base-t
+  - name: Ethernet1/1/27
+    type: 1000base-t
+  - name: Ethernet1/1/28
+    type: 1000base-t
+  - name: Ethernet1/1/29
+    type: 1000base-t
+  - name: Ethernet1/1/30
+    type: 1000base-t
+  - name: Ethernet1/1/31
+    type: 1000base-t
+  - name: Ethernet1/1/32
+    type: 1000base-t
+  - name: Ethernet1/1/33
+    type: 1000base-t
+  - name: Ethernet1/1/34
+    type: 1000base-t
+  - name: Ethernet1/1/35
+    type: 1000base-t
+  - name: Ethernet1/1/36
+    type: 1000base-t
+  - name: Ethernet1/1/37
+    type: 1000base-t
+  - name: Ethernet1/1/38
+    type: 1000base-t
+  - name: Ethernet1/1/39
+    type: 1000base-t
+  - name: Ethernet1/1/40
+    type: 1000base-t
+  - name: Ethernet1/1/41
+    type: 1000base-t
+  - name: Ethernet1/1/42
+    type: 1000base-t
+  - name: Ethernet1/1/43
+    type: 1000base-t
+  - name: Ethernet1/1/44
+    type: 1000base-t
+  - name: Ethernet1/1/45
+    type: 1000base-t
+  - name: Ethernet1/1/46
+    type: 1000base-t
+  - name: Ethernet1/1/47
+    type: 1000base-t
+  - name: Ethernet1/1/48
+    type: 1000base-t
+  - name: Ethernet1/2/1
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/2
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/3
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/4
+    type: 10gbase-x-sfpp

--- a/device-types/Cisco/N2K-C2232PP-10GE.yaml
+++ b/device-types/Cisco/N2K-C2232PP-10GE.yaml
@@ -1,0 +1,94 @@
+manufacturer: Cisco
+model:  N2K-C2232PP-10GE
+slug: n2k-c2232pp-10ge
+part_number: N2K-C2232PP-10GE
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power Supply 1
+    type: iec-60320-c14
+    maximum_draw: 400
+  - name: Power Supply 2
+    type: iec-60320-c14
+    maximum_draw: 400
+interfaces:
+  - name: Ethernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/2
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/4
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/5
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/6
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/7
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/8
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/9
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/10
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/11
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/12
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/13
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/14
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/15
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/16
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/17
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/18
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/19
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/20
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/21
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/22
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/23
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/24
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/25
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/26
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/27
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/28
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/29
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/30
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/31
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/32
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/1
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/2
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/3
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/4
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/5
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/6
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/7
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/8
+    type: 10gbase-x-sfpp

--- a/device-types/Cisco/N2K-C2232TM-E-10GE.yaml
+++ b/device-types/Cisco/N2K-C2232TM-E-10GE.yaml
@@ -1,0 +1,94 @@
+manufacturer: Cisco
+model: N2K-C2232TM-E-10GE
+slug: n2k-c2232tm-e-10ge
+part_number: N2K-C2232TM-E-10GE
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power Supply 1
+    type: iec-60320-c14
+    maximum_draw: 400
+  - name: Power Supply 2
+    type: iec-60320-c14
+    maximum_draw: 400
+interfaces:
+  - name: Ethernet1/1/1
+    type: 10gbase-t
+  - name: Ethernet1/1/2
+    type: 10gbase-t
+  - name: Ethernet1/1/3
+    type: 10gbase-t
+  - name: Ethernet1/1/4
+    type: 10gbase-t
+  - name: Ethernet1/1/5
+    type: 10gbase-t
+  - name: Ethernet1/1/6
+    type: 10gbase-t
+  - name: Ethernet1/1/7
+    type: 10gbase-t
+  - name: Ethernet1/1/8
+    type: 10gbase-t
+  - name: Ethernet1/1/9
+    type: 10gbase-t
+  - name: Ethernet1/1/10
+    type: 10gbase-t
+  - name: Ethernet1/1/11
+    type: 10gbase-t
+  - name: Ethernet1/1/12
+    type: 10gbase-t
+  - name: Ethernet1/1/13
+    type: 10gbase-t
+  - name: Ethernet1/1/14
+    type: 10gbase-t
+  - name: Ethernet1/1/15
+    type: 10gbase-t
+  - name: Ethernet1/1/16
+    type: 10gbase-t
+  - name: Ethernet1/1/17
+    type: 10gbase-t
+  - name: Ethernet1/1/18
+    type: 10gbase-t
+  - name: Ethernet1/1/19
+    type: 10gbase-t
+  - name: Ethernet1/1/20
+    type: 10gbase-t
+  - name: Ethernet1/1/21
+    type: 10gbase-t
+  - name: Ethernet1/1/22
+    type: 10gbase-t
+  - name: Ethernet1/1/23
+    type: 10gbase-t
+  - name: Ethernet1/1/24
+    type: 10gbase-t
+  - name: Ethernet1/1/25
+    type: 10gbase-t
+  - name: Ethernet1/1/26
+    type: 10gbase-t
+  - name: Ethernet1/1/27
+    type: 10gbase-t
+  - name: Ethernet1/1/28
+    type: 10gbase-t
+  - name: Ethernet1/1/29
+    type: 10gbase-t
+  - name: Ethernet1/1/30
+    type: 10gbase-t
+  - name: Ethernet1/1/31
+    type: 10gbase-t
+  - name: Ethernet1/1/32
+    type: 10gbase-t
+  - name: Ethernet1/2/1
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/2
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/3
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/4
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/5
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/6
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/7
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/8
+    type: 10gbase-x-sfpp

--- a/device-types/Cisco/N2K-C2248PQ.yaml
+++ b/device-types/Cisco/N2K-C2248PQ.yaml
@@ -1,0 +1,118 @@
+manufacturer: Cisco
+model: N2K-C2248PQ
+slug: n2k-c2248pq
+part_number: N2K-C2248PQ
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power Supply 1
+    type: iec-60320-c14
+    maximum_draw: 400
+  - name: Power Supply 2
+    type: iec-60320-c14
+    maximum_draw: 400
+interfaces:
+  - name: Ethernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/2
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/4
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/5
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/6
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/7
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/8
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/9
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/10
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/11
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/12
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/13
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/14
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/15
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/16
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/17
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/18
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/19
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/20
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/21
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/22
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/23
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/24
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/25
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/26
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/27
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/28
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/29
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/30
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/31
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/32
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/33
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/34
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/35
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/36
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/37
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/38
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/39
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/40
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/41
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/42
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/43
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/44
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/45
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/46
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/47
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/1/48
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/2/1
+    type: 40gbase-x-qsfpp
+  - name: Ethernet1/2/2
+    type: 40gbase-x-qsfpp
+  - name: Ethernet1/2/3
+    type: 40gbase-x-qsfpp
+  - name: Ethernet1/2/4
+    type: 40gbase-x-qsfpp


### PR DESCRIPTION
Add Cisco Nexus 2000 fabric extenders.  Ports will likely always need to be renamed as the FEX numbers start at slot 100 IIUC, eg. Ethernet101/1/1 instead of Ethernet1/1/1
https://www.cisco.com/c/en/us/products/collateral/switches/nexus-2000-series-fabric-extenders/data_sheet_c78-507093.html