### PR TITLE
Add additional Dell server products

### DIFF
--- a/device-types/Dell/PowerEdge_R620.yaml
+++ b/device-types/Dell/PowerEdge_R620.yaml
@@ -1,7 +1,7 @@
 manufacturer: Dell
-model: PowerEdge R720
-slug: dell_poweredge_r720
-u_height: 2
+model: PowerEdge R620
+slug: dell_poweredge_r620
+u_height: 1
 is_full_depth: true
 console-ports:
   - name: Serial
@@ -34,6 +34,6 @@ interfaces:
     type: 1000base-t
   - name: Gig-E 4
     type: 1000base-t
-  - name: IDRAC
+  - name: iDRAC
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Dell/PowerEdge_R630.yaml
+++ b/device-types/Dell/PowerEdge_R630.yaml
@@ -1,0 +1,39 @@
+manufacturer: Dell
+model: PowerEdge R630
+slug: dell_poweredge_r630
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: de-9
+  - name: USB
+    type: usb-a
+  - name: VGA
+    type: other
+console-server-ports:
+  - name: Front USB1
+    type: usb-a
+  - name: Front USB2
+    type: usb-a
+console-server-ports:
+  - name: Rear USB1
+    type: usb-a
+  - name: Rear USB2
+    type: usb-a
+power-ports:
+  - name: Power 1
+    type: iec-60320-c14
+  - name: Power 2
+    type: iec-60320-c14
+interfaces:
+  - name: Gig-E 1
+    type: 1000base-t
+  - name: Gig-E 2
+    type: 1000base-t
+  - name: Gig-E 3
+    type: 1000base-t
+  - name: Gig-E 4
+    type: 1000base-t
+  - name: iDRAC
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Dell/PowerEdge_R640.yaml
+++ b/device-types/Dell/PowerEdge_R640.yaml
@@ -1,0 +1,39 @@
+manufacturer: Dell
+model: PowerEdge R640
+slug: dell_poweredge_r640
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: de-9
+  - name: USB
+    type: usb-a
+  - name: VGA
+    type: other
+console-server-ports:
+  - name: Front USB1
+    type: usb-a
+  - name: Front USB2
+    type: usb-a
+console-server-ports:
+  - name: Rear USB1
+    type: usb-a
+  - name: Rear USB2
+    type: usb-a
+power-ports:
+  - name: Power 1
+    type: iec-60320-c14
+  - name: Power 2
+    type: iec-60320-c14
+interfaces:
+  - name: Gig-E 1
+    type: 1000base-t
+  - name: Gig-E 2
+    type: 1000base-t
+  - name: Gig-E 3
+    type: 1000base-t
+  - name: Gig-E 4
+    type: 1000base-t
+  - name: iDRAC
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Dell/PowerEdge_R720.yaml
+++ b/device-types/Dell/PowerEdge_R720.yaml
@@ -1,0 +1,39 @@
+manufacturer: Dell
+model: PowerEdge R720
+slug: dell_poweredge_r720
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: de-9
+  - name: USB
+    type: usb-a
+  - name: VGA
+    type: other
+console-server-ports:
+  - name: Front USB1
+    type: usb-a
+  - name: Front USB2
+    type: usb-a
+console-server-ports:
+  - name: Rear USB1
+    type: usb-a
+  - name: Rear USB2
+    type: usb-a
+power-ports:
+  - name: Power 1
+    type: iec-60320-c14
+  - name: Power 2
+    type: iec-60320-c14
+interfaces:
+  - name: Gig-E 1
+    type: 1000base-t
+  - name: Gig-E 2
+    type: 1000base-t
+  - name: Gig-E 3
+    type: 1000base-t
+  - name: Gig-E 4
+    type: 1000base-t
+  - name: iDRAC
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Dell/PowerEdge_R730.yaml
+++ b/device-types/Dell/PowerEdge_R730.yaml
@@ -1,0 +1,39 @@
+manufacturer: Dell
+model: PowerEdge R730
+slug: dell_poweredge_r730
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: de-9
+  - name: USB
+    type: usb-a
+  - name: VGA
+    type: other
+console-server-ports:
+  - name: Front USB1
+    type: usb-a
+  - name: Front USB2
+    type: usb-a
+console-server-ports:
+  - name: Rear USB1
+    type: usb-a
+  - name: Rear USB2
+    type: usb-a
+power-ports:
+  - name: Power 1
+    type: iec-60320-c14
+  - name: Power 2
+    type: iec-60320-c14
+interfaces:
+  - name: Gig-E 1
+    type: 1000base-t
+  - name: Gig-E 2
+    type: 1000base-t
+  - name: Gig-E 3
+    type: 1000base-t
+  - name: Gig-E 4
+    type: 1000base-t
+  - name: iDRAC
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Dell/PowerEdge_R740.yaml
+++ b/device-types/Dell/PowerEdge_R740.yaml
@@ -1,0 +1,39 @@
+manufacturer: Dell
+model: PowerEdge R740
+slug: dell_poweredge_r740
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: de-9
+  - name: USB
+    type: usb-a
+  - name: VGA
+    type: other
+console-server-ports:
+  - name: Front USB1
+    type: usb-a
+  - name: Front USB2
+    type: usb-a
+console-server-ports:
+  - name: Rear USB1
+    type: usb-a
+  - name: Rear USB2
+    type: usb-a
+power-ports:
+  - name: Power 1
+    type: iec-60320-c14
+  - name: Power 2
+    type: iec-60320-c14
+interfaces:
+  - name: Gig-E 1
+    type: 1000base-t
+  - name: Gig-E 2
+    type: 1000base-t
+  - name: Gig-E 3
+    type: 1000base-t
+  - name: Gig-E 4
+    type: 1000base-t
+  - name: iDRAC
+    type: 1000base-t
+    mgmt_only: true


### PR DESCRIPTION
Only the R720 was included in the existing community definitions. The additional servers are nearly identical.

While working on this, I made a few other alterations:
- Changed "IDRAC" to Dell's capitalization, "iDRAC"
- Changed filename from "R720" to "PowerEdge_R720" to include the entire product name in the filename.

As a note, Dell servers are a bit odd and don't have public part numbers that I could find, so there's no straightforward way to identify "R630 with 8 2.5" drives" that doesn't get needlessly wordy. This is almost never significant, except in the case of models like the R630 with 10 2.5" disks, which forgoes one of the front USB ports. I chose to use one YAML file for each model since there's no standard way to denote a LFF, SFF, etc variant for Dell servers. For users with one of the unusual configurations, they can delete a single USB port from the front after creating a device.