### PR TITLE
Add a number of Catalyst 3xxx models

### DIFF
--- a/device-types/Cisco/WS-C3550-24-SMI.yaml
+++ b/device-types/Cisco/WS-C3550-24-SMI.yaml
@@ -1,0 +1,64 @@
+manufacturer: Cisco
+model: WS-C3550-24-SMI
+slug: ws-c3550-24-smi
+part_number: WS-C3550-24-SMI
+u_height: 1
+console-ports:
+  - name: con 0
+    type: rj-45
+power-ports:
+  - name: Power Supply 0
+    type: iec-60320-c14
+interfaces:
+  - name: FastEthernet0/1
+    type: 100base-tx
+  - name: FastEthernet0/2
+    type: 100base-tx
+  - name: FastEthernet0/3
+    type: 100base-tx
+  - name: FastEthernet0/4
+    type: 100base-tx
+  - name: FastEthernet0/5
+    type: 100base-tx
+  - name: FastEthernet0/6
+    type: 100base-tx
+  - name: FastEthernet0/7
+    type: 100base-tx
+  - name: FastEthernet0/8
+    type: 100base-tx
+  - name: FastEthernet0/9
+    type: 100base-tx
+  - name: FastEthernet0/10
+    type: 100base-tx
+  - name: FastEthernet0/11
+    type: 100base-tx
+  - name: FastEthernet0/12
+    type: 100base-tx
+  - name: FastEthernet0/13
+    type: 100base-tx
+  - name: FastEthernet0/14
+    type: 100base-tx
+  - name: FastEthernet0/15
+    type: 100base-tx
+  - name: FastEthernet0/16
+    type: 100base-tx
+  - name: FastEthernet0/17
+    type: 100base-tx
+  - name: FastEthernet0/18
+    type: 100base-tx
+  - name: FastEthernet0/19
+    type: 100base-tx
+  - name: FastEthernet0/20
+    type: 100base-tx
+  - name: FastEthernet0/21
+    type: 100base-tx
+  - name: FastEthernet0/22
+    type: 100base-tx
+  - name: FastEthernet0/23
+    type: 100base-tx
+  - name: FastEthernet0/24
+    type: 100base-tx
+  - name: GigabitEthernet0/1
+    type: 1000base-x-gbic
+  - name: GigabitEthernet0/2
+    type: 1000base-x-gbic

--- a/device-types/Cisco/WS-C3650-24FD-L.yaml
+++ b/device-types/Cisco/WS-C3650-24FD-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-24FD-L
+slug: ws-c3650-24fd-L
+part_number: WS-C3650-24FD-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -67,11 +67,7 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
-  - name: PSU1
-    type: iec-60320-c14
+    maximum_draw: 1025

--- a/device-types/Cisco/WS-C3650-24PD-L.yaml
+++ b/device-types/Cisco/WS-C3650-24PD-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-24PD-L
+slug: ws-c3650-24pd-L
+part_number: WS-C3650-24PD-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -67,11 +67,7 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
-  - name: PSU1
-    type: iec-60320-c14
+    maximum_draw: 640

--- a/device-types/Cisco/WS-C3650-24PS-L.yaml
+++ b/device-types/Cisco/WS-C3650-24PS-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-24PS-L
+slug: ws-c3650-24ps-L
+part_number: WS-C3650-24PS-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -60,18 +60,13 @@ interfaces:
     type: 1000base-x-sfp
   - name: GigabitEthernet1/1/2
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
-    type: iec-60320-c14
-    maximum_draw: 715
-  - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3650-24TD-L.yaml
+++ b/device-types/Cisco/WS-C3650-24TD-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-24TD-L
+slug: ws-c3650-24ts-l
+part_number: WS-C3650-24TD-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -67,11 +67,6 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
-    type: iec-60320-c14
-    maximum_draw: 715
-  - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3650-24TS-L.yaml
+++ b/device-types/Cisco/WS-C3650-24TS-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-24TS-L
+slug: ws-c3650-24ts-l
+part_number: WS-C3650-24TS-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -60,18 +60,13 @@ interfaces:
     type: 1000base-x-sfp
   - name: GigabitEthernet1/1/2
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
-    type: iec-60320-c14
-    maximum_draw: 715
-  - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3650-48FD-L.yaml
+++ b/device-types/Cisco/WS-C3650-48FD-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-48FD-E
+slug: ws-c3650-48fd-e
+part_number: WS-C3650-48FD-E
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,6 +56,54 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
     type: 1000base-x-sfp
   - name: GigabitEthernet1/1/2
@@ -67,11 +115,10 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 1025
   - name: PSU1
     type: iec-60320-c14
+    maximum_draw: 1025

--- a/device-types/Cisco/WS-C3650-48FQ-L.yaml
+++ b/device-types/Cisco/WS-C3650-48FQ-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-48FQ-L
+slug: ws-c3650-48fq-l
+part_number: WS-C3650-48FQ-l
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,22 +56,64 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: FortyGigabitEthernet1/1/1
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/1/2
+    type: 40gbase-x-qsfpp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 1025
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3650-48FS-L.yaml
+++ b/device-types/Cisco/WS-C3650-48FS-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-48FS-L
+slug: ws-c3650-48fs-l
+part_number: WS-C3650-48FS-l
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,22 +56,68 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
     type: 1000base-x-sfp
   - name: GigabitEthernet1/1/2
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 1025
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3650-48PD-L.yaml
+++ b/device-types/Cisco/WS-C3650-48PD-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-48PD-L
+slug: ws-c3650-48pd-l
+part_number: WS-C3650-48PD-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,6 +56,54 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
     type: 1000base-x-sfp
   - name: GigabitEthernet1/1/2
@@ -67,11 +115,10 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 640
   - name: PSU1
     type: iec-60320-c14
+    maximum_draw: 640

--- a/device-types/Cisco/WS-C3650-48PQ-L.yaml
+++ b/device-types/Cisco/WS-C3650-48PQ-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-48PQ-L
+slug: ws-c3650-48pq-l
+part_number: WS-C3650-48PQ-l
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,22 +56,65 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: FortyGigabitEthernet1/1/1
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/1/2
+    type: 40gbase-x-qsfpp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 640
   - name: PSU1
     type: iec-60320-c14
+

--- a/device-types/Cisco/WS-C3650-48PS-L.yaml
+++ b/device-types/Cisco/WS-C3650-48PS-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-48PS-L
+slug: ws-c3650-48ps-l
+part_number: WS-C3650-48PS-l
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,22 +56,68 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
     type: 1000base-x-sfp
   - name: GigabitEthernet1/1/2
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 1025
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3650-48TD-L.yaml
+++ b/device-types/Cisco/WS-C3650-48TD-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-48TD-L
+slug: ws-c3650-48td-l
+part_number: WS-C3650-48TD-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,6 +56,54 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
     type: 1000base-x-sfp
   - name: GigabitEthernet1/1/2
@@ -67,11 +115,8 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3650-48TS-L.yaml
+++ b/device-types/Cisco/WS-C3650-48TS-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3650-48TS-L
+slug: ws-c3650-48ts-l
+part_number: WS-C3650-48TS-l
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,22 +56,68 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
     type: 1000base-x-sfp
   - name: GigabitEthernet1/1/2
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 640
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3750-24PS-S.yaml
+++ b/device-types/Cisco/WS-C3750-24PS-S.yaml
@@ -1,0 +1,64 @@
+manufacturer: Cisco
+model: Catalyst 3750-24PS IP Base
+slug: ws-c3750-24ps-s
+part_number: WS-C3750-24PS-S
+is_full_depth: false
+interfaces:
+  - name: FastEthernet1/0/1
+    type: 100base-tx
+  - name: FastEthernet1/0/2
+    type: 100base-tx
+  - name: FastEthernet1/0/3
+    type: 100base-tx
+  - name: FastEthernet1/0/4
+    type: 100base-tx
+  - name: FastEthernet1/0/5
+    type: 100base-tx
+  - name: FastEthernet1/0/6
+    type: 100base-tx
+  - name: FastEthernet1/0/7
+    type: 100base-tx
+  - name: FastEthernet1/0/8
+    type: 100base-tx
+  - name: FastEthernet1/0/9
+    type: 100base-tx
+  - name: FastEthernet1/0/10
+    type: 100base-tx
+  - name: FastEthernet1/0/11
+    type: 100base-tx
+  - name: FastEthernet1/0/12
+    type: 100base-tx
+  - name: FastEthernet1/0/13
+    type: 100base-tx
+  - name: FastEthernet1/0/14
+    type: 100base-tx
+  - name: FastEthernet1/0/15
+    type: 100base-tx
+  - name: FastEthernet1/0/16
+    type: 100base-tx
+  - name: FastEthernet1/0/17
+    type: 100base-tx
+  - name: FastEthernet1/0/18
+    type: 100base-tx
+  - name: FastEthernet1/0/19
+    type: 100base-tx
+  - name: FastEthernet1/0/20
+    type: 100base-tx
+  - name: FastEthernet1/0/21
+    type: 100base-tx
+  - name: FastEthernet1/0/22
+    type: 100base-tx
+  - name: FastEthernet1/0/23
+    type: 100base-tx
+  - name: FastEthernet1/0/24
+    type: 100base-tx
+  - name: GigabitEthernet1/0/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/2
+    type: 1000base-x-sfp
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Cisco/WS-C3750-24TS-S.yaml
+++ b/device-types/Cisco/WS-C3750-24TS-S.yaml
@@ -1,0 +1,64 @@
+manufacturer: Cisco
+model: Catalyst 3750-24TS IP Base
+slug: ws-c3750-24ts-s
+part_number: WS-C3750-24TS-S
+is_full_depth: false
+interfaces:
+  - name: FastEthernet1/0/1
+    type: 100base-tx
+  - name: FastEthernet1/0/2
+    type: 100base-tx
+  - name: FastEthernet1/0/3
+    type: 100base-tx
+  - name: FastEthernet1/0/4
+    type: 100base-tx
+  - name: FastEthernet1/0/5
+    type: 100base-tx
+  - name: FastEthernet1/0/6
+    type: 100base-tx
+  - name: FastEthernet1/0/7
+    type: 100base-tx
+  - name: FastEthernet1/0/8
+    type: 100base-tx
+  - name: FastEthernet1/0/9
+    type: 100base-tx
+  - name: FastEthernet1/0/10
+    type: 100base-tx
+  - name: FastEthernet1/0/11
+    type: 100base-tx
+  - name: FastEthernet1/0/12
+    type: 100base-tx
+  - name: FastEthernet1/0/13
+    type: 100base-tx
+  - name: FastEthernet1/0/14
+    type: 100base-tx
+  - name: FastEthernet1/0/15
+    type: 100base-tx
+  - name: FastEthernet1/0/16
+    type: 100base-tx
+  - name: FastEthernet1/0/17
+    type: 100base-tx
+  - name: FastEthernet1/0/18
+    type: 100base-tx
+  - name: FastEthernet1/0/19
+    type: 100base-tx
+  - name: FastEthernet1/0/20
+    type: 100base-tx
+  - name: FastEthernet1/0/21
+    type: 100base-tx
+  - name: FastEthernet1/0/22
+    type: 100base-tx
+  - name: FastEthernet1/0/23
+    type: 100base-tx
+  - name: FastEthernet1/0/24
+    type: 100base-tx
+  - name: GigabitEthernet1/0/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/2
+    type: 1000base-x-sfp
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+console-ports:
+  - name: Console
+    type: rj-45

--- a/device-types/Cisco/WS-C3750E-48TD-S.yaml
+++ b/device-types/Cisco/WS-C3750E-48TD-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3750X-48PF-S
-slug: ws-c3750x-48pf-s
-part_number: WS-C3750X-48PF-S 
+model: Catalyst 3750E-48TS-S
+slug: ws-c3750e-48ts-s
+part_number: WS-C3750E-48TS-S
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -104,14 +104,23 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/48
     type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/51
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/52
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 1100
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3750G-12S-E.yaml
+++ b/device-types/Cisco/WS-C3750G-12S-E.yaml
@@ -1,0 +1,39 @@
+manufacturer: Cisco
+model: Catalyst 3750G-12S IP Services
+slug: ws-c3750g-12s-e
+part_number: WS-C3750G-12S-E
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/2
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/4
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/5
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/6
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/7
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/8
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/9
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/10
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/11
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/12
+    type: 1000base-x-sfp
+console-ports:
+  - name: con0
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/WS-C3750G-12S-S.yaml
+++ b/device-types/Cisco/WS-C3750G-12S-S.yaml
@@ -1,0 +1,39 @@
+manufacturer: Cisco
+model: Catalyst 3750G-12S IP Base
+slug: ws-c3750g-12s-s
+part_number: WS-C3750G-12S-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/2
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/4
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/5
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/6
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/7
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/8
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/9
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/10
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/11
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/12
+    type: 1000base-x-sfp
+console-ports:
+  - name: con0
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/WS-C3750G-24TS-1U.yaml
+++ b/device-types/Cisco/WS-C3750G-24TS-1U.yaml
@@ -1,13 +1,10 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3750G-24TS-1U
+slug: ws-c3750g-24ts-1u
+part_number: WS-C3750G-24TS-1U 
 is_full_depth: false
 u_height: 1
 interfaces:
-  - name: GigabitEthernet0/0
-    type: 1000base-t
-    mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2
@@ -56,22 +53,18 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
+  - name: GigabitEthernet1/0/25
     type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
+  - name: GigabitEthernet1/0/26
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/0/27
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/28
+    type: 1000base-x-sfp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
-  - name: PSU1
-    type: iec-60320-c14
+

--- a/device-types/Cisco/WS-C3750G-24TS-S.yaml
+++ b/device-types/Cisco/WS-C3750G-24TS-S.yaml
@@ -1,13 +1,10 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3750G-24TS-S
+slug: ws-c3750g-24ts-s
+part_number: WS-C3750G-24TS-S 
 is_full_depth: false
 u_height: 1
 interfaces:
-  - name: GigabitEthernet0/0
-    type: 1000base-t
-    mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2
@@ -56,22 +53,18 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
+  - name: GigabitEthernet1/0/25
     type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
+  - name: GigabitEthernet1/0/26
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/0/27
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/28
+    type: 1000base-x-sfp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
-  - name: PSU1
-    type: iec-60320-c14
+

--- a/device-types/Cisco/WS-C3750G-24TS-S1U.yaml
+++ b/device-types/Cisco/WS-C3750G-24TS-S1U.yaml
@@ -1,13 +1,10 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3750G-24TS-S1U
+slug: ws-c3750g-24ts-s1u
+part_number: WS-C3750G-24TS-S1U 
 is_full_depth: false
 u_height: 1
 interfaces:
-  - name: GigabitEthernet0/0
-    type: 1000base-t
-    mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2
@@ -56,22 +53,19 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
+  - name: GigabitEthernet1/0/25
     type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
+  - name: GigabitEthernet1/0/26
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/0/27
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/28
+    type: 1000base-x-sfp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
-  - name: PSU1
-    type: iec-60320-c14
+    maximum_draw: 540
+

--- a/device-types/Cisco/WS-C3750G-48PS-S.yaml
+++ b/device-types/Cisco/WS-C3750G-48PS-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3750G-24PS-S
-slug: ws-c3750g-24ps-s
-part_number: WS-C3750G-24PS-S 
+model: Catalyst 3750G-48PS-S
+slug: ws-c3750g-48ps-s
+part_number: WS-C3750G-48PS-S 
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -54,12 +54,60 @@ interfaces:
   - name: GigabitEthernet1/0/24
     type: 1000base-t
   - name: GigabitEthernet1/0/25
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/0/26
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/0/27
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/51
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/52
     type: 1000base-x-sfp
 console-ports:
   - name: con0

--- a/device-types/Cisco/WS-C3750G-48TS-S.yaml
+++ b/device-types/Cisco/WS-C3750G-48TS-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3750G-24PS-S
-slug: ws-c3750g-24ps-s
-part_number: WS-C3750G-24PS-S 
+model: Catalyst 3750G-48TS-S
+slug: ws-c3750g-48ts-s
+part_number: WS-C3750G-48TS-S 
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -54,12 +54,60 @@ interfaces:
   - name: GigabitEthernet1/0/24
     type: 1000base-t
   - name: GigabitEthernet1/0/25
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/0/26
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/0/27
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/51
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/52
     type: 1000base-x-sfp
 console-ports:
   - name: con0
@@ -67,4 +115,3 @@ console-ports:
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-

--- a/device-types/Cisco/WS-C3750V2-48PS-S.yaml
+++ b/device-types/Cisco/WS-C3750V2-48PS-S.yaml
@@ -1,0 +1,118 @@
+manufacturer: Cisco
+model: Catalyst 3750v2-48PS-S
+slug: ws-c3750v2-48ps-s
+part_number: WS-C3750V2-48PS-S 
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: FastEthernet1/0/1
+    type: 100base-tx
+  - name: FastEthernet1/0/2
+    type: 100base-tx
+  - name: FastEthernet1/0/3
+    type: 100base-tx
+  - name: FastEthernet1/0/4
+    type: 100base-tx
+  - name: FastEthernet1/0/5
+    type: 100base-tx
+  - name: FastEthernet1/0/6
+    type: 100base-tx
+  - name: FastEthernet1/0/7
+    type: 100base-tx
+  - name: FastEthernet1/0/8
+    type: 100base-tx
+  - name: FastEthernet1/0/9
+    type: 100base-tx
+  - name: FastEthernet1/0/10
+    type: 100base-tx
+  - name: FastEthernet1/0/11
+    type: 100base-tx
+  - name: FastEthernet1/0/12
+    type: 100base-tx
+  - name: FastEthernet1/0/13
+    type: 100base-tx
+  - name: FastEthernet1/0/14
+    type: 100base-tx
+  - name: FastEthernet1/0/15
+    type: 100base-tx
+  - name: FastEthernet1/0/16
+    type: 100base-tx
+  - name: FastEthernet1/0/17
+    type: 100base-tx
+  - name: FastEthernet1/0/18
+    type: 100base-tx
+  - name: FastEthernet1/0/19
+    type: 100base-tx
+  - name: FastEthernet1/0/20
+    type: 100base-tx
+  - name: FastEthernet1/0/21
+    type: 100base-tx
+  - name: FastEthernet1/0/22
+    type: 100base-tx
+  - name: FastEthernet1/0/23
+    type: 100base-tx
+  - name: FastEthernet1/0/24
+    type: 100base-tx
+  - name: FastEthernet1/0/25
+    type: 100base-tx
+  - name: FastEthernet1/0/26
+    type: 100base-tx
+  - name: FastEthernet1/0/27
+    type: 100base-tx
+  - name: FastEthernet1/0/28
+    type: 100base-tx
+  - name: FastEthernet1/0/29
+    type: 100base-tx
+  - name: FastEthernet1/0/30
+    type: 100base-tx
+  - name: FastEthernet1/0/31
+    type: 100base-tx
+  - name: FastEthernet1/0/32
+    type: 100base-tx
+  - name: FastEthernet1/0/33
+    type: 100base-tx
+  - name: FastEthernet1/0/34
+    type: 100base-tx
+  - name: FastEthernet1/0/35
+    type: 100base-tx
+  - name: FastEthernet1/0/36
+    type: 100base-tx
+  - name: FastEthernet1/0/37
+    type: 100base-tx
+  - name: FastEthernet1/0/38
+    type: 100base-tx
+  - name: FastEthernet1/0/39
+    type: 100base-tx
+  - name: FastEthernet1/0/40
+    type: 100base-tx
+  - name: FastEthernet1/0/41
+    type: 100base-tx
+  - name: FastEthernet1/0/42
+    type: 100base-tx
+  - name: FastEthernet1/0/43
+    type: 100base-tx
+  - name: FastEthernet1/0/44
+    type: 100base-tx
+  - name: FastEthernet1/0/45
+    type: 100base-tx
+  - name: FastEthernet1/0/46
+    type: 100base-tx
+  - name: FastEthernet1/0/47
+    type: 100base-tx
+  - name: FastEthernet1/0/48
+    type: 100base-tx
+  - name: GigabitEthernet1/0/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/2
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/4
+    type: 1000base-x-sfp
+console-ports:
+  - name: con0
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+

--- a/device-types/Cisco/WS-C3750X-24P-S.yaml
+++ b/device-types/Cisco/WS-C3750X-24P-S.yaml
@@ -1,12 +1,12 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3750X-24P-S
+slug: ws-c3750x-24p-s
+part_number: WS-C3750X-24P-S
 is_full_depth: false
 u_height: 1
 interfaces:
-  - name: GigabitEthernet0/0
-    type: 1000base-t
+  - name: FastEthernet0
+    type: 100base-tx
     mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
@@ -56,18 +56,10 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
+  - name: usb
     type: usb-mini-b
 power-ports:
   - name: PSU0

--- a/device-types/Cisco/WS-C3750X-24T-S.yaml
+++ b/device-types/Cisco/WS-C3750X-24T-S.yaml
@@ -1,12 +1,12 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3750X-24T-S
+slug: ws-c3750x-24t-s
+part_number: WS-C3750X-24T-S
 is_full_depth: false
 u_height: 1
 interfaces:
-  - name: GigabitEthernet0/0
-    type: 1000base-t
+  - name: FastEthernet0
+    type: 100base-tx
     mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
@@ -56,22 +56,14 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
+  - name: usb
     type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 350
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3750X-48P-S.yaml
+++ b/device-types/Cisco/WS-C3750X-48P-S.yaml
@@ -1,12 +1,12 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3750X-48P-S
+slug: ws-c3750x-48p-s
+part_number: WS-C3750X-48P-S
 is_full_depth: false
 u_height: 1
 interfaces:
-  - name: GigabitEthernet0/0
-    type: 1000base-t
+  - name: FastEthernet0
+    type: 100base-tx
     mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
@@ -56,22 +56,62 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
+  - name: usb
     type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 1100
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3750X-48T-L.yaml
+++ b/device-types/Cisco/WS-C3750X-48T-L.yaml
@@ -1,12 +1,12 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3750X-48T-L
+slug: ws-c3750x-48t-l
+part_number: WS-C3750X-48T-L
 is_full_depth: false
 u_height: 1
 interfaces:
-  - name: GigabitEthernet0/0
-    type: 1000base-t
+  - name: FastEthernet0
+    type: 100base-tx
     mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
@@ -56,22 +56,62 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
+  - name: usb
     type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 350
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3750X-48T-S.yaml
+++ b/device-types/Cisco/WS-C3750X-48T-S.yaml
@@ -1,12 +1,12 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3750X-48T-S
+slug: ws-c3750x-48t-s
+part_number: WS-C3750X-48T-S
 is_full_depth: false
 u_height: 1
 interfaces:
-  - name: GigabitEthernet0/0
-    type: 1000base-t
+  - name: FastEthernet0
+    type: 100base-tx
     mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
@@ -56,22 +56,62 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
-  - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
-  - name: TenGigabitEthernet1/1/3
-    type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet1/1/4
-    type: 10gbase-x-sfpp
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
+  - name: usb
     type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 350
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-24P-L.yaml
+++ b/device-types/Cisco/WS-C3850-24P-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-24P-L
+slug: ws-c3850-24p-l
+part_number: WS-C3850-24P-L
 is_full_depth: false
 u_height: 1
 interfaces:

--- a/device-types/Cisco/WS-C3850-24P-S.yaml
+++ b/device-types/Cisco/WS-C3850-24P-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-24P-S
+slug: ws-c3850-24p-s
+part_number: WS-C3850-24P-S
 is_full_depth: false
 u_height: 1
 interfaces:

--- a/device-types/Cisco/WS-C3850-24T-L.yaml
+++ b/device-types/Cisco/WS-C3850-24T-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-24T-L
+slug: ws-c3850-24t-l
+part_number: WS-C3850-24T-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -72,6 +72,6 @@ console-ports:
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 350
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-24T-S.yaml
+++ b/device-types/Cisco/WS-C3850-24T-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-24T-S
+slug: ws-c3850-24t-S
+part_number: WS-C3850-24T-S
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -72,6 +72,6 @@ console-ports:
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 350
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-24XS-E.yaml
+++ b/device-types/Cisco/WS-C3850-24XS-E.yaml
@@ -1,0 +1,89 @@
+manufacturer: Cisco
+model: Catalyst 3850-24XS-E
+slug: ws-c3850-24xs-e
+part_number: WS-C3850-24XS-E
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/4
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/5
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/6
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/7
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/8
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/9
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/10
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/11
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/12
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/13
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/14
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/15
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/16
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/17
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/18
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/19
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/20
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/21
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/22
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/23
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/24
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/1
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/2
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/4
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/5
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/6
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/7
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/8
+    type: 10gbase-x-sfpp
+  - name: FortyGigabitEthernet1/1/1
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/1/2
+    type: 40gbase-x-qsfpp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: usb0
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 715
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-24XS-L.yaml
+++ b/device-types/Cisco/WS-C3850-24XS-L.yaml
@@ -1,0 +1,89 @@
+manufacturer: Cisco
+model: Catalyst 3850-24XS-L
+slug: ws-c3850-24xs-l
+part_number: WS-C3850-24XS-L
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/4
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/5
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/6
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/7
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/8
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/9
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/10
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/11
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/12
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/13
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/14
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/15
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/16
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/17
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/18
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/19
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/20
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/21
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/22
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/23
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/24
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/1
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/2
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/4
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/5
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/6
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/7
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/8
+    type: 10gbase-x-sfpp
+  - name: FortyGigabitEthernet1/1/1
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/1/2
+    type: 40gbase-x-qsfpp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: usb0
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 715
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-24XS-S.yaml
+++ b/device-types/Cisco/WS-C3850-24XS-S.yaml
@@ -1,0 +1,89 @@
+manufacturer: Cisco
+model: Catalyst 3850-24XS-S
+slug: ws-c3850-24xs-s
+part_number: WS-C3850-24XS-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/4
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/5
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/6
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/7
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/8
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/9
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/10
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/11
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/12
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/13
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/14
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/15
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/16
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/17
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/18
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/19
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/20
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/21
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/22
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/23
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/24
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/1
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/2
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/4
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/5
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/6
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/1/7
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/8
+    type: 10gbase-x-sfpp
+  - name: FortyGigabitEthernet1/1/1
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/1/2
+    type: 40gbase-x-qsfpp
+console-ports:
+  - name: con0
+    type: rj-45
+  - name: usb0
+    type: usb-mini-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 715
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-48F-S.yaml
+++ b/device-types/Cisco/WS-C3850-48F-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
 model: Catalyst 3850-48F IP Base
 slug: ws-c3850-48f-s
-part_number: WS-C3850-48F-s 
+part_number: WS-C3850-48F-S
 is_full_depth: false
 u_height: 1
 interfaces:

--- a/device-types/Cisco/WS-C3850-48F-S.yaml
+++ b/device-types/Cisco/WS-C3850-48F-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-48F IP Base
+slug: ws-c3850-48f-s
+part_number: WS-C3850-48F-s 
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,10 +56,66 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp  
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4
@@ -67,11 +123,10 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 1100
   - name: PSU1
     type: iec-60320-c14
+

--- a/device-types/Cisco/WS-C3850-48P-E.yaml
+++ b/device-types/Cisco/WS-C3850-48P-E.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-48P IP Services
+slug: ws-c3850-48p-e
+part_number: WS-C3850-48P-e 
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,10 +56,66 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp  
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4
@@ -67,8 +123,6 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-48P-E.yaml
+++ b/device-types/Cisco/WS-C3850-48P-E.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
 model: Catalyst 3850-48P IP Services
 slug: ws-c3850-48p-e
-part_number: WS-C3850-48P-e 
+part_number: WS-C3850-48P-E
 is_full_depth: false
 u_height: 1
 interfaces:

--- a/device-types/Cisco/WS-C3850-48P-L.yaml
+++ b/device-types/Cisco/WS-C3850-48P-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-48P LAN Base
+slug: ws-c3850-48p-l
+part_number: WS-C3850-48P-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,10 +56,66 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp  
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4
@@ -67,8 +123,6 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-48P-S.yaml
+++ b/device-types/Cisco/WS-C3850-48P-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-48P IP Base
+slug: ws-c3850-48p-s
+part_number: WS-C3850-48P-S
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,10 +56,66 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp  
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4
@@ -67,8 +123,6 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-48T-E.yaml
+++ b/device-types/Cisco/WS-C3850-48T-E.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-48T IP Services
+slug: ws-c3850-48t-e
+part_number: WS-C3850-48T-E
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,10 +56,66 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp  
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4
@@ -67,11 +123,9 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 350
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Cisco/WS-C3850-48T-L.yaml
+++ b/device-types/Cisco/WS-C3850-48T-L.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-48T LAN Base
+slug: ws-c3850-48t-l
+part_number: WS-C3850-48T-L
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,10 +56,66 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp  
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4
@@ -67,11 +123,10 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 350
   - name: PSU1
     type: iec-60320-c14
+

--- a/device-types/Cisco/WS-C3850-48T-S.yaml
+++ b/device-types/Cisco/WS-C3850-48T-S.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: Catalyst 3850-24P-E
-slug: ws-c3850-24p-e
-part_number: WS-C3850-24P-E
+model: Catalyst 3850-48T IP Base
+slug: ws-c3850-48t-s
+part_number: WS-C3850-48T-S
 is_full_depth: false
 u_height: 1
 interfaces:
@@ -56,10 +56,66 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp  
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp  
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4
@@ -67,11 +123,10 @@ interfaces:
 console-ports:
   - name: con0
     type: rj-45
-  - name: usb0
-    type: usb-mini-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-    maximum_draw: 715
+    maximum_draw: 350
   - name: PSU1
     type: iec-60320-c14
+


### PR DESCRIPTION
Adding a number of Cisco Catalyst models, old and new, Cat35xx, Cat37xx, Cat36xx, Cat38xx with LAN Base licensing primarily, but IP Base and IP Services for many models as well.