### PR TITLE
Add Aruba 2530, 2920 family switches

### DIFF
--- a/device-types/Aruba/2530-24G.yaml
+++ b/device-types/Aruba/2530-24G.yaml
@@ -1,0 +1,99 @@
+---
+manufacturer: Aruba
+model: 2530-24G Switch
+slug: 2530-24g
+part_number: J9782A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 15
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: '1'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '2'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '3'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '4'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '5'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '6'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '7'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '8'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '9'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '10'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '11'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '12'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '13'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '14'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '15'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '16'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '17'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '18'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '19'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '20'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '21'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '22'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '23'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '24'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '25'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '26'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '27'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '28'
+    type: 1000base-x-sfp
+    mgmt_only: false

--- a/device-types/Aruba/2530-48G.yaml
+++ b/device-types/Aruba/2530-48G.yaml
@@ -1,0 +1,171 @@
+---
+manufacturer: Aruba
+model: 2530-48G Switch
+slug: 2530-48g
+part_number: J9781A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 30
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: '1'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '2'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '3'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '4'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '5'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '6'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '7'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '8'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '9'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '10'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '11'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '12'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '13'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '14'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '15'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '16'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '17'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '18'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '19'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '20'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '21'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '22'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '23'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '24'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '25'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '26'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '27'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '28'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '29'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '30'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '31'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '32'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '33'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '34'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '35'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '36'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '37'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '38'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '39'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '40'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '41'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '42'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '43'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '44'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '45'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '46'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '47'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '48'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '49'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '50'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '51'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '52'
+    type: 1000base-x-sfp
+    mgmt_only: false

--- a/device-types/Aruba/2530-8G.yaml
+++ b/device-types/Aruba/2530-8G.yaml
@@ -1,0 +1,51 @@
+---
+manufacturer: Aruba
+model: 2530-8G Switch
+slug: 2530-8g
+part_number: J9783A
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 8
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: '1'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '2'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '3'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '4'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '5'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '6'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '7'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '8'
+    type: 1000base-t
+    mgmt_only: false
+  - name: 9-RJ45
+    type: 1000base-t
+    mgmt_only: false
+  - name: 10-RJ45
+    type: 1000base-t
+    mgmt_only: false
+  - name: 9-SFP
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: 10-SFP
+    type: 1000base-x-sfp
+    mgmt_only: false

--- a/device-types/Aruba/2920-24G-PoEP.yml
+++ b/device-types/Aruba/2920-24G-PoEP.yml
@@ -1,0 +1,69 @@
+---
+manufacturer: Aruba
+model: 2920-24G-PoEP
+slug: 2920-24g-poep
+part_number: 9727AJ
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 475
+    allocated_draw: 42
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: USB Console
+    type: usb-micro-b
+interfaces:
+  - name: Management
+    type: 1000base-t
+    mgmt_only: true
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t


### PR DESCRIPTION
This PR adds non-PoE models from Aruba 2530 family and Aruba 2920-24G-PoEP.