### PR TITLE
Add MikroTik RB750Gr3

### DIFF
--- a/device-types/MikroTik/RB750Gr3.yaml
+++ b/device-types/MikroTik/RB750Gr3.yaml
@@ -1,0 +1,15 @@
+---
+manufacturer: MikroTik
+model: RB750Gr3
+slug: rb750Gr3
+interfaces:
+  - name: ether1
+    type: 1000base-t
+  - name: ether2
+    type: 1000base-t
+  - name: ether3
+    type: 1000base-t
+  - name: ether4
+    type: 1000base-t
+  - name: ether5
+    type: 1000base-t


### PR DESCRIPTION
This PR adds MikroTik RB750Gr3. Product page https://mikrotik.com/product/RB750Gr3. Technically this model is identical to already present RB750r3, but RB750r3 seems to be discontinued for I was even unable to find it's product page.