### PR TITLE
Add Tripplite SMART1500LCD UPS

### DIFF
--- a/device-types/TrippLite/SMART1500LCD.yaml
+++ b/device-types/TrippLite/SMART1500LCD.yaml
@@ -7,7 +7,7 @@ comments: |
 
   Dimensions: 438 x 89 x 267 mm (17.25" x 3.5" x 10.5") Weight: 13.6 kg
 u_height: 2
-is_full_depth: true
+is_full_depth: false
 console-ports:
   - name: RS232
     type: de-9

--- a/device-types/TrippLite/SMART1500LCD.yaml
+++ b/device-types/TrippLite/SMART1500LCD.yaml
@@ -1,0 +1,36 @@
+---
+manufacturer: Tripp-Lite
+model: SMART1500LCD
+slug: smart1500lcd
+comments: |
+  Battery-backed power supply feeding 8 Nema-5-15R receptables
+
+  Dimensions: 438 x 89 x 267 mm (17.25" x 3.5" x 10.5") Weight: 13.6 kg
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: RS232
+    type: de-9
+  - name: USB
+    type: usb-b
+power-ports:
+  - name: Primary
+    type: nema-5-15p
+    maximum_draw: 1000
+power-outlets:
+  - name: '1'
+    type: nema-5-15r
+  - name: '2'
+    type: nema-5-15r
+  - name: '3'
+    type: nema-5-15r
+  - name: '4'
+    type: nema-5-15r
+  - name: '5'
+    type: nema-5-15r
+  - name: '6'
+    type: nema-5-15r
+  - name: '7'
+    type: nema-5-15r
+  - name: '8'
+    type: nema-5-15r


### PR DESCRIPTION
Add Tripplite SMART1500LCD UPS with info from [manufacturer info page](https://www.tripplite.com/smartpro-lcd-120v-1500va-900w-line-interactive-ups-avr-2u-rack-tower-lcd-usb-db9-serial-8-outlets~SMART1500LCD) and [datasheet](https://assets.tripplite.com/product-pdfs/en/smart1500lcd.pdf)