### PR TITLE
Create WS-C4948-10G-S.yaml

### DIFF
--- a/device-types/Cisco/WS-C4948-10G-S.yaml
+++ b/device-types/Cisco/WS-C4948-10G-S.yaml
@@ -1,0 +1,119 @@
+---
+manufacturer: Cisco
+model: Catalyst 4948-10GE
+slug: ws-c4948-10ge-s
+part_number: WS-C4948-10GE-S
+is_full_depth: false
+u_height: 1
+interfaces:
+  - name: FastEthernet1
+    type: 100base-tx
+    mgmt_only: true
+  - name: GigabitEthernet1/1
+    type: 1000base-t
+  - name: GigabitEthernet1/2
+    type: 1000base-t
+  - name: GigabitEthernet1/3
+    type: 1000base-t
+  - name: GigabitEthernet1/4
+    type: 1000base-t
+  - name: GigabitEthernet1/5
+    type: 1000base-t
+  - name: GigabitEthernet1/6
+    type: 1000base-t
+  - name: GigabitEthernet1/7
+    type: 1000base-t
+  - name: GigabitEthernet1/8
+    type: 1000base-t
+  - name: GigabitEthernet1/9
+    type: 1000base-t
+  - name: GigabitEthernet1/10
+    type: 1000base-t
+  - name: GigabitEthernet1/11
+    type: 1000base-t
+  - name: GigabitEthernet1/12
+    type: 1000base-t
+  - name: GigabitEthernet1/13
+    type: 1000base-t
+  - name: GigabitEthernet1/14
+    type: 1000base-t
+  - name: GigabitEthernet1/15
+    type: 1000base-t
+  - name: GigabitEthernet1/16
+    type: 1000base-t
+  - name: GigabitEthernet1/17
+    type: 1000base-t
+  - name: GigabitEthernet1/18
+    type: 1000base-t
+  - name: GigabitEthernet1/19
+    type: 1000base-t
+  - name: GigabitEthernet1/20
+    type: 1000base-t
+  - name: GigabitEthernet1/21
+    type: 1000base-t
+  - name: GigabitEthernet1/22
+    type: 1000base-t
+  - name: GigabitEthernet1/23
+    type: 1000base-t
+  - name: GigabitEthernet1/24
+    type: 1000base-t
+  - name: GigabitEthernet1/25
+    type: 1000base-t
+  - name: GigabitEthernet1/26
+    type: 1000base-t
+  - name: GigabitEthernet1/27
+    type: 1000base-t
+  - name: GigabitEthernet1/28
+    type: 1000base-t
+  - name: GigabitEthernet1/29
+    type: 1000base-t
+  - name: GigabitEthernet1/30
+    type: 1000base-t
+  - name: GigabitEthernet1/31
+    type: 1000base-t
+  - name: GigabitEthernet1/32
+    type: 1000base-t
+  - name: GigabitEthernet1/33
+    type: 1000base-t
+  - name: GigabitEthernet1/34
+    type: 1000base-t
+  - name: GigabitEthernet1/35
+    type: 1000base-t
+  - name: GigabitEthernet1/36
+    type: 1000base-t
+  - name: GigabitEthernet1/37
+    type: 1000base-t
+  - name: GigabitEthernet1/38
+    type: 1000base-t
+  - name: GigabitEthernet1/39
+    type: 1000base-t
+  - name: GigabitEthernet1/40
+    type: 1000base-t
+  - name: GigabitEthernet1/41
+    type: 1000base-t
+  - name: GigabitEthernet1/42
+    type: 1000base-t
+  - name: GigabitEthernet1/43
+    type: 1000base-t
+  - name: GigabitEthernet1/44
+    type: 1000base-t
+  - name: GigabitEthernet1/45
+    type: 1000base-t
+  - name: GigabitEthernet1/46
+    type: 1000base-t
+  - name: GigabitEthernet1/47
+    type: 1000base-t
+  - name: GigabitEthernet1/48
+    type: 1000base-t
+  - name: TenGigabitEthernet1/49
+    type: 10gbase-x-x2
+  - name: TenGigabitEthernet1/50
+    type: 10gbase-x-x2
+console-ports:
+  - name: con0
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+  - name: PSU1
+    type: iec-60320-c14


### PR DESCRIPTION
Adds the Cisco Catalyst 4948-10GE 48 Port Switch

This switch is basically identical to the newer C4948 variant, but has the older X2 interfaces.