### PR TITLE
Add and fix various Cisco models

### DIFF
--- a/device-types/Cisco/C9500-32QC.yaml
+++ b/device-types/Cisco/C9500-32QC.yaml
@@ -1,0 +1,116 @@
+manufacturer: Cisco
+model: Catalyst 9500-32QC
+slug: c9500-32qc
+part_number: C9500-32QC
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-mini-b
+power-ports:
+  - name: PS-0
+    type: iec-60320-c14
+  - name: PS-1
+    type: iec-60320-c14
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: FortyGigabitEthernet1/0/1
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/2
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/3
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/4
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/5
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/6
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/7
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/8
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/9
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/10
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/11
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/12
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/13
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/14
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/15
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/16
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/17
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/18
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/19
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/20
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/21
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/22
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/23
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/24
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/25
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/26
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/27
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/28
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/29
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/30
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/31
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet1/0/32
+    type: 40gbase-x-qsfpp
+  - name: HundredGigE1/0/33
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/34
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/35
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/36
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/37
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/38
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/39
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/40
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/41
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/42
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/43
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/44
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/45
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/46
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/47
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE1/0/48
+    type: 100gbase-x-qsfp28

--- a/device-types/Cisco/ISR3945.yaml
+++ b/device-types/Cisco/ISR3945.yaml
@@ -1,0 +1,29 @@
+manufacturer: Cisco
+model: ISR3945
+part_number: CISCO3945-CHASSIS
+slug: isr3945
+u_height: 3
+is_full_depth: true
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/2
+    type: 1000base-t
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: aux 0
+    type: rj-45
+  - name: con usb
+    type: usb-mini-b
+  - name: usb 0
+    type: usb-a
+  - name: usb 1
+    type: usb-a
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/c9300-24p.yaml
+++ b/device-types/Cisco/c9300-24p.yaml
@@ -8,7 +8,9 @@ console-ports:
   - name: con 0
     type: rj-45
 power-ports:
-  - name: PS-1
+  - name: PS-A
+    type: iec-60320-c14
+  - name: PS-B
     type: iec-60320-c14
 interfaces:
   - name: GigabitEthernet1/0/1
@@ -59,6 +61,6 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/c9300-24t.yaml
+++ b/device-types/Cisco/c9300-24t.yaml
@@ -8,7 +8,9 @@ console_ports:
   - name: con 0
     type: rj-45
 power_ports:
-  - name: PS-1
+  - name: PS-A
+    type: iec-60320-c14
+  - name: PS-B
     type: iec-60320-c14
 interfaces:
   - name: GigabitEthernet1/0/1
@@ -59,6 +61,6 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/24
     type: 1000base-t
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/c9300-48p.yaml
+++ b/device-types/Cisco/c9300-48p.yaml
@@ -8,7 +8,9 @@ console-ports:
   - name: con 0
     type: rj-45
 power-ports:
-  - name: PS-1
+  - name: PS-A
+    type: iec-60320-c14
+  - name: PS-B
     type: iec-60320-c14
 interfaces:
   - name: GigabitEthernet1/0/1
@@ -107,6 +109,6 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet1/0/48
     type: 1000base-t
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/c9300-48t.yaml
+++ b/device-types/Cisco/c9300-48t.yaml
@@ -1,7 +1,7 @@
 manufacturer: Cisco
-model: C9300-48U
-part_number: C9300-48U
-slug: c9300-48u
+model: C9300-48T
+part_number: C9300-48T
+slug: c9300-48t
 u_height: 1
 is_full_depth: true
 console-ports:
@@ -10,8 +10,12 @@ console-ports:
 power-ports:
   - name: PS-A
     type: iec-60320-c14
+    maximum_draw: 103
+    allocated_draw: 97
   - name: PS-B
     type: iec-60320-c14
+    maximum_draw: 103
+    allocated_draw: 97
 interfaces:
   - name: GigabitEthernet1/0/1
     type: 1000base-t

--- a/device-types/Cisco/c9300-48uxm.yaml
+++ b/device-types/Cisco/c9300-48uxm.yaml
@@ -7,10 +7,10 @@ console-ports:
   - name: con 0
     type: rj-45
 power-ports:
-  - name: PS-1
+  - name: PS-A
     type: iec-60320-c14
     maximum_draw: 1100
-  - name: PS-2
+  - name: PS-B
     type: iec-60320-c14
     maximum_draw: 1100
 interfaces:

--- a/device-types/Cisco/ws-c2960x-24td-l.yaml
+++ b/device-types/Cisco/ws-c2960x-24td-l.yaml
@@ -1,0 +1,73 @@
+manufacturer: Cisco
+model: Catalyst 2960X-24TD-L
+slug: ws-c2960x-24td-l
+part_number: WS-C2960X-24TD-L
+is_full_depth: false
+u_height: 1
+comments: LAN Base feature set
+interfaces:
+  - name: FastEthernet0
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/26
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con0
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14

--- a/device-types/Cisco/ws-c2960x-48td-l.yaml
+++ b/device-types/Cisco/ws-c2960x-48td-l.yaml
@@ -1,0 +1,122 @@
+manufacturer: Cisco
+model: Catalyst 2960X-48TD-L
+slug: ws-c2960x-48td-l
+part_number: WS-C2960X-48TD-L 
+is_full_depth: false
+u_height: 1
+comments: LAN Base feature set
+interfaces:
+  - name: FastEthernet0
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45 
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 50

--- a/device-types/Cisco/ws-c2960xr-48fpd-i.yaml
+++ b/device-types/Cisco/ws-c2960xr-48fpd-i.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 2960XR-48FPD-I
+slug: ws-c2960xr-48fpd-i
+part_number: WS-C2960XR-48FPD-I
+is_full_depth: false
+u_height: 1
+comments: IP Lite feature set
+interfaces:
+  - name: FastEthernet0
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45 
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/ws-c2960xr-48fps-i.yaml
+++ b/device-types/Cisco/ws-c2960xr-48fps-i.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 2960XR-48FPS-I
+slug: ws-c2960xr-48fps-i
+part_number: WS-C2960XR-48FPS-I
+is_full_depth: false
+u_height: 1
+comments: IP Lite feature set
+interfaces:
+  - name: FastEthernet0
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/51
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/52
+    type: 1000base-x-sfp
+console-ports:
+  - name: con 0
+    type: rj-45 
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/ws-c2960xr-48lpd-i.yaml
+++ b/device-types/Cisco/ws-c2960xr-48lpd-i.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 2960XR-48LPD-I
+slug: ws-c2960xr-48lpd-i
+part_number: WS-C2960XR-48LPD-I
+is_full_depth: false
+u_height: 1
+comments: IP Lite feature set
+interfaces:
+  - name: FastEthernet0
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45 
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/ws-c2960xr-48lps-i.yaml
+++ b/device-types/Cisco/ws-c2960xr-48lps-i.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 2960XR-48LPS-I
+slug: ws-c2960xr-48lps-i
+part_number: WS-C2960XR-48LPS-I
+is_full_depth: false
+u_height: 1
+comments: IP Lite feature set
+interfaces:
+  - name: FastEthernet0
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/51
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/52
+    type: 1000base-x-sfp
+console-ports:
+  - name: con 0
+    type: rj-45 
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/ws-c2960xr-48td-i.yaml
+++ b/device-types/Cisco/ws-c2960xr-48td-i.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 2960XR-48TD-I
+slug: ws-c2960xr-48td-i
+part_number: WS-C2960XR-48TD-I
+is_full_depth: false
+u_height: 1
+comments: IP Lite feature set
+interfaces:
+  - name: FastEthernet0
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet1/0/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/0/2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45 
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/ws-c2960xr-48ts-i.yaml
+++ b/device-types/Cisco/ws-c2960xr-48ts-i.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 2960XR-48TS-I
+slug: ws-c2960xr-48ts-i
+part_number: WS-C2960XR-48TS-I
+is_full_depth: false
+u_height: 1
+comments: IP Lite feature set
+interfaces:
+  - name: FastEthernet0
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: GigabitEthernet1/0/49
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/50
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/51
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/52
+    type: 1000base-x-sfp
+console-ports:
+  - name: con 0
+    type: rj-45 
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14

--- a/device-types/Cisco/ws-c3650-48fq-e.yaml
+++ b/device-types/Cisco/ws-c3650-48fq-e.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 3650-48FQ-E
+slug: ws-c3650-48fq-e
+part_number: WS-C3650-48FQ-E
+is_full_depth: false
+u_height: 1
+comments: IP Services feature set
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/4
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45
+power-ports:
+  - name: PS-A
+    type: iec-60320-c16
+  - name: PS-B
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3650-48fq-s.yaml
+++ b/device-types/Cisco/ws-c3650-48fq-s.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 3650-48FQ-S
+slug: ws-c3650-48fq-s
+part_number: WS-C3650-48FQ-S
+is_full_depth: false
+u_height: 1
+comments: IP Base feature set
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/4
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45
+power-ports:
+  - name: PS-A
+    type: iec-60320-c16
+  - name: PS-B
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3650-48pq-e.yaml
+++ b/device-types/Cisco/ws-c3650-48pq-e.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 3650-48PQ-E
+slug: ws-c3650-48pq-e
+part_number: WS-C3650-48PQ-E
+is_full_depth: false
+u_height: 1
+comments: IP Services feature set
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/4
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45
+power-ports:
+  - name: PS-A
+    type: iec-60320-c16
+  - name: PS-B
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3650-48pq-s.yaml
+++ b/device-types/Cisco/ws-c3650-48pq-s.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 3650-48PQ-S
+slug: ws-c3650-48pq-s
+part_number: WS-C3650-48PQ-S
+is_full_depth: false
+u_height: 1
+comments: IP Base feature set
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/4
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45
+power-ports:
+  - name: PS-A
+    type: iec-60320-c16
+  - name: PS-B
+    type: iec-60320-c16

--- a/device-types/Cisco/ws-c3650-48tq-e.yaml
+++ b/device-types/Cisco/ws-c3650-48tq-e.yaml
@@ -1,0 +1,123 @@
+manufacturer: Cisco
+model: Catalyst 3650-48TQ-E
+slug: ws-c3650-48tq-e
+part_number: WS-C3650-48TQ-E
+is_full_depth: false
+u_height: 1
+comments: IP Services feature set
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-t
+  - name: GigabitEthernet1/0/18
+    type: 1000base-t
+  - name: GigabitEthernet1/0/19
+    type: 1000base-t
+  - name: GigabitEthernet1/0/20
+    type: 1000base-t
+  - name: GigabitEthernet1/0/21
+    type: 1000base-t
+  - name: GigabitEthernet1/0/22
+    type: 1000base-t
+  - name: GigabitEthernet1/0/23
+    type: 1000base-t
+  - name: GigabitEthernet1/0/24
+    type: 1000base-t
+  - name: GigabitEthernet1/0/25
+    type: 1000base-t
+  - name: GigabitEthernet1/0/26
+    type: 1000base-t
+  - name: GigabitEthernet1/0/27
+    type: 1000base-t
+  - name: GigabitEthernet1/0/28
+    type: 1000base-t
+  - name: GigabitEthernet1/0/29
+    type: 1000base-t
+  - name: GigabitEthernet1/0/30
+    type: 1000base-t
+  - name: GigabitEthernet1/0/31
+    type: 1000base-t
+  - name: GigabitEthernet1/0/32
+    type: 1000base-t
+  - name: GigabitEthernet1/0/33
+    type: 1000base-t
+  - name: GigabitEthernet1/0/34
+    type: 1000base-t
+  - name: GigabitEthernet1/0/35
+    type: 1000base-t
+  - name: GigabitEthernet1/0/36
+    type: 1000base-t
+  - name: GigabitEthernet1/0/37
+    type: 1000base-t
+  - name: GigabitEthernet1/0/38
+    type: 1000base-t
+  - name: GigabitEthernet1/0/39
+    type: 1000base-t
+  - name: GigabitEthernet1/0/40
+    type: 1000base-t
+  - name: GigabitEthernet1/0/41
+    type: 1000base-t
+  - name: GigabitEthernet1/0/42
+    type: 1000base-t
+  - name: GigabitEthernet1/0/43
+    type: 1000base-t
+  - name: GigabitEthernet1/0/44
+    type: 1000base-t
+  - name: GigabitEthernet1/0/45
+    type: 1000base-t
+  - name: GigabitEthernet1/0/46
+    type: 1000base-t
+  - name: GigabitEthernet1/0/47
+    type: 1000base-t
+  - name: GigabitEthernet1/0/48
+    type: 1000base-t
+  - name: TenGigabitEthernet1/1/1
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/2
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/3
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet1/1/4
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con 0
+    type: rj-45
+power-ports:
+  - name: PS-A
+    type: iec-60320-c16
+  - name: PS-B
+    type: iec-60320-c16


### PR DESCRIPTION
Added some new and old Cisco models. Fixed a couple others.

- Added C9300-48t
- Fixed other C9300s PWR and mgmt interface names
- Added some C2960 variants
- Added some C3650 variants
- Added ISR3945
