### PR TITLE
Rename 93108TC to be more consistent with other systems

### DIFF
--- a/device-types/Cisco/N9K-C93108TC-FX.yaml
+++ b/device-types/Cisco/N9K-C93108TC-FX.yaml
@@ -1,5 +1,5 @@
 manufacturer: Cisco
-model: Nexus9000 C93108TC-FX Chassis
+model: Nexus 93108TC-FX
 slug: n9k-c93108tc-fx
 part_number: N9K-C93108TC-FX
 u_height: 1


### PR DESCRIPTION
This pull request renames the Nexus 93108TC-FX. It removes "Chassis" from the title since it isn't a chassis. Also, it removes the prefix of "Nexus9000" in favor of Nexus since 9000 is redundant since the model number is listed. Finally, it removes the C in front of the 93108 model number.