### PR TITLE
Add default SVI to RA Stratix 5700 Switches

### DIFF
--- a/device-types/Rockwell Automation/1783-BMS06SA.yaml
+++ b/device-types/Rockwell Automation/1783-BMS06SA.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/6
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS06SGA.yaml
+++ b/device-types/Rockwell Automation/1783-BMS06SGA.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/4
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS06SGL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS06SGL.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/4
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS06SL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS06SL.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/6
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS06TA.yaml
+++ b/device-types/Rockwell Automation/1783-BMS06TA.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/6
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS06TGA.yaml
+++ b/device-types/Rockwell Automation/1783-BMS06TGA.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/4
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS06TGL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS06TGL.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/4
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS06TL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS06TL.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/6
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS10CA.yaml
+++ b/device-types/Rockwell Automation/1783-BMS10CA.yaml
@@ -26,6 +26,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/10
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS10CGA.yaml
+++ b/device-types/Rockwell Automation/1783-BMS10CGA.yaml
@@ -26,6 +26,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/8
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS10CGL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS10CGL.yaml
@@ -26,6 +26,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/8
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS10CGN.yaml
+++ b/device-types/Rockwell Automation/1783-BMS10CGN.yaml
@@ -26,6 +26,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/8
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS10CGP.yaml
+++ b/device-types/Rockwell Automation/1783-BMS10CGP.yaml
@@ -26,6 +26,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/8
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS10CL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS10CL.yaml
@@ -26,6 +26,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/10
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS20CA.yaml
+++ b/device-types/Rockwell Automation/1783-BMS20CA.yaml
@@ -46,6 +46,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/20
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS20CGL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS20CGL.yaml
@@ -46,6 +46,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/18
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS20CGN.yaml
+++ b/device-types/Rockwell Automation/1783-BMS20CGN.yaml
@@ -46,6 +46,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/18
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS20CGP.yaml
+++ b/device-types/Rockwell Automation/1783-BMS20CGP.yaml
@@ -46,6 +46,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/18
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS20CGPK.yaml
+++ b/device-types/Rockwell Automation/1783-BMS20CGPK.yaml
@@ -46,6 +46,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/18
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS20CL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS20CL.yaml
@@ -46,6 +46,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/20
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS4S2SGA.yaml
+++ b/device-types/Rockwell Automation/1783-BMS4S2SGA.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/4
     type: 100base-tx
+  - name: SVI1
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b

--- a/device-types/Rockwell Automation/1783-BMS4S2SGL.yaml
+++ b/device-types/Rockwell Automation/1783-BMS4S2SGL.yaml
@@ -18,6 +18,8 @@ interfaces:
     type: 100base-tx
   - name: FastEthernet1/4
     type: 100base-tx
+  - name: VLAN0
+    type: virtual
 console-ports:
   - name: usb
     type: usb-mini-b


### PR DESCRIPTION
This PR adds the default software virtual interface for all variants of the stratix 5700 switches.