### PR TITLE
Update QFX5200-32C.yaml

### DIFF
--- a/device-types/Juniper/QFX5200-32C.yaml
+++ b/device-types/Juniper/QFX5200-32C.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Juniper
-model: QFX5120-32C
-slug: qfx5120-32c
+model: QFX5200-32C
+slug: qfx5200-32c
 interfaces:
   - name: fxp0
     type: 1000base-t


### PR DESCRIPTION
The slug and device name still referenced the QFX5120, where is was copied from.