### PR TITLE
Remove duplicate console-server-ports key

### DIFF
--- a/device-types/Dell/PowerEdge_R620.yaml
+++ b/device-types/Dell/PowerEdge_R620.yaml
@@ -15,7 +15,6 @@ console-server-ports:
     type: usb-a
   - name: Front USB2
     type: usb-a
-console-server-ports:
   - name: Rear USB1
     type: usb-a
   - name: Rear USB2

--- a/device-types/Dell/PowerEdge_R630.yaml
+++ b/device-types/Dell/PowerEdge_R630.yaml
@@ -15,7 +15,6 @@ console-server-ports:
     type: usb-a
   - name: Front USB2
     type: usb-a
-console-server-ports:
   - name: Rear USB1
     type: usb-a
   - name: Rear USB2

--- a/device-types/Dell/PowerEdge_R640.yaml
+++ b/device-types/Dell/PowerEdge_R640.yaml
@@ -15,7 +15,6 @@ console-server-ports:
     type: usb-a
   - name: Front USB2
     type: usb-a
-console-server-ports:
   - name: Rear USB1
     type: usb-a
   - name: Rear USB2

--- a/device-types/Dell/PowerEdge_R720.yaml
+++ b/device-types/Dell/PowerEdge_R720.yaml
@@ -15,7 +15,6 @@ console-server-ports:
     type: usb-a
   - name: Front USB2
     type: usb-a
-console-server-ports:
   - name: Rear USB1
     type: usb-a
   - name: Rear USB2

--- a/device-types/Dell/PowerEdge_R730.yaml
+++ b/device-types/Dell/PowerEdge_R730.yaml
@@ -15,7 +15,6 @@ console-server-ports:
     type: usb-a
   - name: Front USB2
     type: usb-a
-console-server-ports:
   - name: Rear USB1
     type: usb-a
   - name: Rear USB2

--- a/device-types/Dell/PowerEdge_R740.yaml
+++ b/device-types/Dell/PowerEdge_R740.yaml
@@ -15,7 +15,6 @@ console-server-ports:
     type: usb-a
   - name: Front USB2
     type: usb-a
-console-server-ports:
   - name: Rear USB1
     type: usb-a
   - name: Rear USB2


### PR DESCRIPTION
The Dell PowerEdge definitions contain a duplicate `console-server-ports` key to separate front/rear ports. This results in only the rear ports being imported into NetBox.

Removing this duplicate key resolves the issue.