### PR TITLE
Add two Ubiquiti access points

### DIFF
--- a/device-types/Ubiquiti/U6-LR.yaml
+++ b/device-types/Ubiquiti/U6-LR.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Ubiquiti
+model: U6-LR
+slug: u6-lr
+u_height: 0
+is_full_depth: false
+comments: '[UniFi 6 Long Range Access Point](https://store.ui.com/products/unifi-6-long-range-access-point)'
+interfaces:
+  - name: lan0
+    type: 1000base-t
+    mgmt_only: false

--- a/device-types/Ubiquiti/UAP-FlexHD.yaml
+++ b/device-types/Ubiquiti/UAP-FlexHD.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Ubiquiti
+model: UAP-FlexHD
+slug: uap-flexhd
+u_height: 0
+is_full_depth: false
+comments: '[UniFi FlexHD Access Point](https://store.ui.com/products/unifi-flexhd)'
+interfaces:
+  - name: lan0
+    type: 1000base-t
+    mgmt_only: false


### PR DESCRIPTION
Adds the U6-LR and UAP-FlexHD access point definitions.  Based on info from UI.com web site and the existing U6-Lite definition as a template.