### PR TITLE
Add various Aruba and legacy HPE devices

### DIFF
--- a/device-types/Aruba/Aruba2920-24G.yaml
+++ b/device-types/Aruba/Aruba2920-24G.yaml
@@ -1,0 +1,68 @@
+manufacturer: Aruba
+model: 2920-24G
+slug:  2920-24g
+part_number: J9726A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 165
+    allocated_draw: 58
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: USB Console
+    type: usb-micro-b
+interfaces:
+  - name: Management
+    type: 1000base-t
+    mgmt_only: true
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t

--- a/device-types/Aruba/Aruba2920-48G-PoEP.yaml
+++ b/device-types/Aruba/Aruba2920-48G-PoEP.yaml
@@ -1,0 +1,116 @@
+manufacturer: Aruba
+model: 2920-48G-PoE+
+slug:  2920-48g-poep
+part_number: J9729A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 575
+    allocated_draw: 487
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: USB Console
+    type: usb-micro-b
+interfaces:
+  - name: Management
+    type: 1000base-t
+    mgmt_only: true
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t
+  - name: '25'
+    type: 1000base-t
+  - name: '26'
+    type: 1000base-t
+  - name: '27'
+    type: 1000base-t
+  - name: '28'
+    type: 1000base-t
+  - name: '29'
+    type: 1000base-t
+  - name: '30'
+    type: 1000base-t
+  - name: '31'
+    type: 1000base-t
+  - name: '32'
+    type: 1000base-t
+  - name: '33'
+    type: 1000base-t
+  - name: '34'
+    type: 1000base-t
+  - name: '35'
+    type: 1000base-t
+  - name: '36'
+    type: 1000base-t
+  - name: '37'
+    type: 1000base-t
+  - name: '38'
+    type: 1000base-t
+  - name: '39'
+    type: 1000base-t
+  - name: '40'
+    type: 1000base-t
+  - name: '41'
+    type: 1000base-t
+  - name: '42'
+    type: 1000base-t
+  - name: '43'
+    type: 1000base-t
+  - name: '44'
+    type: 1000base-t
+  - name: '45'
+    type: 1000base-t
+  - name: '46'
+    type: 1000base-t
+  - name: '47'
+    type: 1000base-t
+  - name: '48'
+    type: 1000base-t

--- a/device-types/Aruba/Aruba2920-48G.yaml
+++ b/device-types/Aruba/Aruba2920-48G.yaml
@@ -1,0 +1,116 @@
+manufacturer: Aruba
+model: 2920-48G
+slug:  2920-48g
+part_number: J9728A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 165
+    allocated_draw: 70
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: USB Console
+    type: usb-micro-b
+interfaces:
+  - name: Management
+    type: 1000base-t
+    mgmt_only: true
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t
+  - name: '25'
+    type: 1000base-t
+  - name: '26'
+    type: 1000base-t
+  - name: '27'
+    type: 1000base-t
+  - name: '28'
+    type: 1000base-t
+  - name: '29'
+    type: 1000base-t
+  - name: '30'
+    type: 1000base-t
+  - name: '31'
+    type: 1000base-t
+  - name: '32'
+    type: 1000base-t
+  - name: '33'
+    type: 1000base-t
+  - name: '34'
+    type: 1000base-t
+  - name: '35'
+    type: 1000base-t
+  - name: '36'
+    type: 1000base-t
+  - name: '37'
+    type: 1000base-t
+  - name: '38'
+    type: 1000base-t
+  - name: '39'
+    type: 1000base-t
+  - name: '40'
+    type: 1000base-t
+  - name: '41'
+    type: 1000base-t
+  - name: '42'
+    type: 1000base-t
+  - name: '43'
+    type: 1000base-t
+  - name: '44'
+    type: 1000base-t
+  - name: '45'
+    type: 1000base-t
+  - name: '46'
+    type: 1000base-t
+  - name: '47'
+    type: 1000base-t
+  - name: '48'
+    type: 1000base-t

--- a/device-types/Aruba/Aruba2930F-48G-4SFPP.yaml
+++ b/device-types/Aruba/Aruba2930F-48G-4SFPP.yaml
@@ -1,0 +1,124 @@
+manufacturer: Aruba
+model: 2930F-48G-4SFP+
+slug:  2930f-48g-4sfpp
+part_number: JL254A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 165
+    allocated_draw: 47
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: USB Console
+    type: usb-micro-b
+interfaces:
+  - name: Management
+    type: 1000base-t
+    mgmt_only: true
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t
+  - name: '25'
+    type: 1000base-t
+  - name: '26'
+    type: 1000base-t
+  - name: '27'
+    type: 1000base-t
+  - name: '28'
+    type: 1000base-t
+  - name: '29'
+    type: 1000base-t
+  - name: '30'
+    type: 1000base-t
+  - name: '31'
+    type: 1000base-t
+  - name: '32'
+    type: 1000base-t
+  - name: '33'
+    type: 1000base-t
+  - name: '34'
+    type: 1000base-t
+  - name: '35'
+    type: 1000base-t
+  - name: '36'
+    type: 1000base-t
+  - name: '37'
+    type: 1000base-t
+  - name: '38'
+    type: 1000base-t
+  - name: '39'
+    type: 1000base-t
+  - name: '40'
+    type: 1000base-t
+  - name: '41'
+    type: 1000base-t
+  - name: '42'
+    type: 1000base-t
+  - name: '43'
+    type: 1000base-t
+  - name: '44'
+    type: 1000base-t
+  - name: '45'
+    type: 1000base-t
+  - name: '46'
+    type: 1000base-t
+  - name: '47'
+    type: 1000base-t
+  - name: '48'
+    type: 1000base-t
+  - name: '49'
+    type: 10gbase-x-sfpp
+  - name: '50'
+    type: 10gbase-x-sfpp
+  - name: '51'
+    type: 10gbase-x-sfpp
+  - name: '52'
+    type: 10gbase-x-sfpp

--- a/device-types/Aruba/Aruba7005.yaml
+++ b/device-types/Aruba/Aruba7005.yaml
@@ -1,0 +1,19 @@
+manufacturer: Aruba
+model: Aruba7005
+slug: aruba7005
+is_full_depth: no
+u_height: 1
+interfaces:
+  - name: gigabitethernet 0/0/0
+    type: 1000base-t
+  - name: gigabitethernet 0/0/1
+    type: 1000base-t
+  - name: gigabitethernet 0/0/2
+    type: 1000base-t
+  - name: gigabitethernet 0/0/3
+    type: 1000base-t
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console USB
+    type: usb-mini-b

--- a/device-types/Aruba/Aruba7010.yaml
+++ b/device-types/Aruba/Aruba7010.yaml
@@ -1,0 +1,54 @@
+manufacturer: Aruba
+model: Aruba7010
+slug: aruba7010
+is_full_depth: no
+u_height: 1
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: gigabitethernet 0/0/0
+    type: 1000base-t
+  - name: gigabitethernet 0/0/1
+    type: 1000base-t
+  - name: gigabitethernet 0/0/2
+    type: 1000base-t
+  - name: gigabitethernet 0/0/3
+    type: 1000base-t
+  - name: gigabitethernet 0/0/4
+    type: 1000base-t
+  - name: gigabitethernet 0/0/5
+    type: 1000base-t
+  - name: gigabitethernet 0/0/6
+    type: 1000base-t
+  - name: gigabitethernet 0/0/7
+    type: 1000base-t
+  - name: gigabitethernet 0/0/8
+    type: 1000base-t
+  - name: gigabitethernet 0/0/9
+    type: 1000base-t
+  - name: gigabitethernet 0/0/10
+    type: 1000base-t
+  - name: gigabitethernet 0/0/11
+    type: 1000base-t
+  - name: gigabitethernet 0/0/12
+    type: 1000base-t
+  - name: gigabitethernet 0/0/13
+    type: 1000base-t
+  - name: gigabitethernet 0/0/14
+    type: 1000base-t
+  - name: gigabitethernet 0/0/15
+    type: 1000base-t
+  - name: gigabitethernet 0/0/16
+    type: 1000base-x-sfp
+  - name: gigabitethernet 0/0/17
+    type: 1000base-x-sfp
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14 
+    maximum_draw: 190
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console USB
+    type: usb-mini-b

--- a/device-types/Aruba/Aruba7205.yaml
+++ b/device-types/Aruba/Aruba7205.yaml
@@ -1,0 +1,30 @@
+manufacturer: Aruba
+model: Aruba7205
+slug: aruba7205
+is_full_depth: no
+u_height: 1
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: gigabitethernet 0/0/0
+    type: 1000base-t
+  - name: gigabitethernet 0/0/1
+    type: 1000base-t
+  - name: gigabitethernet 0/0/2
+    type: 1000base-t
+  - name: gigabitethernet 0/0/3
+    type: 1000base-t
+  - name: gigabitethernet 0/0/4
+    type: 10gbase-x-sfpp
+  - name: gigabitethernet 0/0/5
+    type: 10gbase-x-sfpp
+power-ports:
+  - name: PEM0
+    type: iec-60320-c14 
+    maximum_draw: 75
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console USB
+    type: usb-mini-b

--- a/device-types/HPE/ProCurve-2810-24G.yaml
+++ b/device-types/HPE/ProCurve-2810-24G.yaml
@@ -1,0 +1,62 @@
+manufacturer: HPE
+model: ProCurve 2810-24G
+slug:  2810-24g
+part_number: J9021A
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 48
+interfaces:
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t

--- a/device-types/HPE/ProCurve-2810-48G.yaml
+++ b/device-types/HPE/ProCurve-2810-48G.yaml
@@ -1,0 +1,110 @@
+manufacturer: HPE
+model: ProCurve 2810-48G
+slug:  2810-48g
+part_number: J9022A
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 92
+interfaces:
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t
+  - name: '25'
+    type: 1000base-t
+  - name: '26'
+    type: 1000base-t
+  - name: '27'
+    type: 1000base-t
+  - name: '28'
+    type: 1000base-t
+  - name: '29'
+    type: 1000base-t
+  - name: '30'
+    type: 1000base-t
+  - name: '31'
+    type: 1000base-t
+  - name: '32'
+    type: 1000base-t
+  - name: '33'
+    type: 1000base-t
+  - name: '34'
+    type: 1000base-t
+  - name: '35'
+    type: 1000base-t
+  - name: '36'
+    type: 1000base-t
+  - name: '37'
+    type: 1000base-t
+  - name: '38'
+    type: 1000base-t
+  - name: '39'
+    type: 1000base-t
+  - name: '40'
+    type: 1000base-t
+  - name: '41'
+    type: 1000base-t
+  - name: '42'
+    type: 1000base-t
+  - name: '43'
+    type: 1000base-t
+  - name: '44'
+    type: 1000base-t
+  - name: '45'
+    type: 1000base-t
+  - name: '46'
+    type: 1000base-t
+  - name: '47'
+    type: 1000base-t
+  - name: '48'
+    type: 1000base-t


### PR DESCRIPTION
Add some Aruba controllers and switches. Also added a couple legacy ProCurve HP switches.
- 2920-24G
- 2920-48G-PoE+
- 2920-48G
- 2930F-48G-4SFP+
- Aruba7005
- Aruba7010
- Aruba7205
- ProCurve 2810-24G
- ProCurve 2810-48G