### PR TITLE
Add Raspberry Pi models for utility devices

### DIFF
--- a/device-types/Raspberry Pi/RPI3-MODB-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI3-MODB-1GB.yaml
@@ -1,0 +1,12 @@
+manufacturer: Raspberry Pi
+model: Raspberry Pi 3 Model B 1GB
+slug: rpi3-modb-1gb
+part_number: RPI3-MODB-1GB
+u_height: 0
+is_full_depth: false
+interfaces:
+- name: eth0
+  type: 1000base-t
+power-ports:
+  - name: PSU
+    type: nema-1-15p

--- a/device-types/Raspberry Pi/RPI3-MODBP-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI3-MODBP-1GB.yaml
@@ -1,0 +1,12 @@
+manufacturer: Raspberry Pi
+model: Raspberry Pi 3 Model B+ 1GB
+slug: rpi3-modbp-1gb
+part_number: RPI3-MODBP-1GB
+u_height: 0
+is_full_depth: false
+interfaces:
+- name: eth0
+  type: 1000base-t
+power-ports:
+  - name: PSU
+    type: nema-1-15p

--- a/device-types/Raspberry Pi/RPI4-MODBP-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODBP-1GB.yaml
@@ -1,0 +1,12 @@
+manufacturer: Raspberry Pi
+model: Raspberry Pi 4 Model B 1GB
+slug: rpi4-modbp-1gb
+part_number: RPI4-MODBP-1GB
+u_height: 0
+is_full_depth: false
+interfaces:
+- name: eth0
+  type: 1000base-t
+power-ports:
+  - name: PSU
+    type: nema-1-15p


### PR DESCRIPTION
I'm not sure this is useful for everyone, but we are using Raspberry Pi devices as network probes, if that is common enough then maybe it can be in the library and if that is out of scope then we can keep it in our fork.