### PR TITLE
Fix interface slots for ISR2921

### DIFF
--- a/device-types/Cisco/ISR2921.yaml
+++ b/device-types/Cisco/ISR2921.yaml
@@ -5,11 +5,11 @@ slug: isr2921
 u_height: 2
 is_full_depth: true
 interfaces:
-  - name: GigabitEthernet0/0/0
+  - name: GigabitEthernet0/0
     type: 1000base-t
-  - name: GigabitEthernet0/0/1
+  - name: GigabitEthernet0/1
     type: 1000base-t
-  - name: GigabitEthernet0/0/2
+  - name: GigabitEthernet0/2
     type: 1000base-t
 console-ports:
   - name: con 0


### PR DESCRIPTION
My ISR2921 interfaces don't have the subslot. Changing to just 0/0, 0/1, and 0/2.
```
#show inventory 
NAME: "CISCO2921/K9", DESCR: "CISCO2921/K9 chassis, Hw Serial#: redacted, Hw Revision: 1.0"
PID: CISCO2921/K9      , VID: V08 , SN: redacted
```
```
#show interfaces description 
Interface                      Status         Protocol Description
Em0/0                          admin down     down     
Gi0/0                          up             up       
Gi0/1                          up             up       
Gi0/2                          up             up       
```

