### PR TITLE
Juniper: add EX2200-C-12P, EX2200-C-12T, SRX210HE2

### DIFF
--- a/device-types/Juniper/EX2200-C-12P.yaml
+++ b/device-types/Juniper/EX2200-C-12P.yaml
@@ -1,0 +1,45 @@
+manufacturer: Juniper
+model: EX2200-C-12P
+slug: ex2200-c-12p
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/0/4
+    type: 1000base-t
+  - name: ge-0/0/5
+    type: 1000base-t
+  - name: ge-0/0/6
+    type: 1000base-t
+  - name: ge-0/0/7
+    type: 1000base-t
+  - name: ge-0/0/8
+    type: 1000base-t
+  - name: ge-0/0/9
+    type: 1000base-t
+  - name: ge-0/0/10
+    type: 1000base-t
+  - name: ge-0/0/11
+    type: 1000base-t
+  - name: ge-0/1/0
+    type: 1000base-x-sfp
+  - name: ge-0/1/1
+    type: 1000base-x-sfp
+  - name: vme
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 170
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console (USB)
+    type: usb-mini-b
+

--- a/device-types/Juniper/EX2200-C-12T.yaml
+++ b/device-types/Juniper/EX2200-C-12T.yaml
@@ -1,0 +1,45 @@
+manufacturer: Juniper
+model: EX2200-C-12T
+slug: ex2200-c-12t
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/0/4
+    type: 1000base-t
+  - name: ge-0/0/5
+    type: 1000base-t
+  - name: ge-0/0/6
+    type: 1000base-t
+  - name: ge-0/0/7
+    type: 1000base-t
+  - name: ge-0/0/8
+    type: 1000base-t
+  - name: ge-0/0/9
+    type: 1000base-t
+  - name: ge-0/0/10
+    type: 1000base-t
+  - name: ge-0/0/11
+    type: 1000base-t
+  - name: ge-0/1/0
+    type: 1000base-x-sfp
+  - name: ge-0/1/1
+    type: 1000base-x-sfp
+  - name: vme
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 40
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console (USB)
+    type: usb-mini-b
+

--- a/device-types/Juniper/SRX210HE2.yaml
+++ b/device-types/Juniper/SRX210HE2.yaml
@@ -1,0 +1,27 @@
+manufacturer: Juniper
+model: SRX21HE2
+slug: srx210HE2
+is_full_depth: false
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: fe-0/0/2
+    type: 100base-tx
+  - name: fe-0/0/3
+    type: 100base-tx
+  - name: fe-0/0/4
+    type: 100base-tx
+  - name: fe-0/0/5
+    type: 100base-tx
+  - name: fe-0/0/6
+    type: 100base-tx
+  - name: fe-0/0/7
+    type: 100base-tx
+power-ports:
+  - name: PSU0
+    type: ita-g
+console-ports:
+  - name: Console
+    type: rj-45


### PR DESCRIPTION
Adding a couple devices I have at home

* EX2200-C-12P
* EX2200-C-12T
* SRX210HE2

For the SRX210HE2, I was a little unsure what to put for the power type, as it has an external 12v power supply, but in `show chassis hardware` you have Power Supply 0