### PR TITLE
Add Brocade ICX7150-C12P

### DIFF
--- a/device-types/Brocade/icx7150-c12.yaml
+++ b/device-types/Brocade/icx7150-c12.yaml
@@ -1,0 +1,50 @@
+---
+manufacturer: Brocade
+model: ICX 7150-C12P
+slug: icx7150-c12p
+part_number: ICX7150-C12P
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: oob-mgmt1
+    type: 1000base-t
+    mgmt_only: true
+  - name: ge-1/1/1
+    type: 1000base-t
+  - name: ge-1/1/2
+    type: 1000base-t
+  - name: ge-1/1/3
+    type: 1000base-t
+  - name: ge-1/1/4
+    type: 1000base-t
+  - name: ge-1/1/5
+    type: 1000base-t
+  - name: ge-1/1/6
+    type: 1000base-t
+  - name: ge-1/1/7
+    type: 1000base-t
+  - name: ge-1/1/8
+    type: 1000base-t
+  - name: ge-1/1/9
+    type: 1000base-t
+  - name: ge-1/1/10
+    type: 1000base-t
+  - name: ge-1/1/11
+    type: 1000base-t
+  - name: ge-1/1/12
+    type: 1000base-t
+  - name: ge-1/2/1
+    type: 1000base-t
+  - name: ge-1/2/2
+    type: 1000base-t
+  - name: xg-1/3/1
+    type: 10gbase-x-sfpp
+  - name: xg-1/3/2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: con0
+    type: usb-mini-b
+power-ports:
+  - name: psu0
+    type: iec-60320-c14
+    maximum_draw: 150


### PR DESCRIPTION
Using the naming convention built into Netbox (`ge-`, `xe-`, etc), which happens to match Cisco's.  I haven't ever seen "GigabitEthernet1/2" on any Brocade/Ruckus equipment.

Also, previous Brocade switches were named 1/1, 1/2, 1/3.  All switches I've seen in 6450, 6610, 7150, 7250, and 7450 all use the 1/1/1, 1/1/2 convention.  So, I'm using that here as well (which further matches Netbox's suggestions in the UI).

---

This switch has 12x 1-Gbps PoE+ ports, 2x 1-Gbps Uplink ports (assignable), and 2x 10-Gbps Upline SPF+ ports, along with an 1-Gbps management port and 1 console port.