### PR TITLE
Change manufacturer for ULTRABLOK428

### DIFF
--- a/device-types/TrippLite/ULTRABLOK428.yaml
+++ b/device-types/TrippLite/ULTRABLOK428.yaml
@@ -1,4 +1,4 @@
-manufacturer: TrippLite
+manufacturer: Tripp-Lite
 model: ULTRABLOK428
 slug: ultrablok428
 u_height: 0


### PR DESCRIPTION
The manufacturer for ULTRABLOK428 was set to "TrippLite" while all other Tripp-Lite devices are spelled "Tripp-Lite" in their YAML files. For consistency, this change alters the spelling to match the other Tripp-Lite products.