### PR TITLE
Add various F5 BIG-IP models

### DIFF
--- a/device-types/F5/BIG-IP_3900.yaml
+++ b/device-types/F5/BIG-IP_3900.yaml
@@ -1,0 +1,50 @@
+manufacturer: F5
+model: BIG-IP 3900
+slug: big-ip-3900
+part_number: "3900"
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: Console
+    type: de-9
+  - name: usb1
+    type: usb-a
+  - name: usb2
+    type: usb-a
+  - name: Failover
+    type: de-9
+power-ports:
+  - name: psu1
+    type: iec-60320-c14
+    maximum_draw: 240
+  - name: psu2
+    type: iec-60320-c14
+    maximum_draw: 240
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: "1.1"
+    type: 1000base-t
+  - name: "1.2"
+    type: 1000base-t
+  - name: "1.3"
+    type: 1000base-t
+  - name: "1.4"
+    type: 1000base-t
+  - name: "1.5"
+    type: 1000base-t
+  - name: "1.6"
+    type: 1000base-t
+  - name: "1.7"
+    type: 1000base-t
+  - name: "1.8"
+    type: 1000base-t
+  - name: "2.1"
+    type: 1000base-x-sfp
+  - name: "2.2"
+    type: 1000base-x-sfp
+  - name: "2.3"
+    type: 1000base-x-sfp
+  - name: "2.4"
+    type: 1000base-x-sfp

--- a/device-types/F5/BIG-IP_4200v.yaml
+++ b/device-types/F5/BIG-IP_4200v.yaml
@@ -1,0 +1,46 @@
+manufacturer: F5
+model: BIG-IP 4200v
+slug: big-ip-4200v
+part_number: "4200v"
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: usb1
+    type: usb-a
+  - name: usb2
+    type: usb-a
+  - name: Failover
+    type: rj-45
+power-ports:
+  - name: psu1
+    type: iec-60320-c14
+    maximum_draw: 155
+  - name: psu2
+    type: iec-60320-c14
+    maximum_draw: 155
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: "1.1"
+    type: 1000base-t
+  - name: "1.2"
+    type: 1000base-t
+  - name: "1.3"
+    type: 1000base-t
+  - name: "1.4"
+    type: 1000base-t
+  - name: "1.5"
+    type: 1000base-t
+  - name: "1.6"
+    type: 1000base-t
+  - name: "1.7"
+    type: 1000base-t
+  - name: "1.8"
+    type: 1000base-t
+  - name: "2.1"
+    type: 10gbase-x-sfpp
+  - name: "2.2"
+    type: 10gbase-x-sfpp

--- a/device-types/F5/BIG-IP_5200v.yaml
+++ b/device-types/F5/BIG-IP_5200v.yaml
@@ -1,0 +1,50 @@
+manufacturer: F5
+model: BIG-IP 5200v
+slug: big-ip-5200v
+part_number: "5200v"
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: usb1
+    type: usb-a
+  - name: usb2
+    type: usb-a
+  - name: Failover
+    type: rj-45
+power-ports:
+  - name: psu1
+    type: iec-60320-c14
+    maximum_draw: 245
+  - name: psu2
+    type: iec-60320-c14
+    maximum_draw: 245
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: "1.1"
+    type: 1000base-t
+  - name: "1.2"
+    type: 1000base-t
+  - name: "1.3"
+    type: 1000base-t
+  - name: "1.4"
+    type: 1000base-t
+  - name: "2.1"
+    type: 10gbase-x-sfpp
+  - name: "2.2"
+    type: 10gbase-x-sfpp
+  - name: "2.3"
+    type: 10gbase-x-sfpp
+  - name: "2.4"
+    type: 10gbase-x-sfpp
+  - name: "2.5"
+    type: 10gbase-x-sfpp
+  - name: "2.6"
+    type: 10gbase-x-sfpp
+  - name: "2.7"
+    type: 10gbase-x-sfpp
+  - name: "2.8"
+    type: 10gbase-x-sfpp

--- a/device-types/F5/BIG-IP_VPR-C2400.yaml
+++ b/device-types/F5/BIG-IP_VPR-C2400.yaml
@@ -1,0 +1,24 @@
+manufacturer: F5
+model: BIG-IP VPR-C2400
+slug: big-ip-vpr-c2400
+part_number: "VPR-C2400"
+u_height: 4
+is_full_depth: true
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: usb1
+    type: usb-a
+  - name: usb2
+    type: usb-a
+power-ports:
+  - name: psu1
+    type: iec-60320-c20
+    maximum_draw: 1400
+  - name: psu2
+    type: iec-60320-c20
+    maximum_draw: 1400
+interfaces:
+  - name: 1/mgmt
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/F5/BIG-IP_i4600.yaml
+++ b/device-types/F5/BIG-IP_i4600.yaml
@@ -1,0 +1,48 @@
+manufacturer: F5
+model: BIG-IP i4600
+slug: big-ip-i4600
+part_number: "i4600"
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: usb1
+    type: usb-a
+  - name: Failover
+    type: rj-45
+power-ports:
+  - name: psu1
+    type: iec-60320-c14
+    maximum_draw: 165
+  - name: psu2
+    type: iec-60320-c14
+    maximum_draw: 165
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: "1.0"
+    type: 1000base-x-sfp
+  - name: "2.0"
+    type: 1000base-x-sfp
+  - name: "3.0"
+    type: 1000base-x-sfp
+  - name: "4.0"
+    type: 1000base-x-sfp
+  - name: "5.0"
+    type: 10gbase-x-sfpp
+  - name: "6.0"
+    type: 10gbase-x-sfpp
+  - name: "7.0"
+    type: 1000base-x-sfp
+  - name: "8.0"
+    type: 1000base-x-sfp
+  - name: "9.0"
+    type: 1000base-x-sfp
+  - name: "10.0"
+    type: 1000base-x-sfp
+  - name: "11.0"
+    type: 10gbase-x-sfpp
+  - name: "12.0"
+    type: 10gbase-x-sfpp

--- a/device-types/F5/BIG-IP_i4800.yaml
+++ b/device-types/F5/BIG-IP_i4800.yaml
@@ -1,0 +1,48 @@
+manufacturer: F5
+model: BIG-IP i4800
+slug: big-ip-i4800
+part_number: "i4800"
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: usb1
+    type: usb-a
+  - name: Failover
+    type: rj-45
+power-ports:
+  - name: psu1
+    type: iec-60320-c14
+    maximum_draw: 165
+  - name: psu2
+    type: iec-60320-c14
+    maximum_draw: 165
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: "1.0"
+    type: 1000base-x-sfp
+  - name: "2.0"
+    type: 1000base-x-sfp
+  - name: "3.0"
+    type: 1000base-x-sfp
+  - name: "4.0"
+    type: 1000base-x-sfp
+  - name: "5.0"
+    type: 10gbase-x-sfpp
+  - name: "6.0"
+    type: 10gbase-x-sfpp
+  - name: "7.0"
+    type: 1000base-x-sfp
+  - name: "8.0"
+    type: 1000base-x-sfp
+  - name: "9.0"
+    type: 1000base-x-sfp
+  - name: "10.0"
+    type: 1000base-x-sfp
+  - name: "11.0"
+    type: 10gbase-x-sfpp
+  - name: "12.0"
+    type: 10gbase-x-sfpp

--- a/device-types/F5/BIG-IP_i5800.yaml
+++ b/device-types/F5/BIG-IP_i5800.yaml
@@ -1,0 +1,48 @@
+manufacturer: F5
+model: BIG-IP i5800
+slug: big-ip-i5800
+part_number: "i5800"
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: usb1
+    type: usb-a
+  - name: Failover
+    type: rj-45
+power-ports:
+  - name: psu1
+    type: iec-60320-c14
+    maximum_draw: 330
+  - name: psu2
+    type: iec-60320-c14
+    maximum_draw: 330
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: "1.1"
+    type: 10gbase-x-sfpp
+  - name: "1.2"
+    type: 10gbase-x-sfpp
+  - name: "1.3"
+    type: 10gbase-x-sfpp
+  - name: "1.4"
+    type: 10gbase-x-sfpp
+  - name: "2.1"
+    type: 10gbase-x-sfpp
+  - name: "2.2"
+    type: 10gbase-x-sfpp
+  - name: "2.3"
+    type: 10gbase-x-sfpp
+  - name: "2.4"
+    type: 10gbase-x-sfpp
+  - name: "3.0"
+    type: 40gbase-x-qsfpp
+  - name: "4.0"
+    type: 40gbase-x-qsfpp
+  - name: "5.0"
+    type: 40gbase-x-qsfpp
+  - name: "6.0"
+    type: 40gbase-x-qsfpp


### PR DESCRIPTION
Add some F5 BIG-IP models:
- BIG-IP 3900
- BIG-IP 4200v
- BIG-IP 5200v
- BIG-IP i4600
- BIG-IP i4800
- BIG-IP i5800
- BIG-IP Viprion C2400 Chassis