### PR TITLE
Add Microsoft StorSimple devices

### DIFF
--- a/device-types/Microsoft/StorSimple-8100.yaml
+++ b/device-types/Microsoft/StorSimple-8100.yaml
@@ -19,8 +19,12 @@ console-ports:
 power-ports:
   - name: Power 1
     type: iec-60320-c14
+    maximum_draw: 764
+    allocated_draw: 400
   - name: Power 2
     type: iec-60320-c14
+    maximum_draw: 764
+    allocated_draw: 400
 interfaces:
   - name: Controller 0 DATA 0
     type: 1000base-t

--- a/device-types/Microsoft/StorSimple-8100.yaml
+++ b/device-types/Microsoft/StorSimple-8100.yaml
@@ -1,0 +1,52 @@
+manufacturer: Microsoft
+model: StorSimple 8100
+slug: microsoft_storsimple_8100
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Controller 0 Serial
+    type: other
+  - name: Controller 1 Serial
+    type: other
+  - name: Controller 0 USB 0
+    type: usb-a
+  - name: Controller 0 USB 1
+    type: usb-a
+  - name: Controller 1 USB 0
+    type: usb-a
+  - name: Controller 1 USB 1
+    type: usb-a
+power-ports:
+  - name: Power 1
+    type: iec-60320-c14
+  - name: Power 2
+    type: iec-60320-c14
+interfaces:
+  - name: Controller 0 DATA 0
+    type: 1000base-t
+  - name: Controller 0 DATA 1
+    type: 1000base-t
+  - name: Controller 0 DATA 2
+    type: 10gbase-x-sfpp
+  - name: Controller 0 DATA 3
+    type: 10gbase-x-sfpp
+  - name: Controller 0 DATA 4
+    type: 1000base-t
+  - name: Controller 0 DATA 5
+    type: 1000base-t
+  - name: Controller 0 EBOD
+    type: other
+  - name: Controller 1 DATA 0
+    type: 1000base-t
+  - name: Controller 1 DATA 1
+    type: 1000base-t
+  - name: Controller 1 DATA 2
+    type: 10gbase-x-sfpp
+  - name: Controller 1 DATA 3
+    type: 10gbase-x-sfpp
+  - name: Controller 1 DATA 4
+    type: 1000base-t
+  - name: Controller 1 DATA 5
+    type: 1000base-t
+  - name: Controller 1 EBOD
+    type: other

--- a/device-types/Microsoft/StorSimple-8600-EBOD.yaml
+++ b/device-types/Microsoft/StorSimple-8600-EBOD.yaml
@@ -1,0 +1,28 @@
+manufacturer: Microsoft
+model: StorSimple 8600 EBOD Enclosure
+slug: microsoft_storsimple_8600_ebod
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Controller 0 Serial
+    type: other
+  - name: Controller 1 Serial
+    type: other
+power-ports:
+  - name: Power 1
+    type: iec-60320-c14
+  - name: Power 2
+    type: iec-60320-c14
+interfaces:
+  - name: Controller 0 SAS A
+    type: other
+  - name: Controller 0 SAS B
+    type: other
+  - name: Controller 0 SAS C
+    type: other
+  - name: Controller 1 SAS A
+    type: other
+  - name: Controller 1 SAS B
+    type: other
+  - name: Controller 1 SAS C
+    type: other

--- a/device-types/Microsoft/StorSimple-8600-EBOD.yaml
+++ b/device-types/Microsoft/StorSimple-8600-EBOD.yaml
@@ -11,8 +11,12 @@ console-ports:
 power-ports:
   - name: Power 1
     type: iec-60320-c14
+    maximum_draw: 580
+    allocated_draw: 400
   - name: Power 2
     type: iec-60320-c14
+    maximum_draw: 580
+    allocated_draw: 400
 interfaces:
   - name: Controller 0 SAS A
     type: other

--- a/device-types/Microsoft/StorSimple-8600.yaml
+++ b/device-types/Microsoft/StorSimple-8600.yaml
@@ -19,8 +19,12 @@ console-ports:
 power-ports:
   - name: Power 1
     type: iec-60320-c14
+    maximum_draw: 764
+    allocated_draw: 400
   - name: Power 2
     type: iec-60320-c14
+    maximum_draw: 764
+    allocated_draw: 400
 interfaces:
   - name: Controller 0 DATA 0
     type: 1000base-t

--- a/device-types/Microsoft/StorSimple-8600.yaml
+++ b/device-types/Microsoft/StorSimple-8600.yaml
@@ -1,0 +1,52 @@
+manufacturer: Microsoft
+model: StorSimple 8600
+slug: microsoft_storsimple_8600
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Controller 0 Serial
+    type: other
+  - name: Controller 1 Serial
+    type: other
+  - name: Controller 0 USB 0
+    type: usb-a
+  - name: Controller 0 USB 1
+    type: usb-a
+  - name: Controller 1 USB 0
+    type: usb-a
+  - name: Controller 1 USB 1
+    type: usb-a
+power-ports:
+  - name: Power 1
+    type: iec-60320-c14
+  - name: Power 2
+    type: iec-60320-c14
+interfaces:
+  - name: Controller 0 DATA 0
+    type: 1000base-t
+  - name: Controller 0 DATA 1
+    type: 1000base-t
+  - name: Controller 0 DATA 2
+    type: 10gbase-x-sfpp
+  - name: Controller 0 DATA 3
+    type: 10gbase-x-sfpp
+  - name: Controller 0 DATA 4
+    type: 1000base-t
+  - name: Controller 0 DATA 5
+    type: 1000base-t
+  - name: Controller 0 EBOD
+    type: other
+  - name: Controller 1 DATA 0
+    type: 1000base-t
+  - name: Controller 1 DATA 1
+    type: 1000base-t
+  - name: Controller 1 DATA 2
+    type: 10gbase-x-sfpp
+  - name: Controller 1 DATA 3
+    type: 10gbase-x-sfpp
+  - name: Controller 1 DATA 4
+    type: 1000base-t
+  - name: Controller 1 DATA 5
+    type: 1000base-t
+  - name: Controller 1 EBOD
+    type: other


### PR DESCRIPTION
Added the Microsoft StorSimple 8100/8600/8600 EBOD devices.

I had one conceptual struggle while building out the Device Types: The devices have a 10Gbps QSFP port. The trouble is two-fold:
1. Netbox only knows about 40Gbps QSFP, not 10Gbps.
2. Microsoft only supports SFP+ transceivers, and provides adapters in the box so you can use SFP+.

As a result, I entered the QSFP ports as "SFP+" since that corresponds with both the speed and support requirements of the StorSimple devices.