### PR TITLE
Device has 14 HRU not 11

### DIFF
--- a/device-types/Cisco/WS-C4510R+E.yaml
+++ b/device-types/Cisco/WS-C4510R+E.yaml
@@ -2,7 +2,7 @@ manufacturer: Cisco
 model: Catalyst C4510R+E
 slug: ws-c4510r_plus_e
 part_number: WS-C4510R+E
-u_height: 11
+u_height: 14
 is_full_depth: true
 subdevice_role: parent
 console-ports:


### PR DESCRIPTION
Device has more HRU. Source: https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-4500-series-switches/product_data_sheet0900aecd801792b1.html