### PR TITLE
fix Cisco cdb devices

### DIFF
--- a/device-types/Cisco/cdb-8p.yaml
+++ b/device-types/Cisco/cdb-8p.yaml
@@ -4,6 +4,7 @@ slug: cdb-8p
 part_number: CDB-8P
 is_full_depth: false
 subdevice_role: child
+u_height: 0U
 interfaces:
   - name: FastEthernet1/0/1
     type: 100base-tx

--- a/device-types/Cisco/cdb-8p.yaml
+++ b/device-types/Cisco/cdb-8p.yaml
@@ -4,7 +4,7 @@ slug: cdb-8p
 part_number: CDB-8P
 is_full_depth: false
 subdevice_role: child
-u_height: 0U
+u_height: 0
 interfaces:
   - name: FastEthernet1/0/1
     type: 100base-tx

--- a/device-types/Cisco/cdb-8u.yaml
+++ b/device-types/Cisco/cdb-8u.yaml
@@ -3,6 +3,7 @@ model: Catalyst Digital Building Switch (UPoE)
 slug: cdb-8u
 part_number: CDB-8U
 is_full_depth: false
+u_height: 0
 subdevice_role: child
 interfaces:
   - name: FastEthernet1/0/1


### PR DESCRIPTION
This is a child device, so the height must be zero, otherwise the import will fail