### PR TITLE
Should Not Be a Parent, Removed Power Supplies & Console Ports

### DIFF
--- a/device-types/Juniper/MX480.yaml
+++ b/device-types/Juniper/MX480.yaml
@@ -3,28 +3,4 @@ model: MX480
 slug: mx480
 u_height: 8
 is_full_depth: true
-subdevice_role: parent
 comments: '[Juniper MX480 Data Sheet](https://www.juniper.net/us/en/products-services/routing/mx-series/mx480/)'
-console-ports:
-  - name: Console-RE0
-    type: rj-45
-  - name: Console-RE1
-    type: rj-45
-device-bays:
-  - name: RE0/SCB0
-  - name: RE1/SCB1
-  - name: Linecard0
-  - name: Linecard1
-  - name: Linecard2
-  - name: Linecard3
-  - name: Linecard4
-  - name: Linecard5
-power-ports:
-  - name: PSU0
-    type: iec-60320-c20
-  - name: PSU1
-    type: iec-60320-c20
-  - name: PSU2
-    type: iec-60320-c20
-  - name: PSU3
-    type: iec-60320-c20


### PR DESCRIPTION
Removed the power supplies as these are modular and have different power draws, ac/dc, etc.

Removed the console ports.  No guarantee that someone has two REs installed.

Based on the [NetBox documentation](https://netbox.readthedocs.io/en/stable/core-functionality/device-types/) networking gear with line cards should not be modeled as parent/child.

> This parent/child relationship is not suitable for modeling chassis-based devices, wherein child members share a common control plane. Instead, line cards and similarly non-autonomous hardware should be modeled as inventory items within a device, with any associated interfaces or other components assigned directly to the device.