### PR TITLE
Add Juniper SRX650

### DIFF
--- a/device-types/Juniper/SRX650.yaml
+++ b/device-types/Juniper/SRX650.yaml
@@ -1,0 +1,48 @@
+---
+manufacturer: Juniper
+model: SRX650
+slug: srx650
+part_number: ''
+u_height: 2
+is_full_depth: false
+subdevice_role: parent
+comments: '[Juniper SRX650 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/security/srx-series-services-gateways-branch-datasheet.pdf)'
+console-ports:
+- name: Console
+  type: rj-45
+  label: ''
+  description: ''
+power-ports:
+- name: PSU0
+  type: iec-60320-c14
+  maximum_draw: null
+  allocated_draw: null
+  label: ''
+  description: ''
+- name: PSU1
+  type: iec-60320-c14
+  maximum_draw: null
+  allocated_draw: null
+  label: ''
+  description: ''
+interfaces:
+- name: ge-0/0/0
+  type: 1000base-t
+  mgmt_only: false
+  label: ''
+  description: ''
+- name: ge-0/0/1
+  type: 1000base-t
+  mgmt_only: false
+  label: ''
+  description: ''
+- name: ge-0/0/2
+  type: 1000base-t
+  mgmt_only: false
+  label: ''
+  description: ''
+- name: ge-0/0/3
+  type: 1000base-t
+  mgmt_only: false
+  label: ''
+  description: ''


### PR DESCRIPTION
This would add the Juniper SRX650.
This is the default config with no extras such as the 2x10G and 16x1G switch XPIMs