### PR TITLE
Add Rockwell Automation ControlLogix and CompactLogix PLCs

### DIFF
--- a/device-types/Rockwell Automation/1756-A10.yaml
+++ b/device-types/Rockwell Automation/1756-A10.yaml
@@ -1,0 +1,20 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack - 10 Slot
+part_number: 1756-A10
+slug: 1756-a10
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6
+  - name: Slot 7
+  - name: Slot 8
+  - name: Slot 9

--- a/device-types/Rockwell Automation/1756-A10K.yaml
+++ b/device-types/Rockwell Automation/1756-A10K.yaml
@@ -1,0 +1,20 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack K - 10 Slot
+part_number: 1756-A10K
+slug: 1756-a10k
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6
+  - name: Slot 7
+  - name: Slot 8
+  - name: Slot 9

--- a/device-types/Rockwell Automation/1756-A10XT.yaml
+++ b/device-types/Rockwell Automation/1756-A10XT.yaml
@@ -1,0 +1,20 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack XT - 10 Slot
+part_number: 1756-A10XT
+slug: 1756-a10xt
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6
+  - name: Slot 7
+  - name: Slot 8
+  - name: Slot 9

--- a/device-types/Rockwell Automation/1756-A13.yaml
+++ b/device-types/Rockwell Automation/1756-A13.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack - 13 Slot
+part_number: 1756-A13
+slug: 1756-a13
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6
+  - name: Slot 7
+  - name: Slot 8
+  - name: Slot 9
+  - name: Slot 10
+  - name: Slot 11
+  - name: Slot 12

--- a/device-types/Rockwell Automation/1756-A13K.yaml
+++ b/device-types/Rockwell Automation/1756-A13K.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack K - 13 Slot
+part_number: 1756-A13K
+slug: 1756-a13k
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6
+  - name: Slot 7
+  - name: Slot 8
+  - name: Slot 9
+  - name: Slot 10
+  - name: Slot 11
+  - name: Slot 12

--- a/device-types/Rockwell Automation/1756-A17.yaml
+++ b/device-types/Rockwell Automation/1756-A17.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack - 17 Slot
+part_number: 1756-A17
+slug: 1756-a17
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6
+  - name: Slot 7
+  - name: Slot 8
+  - name: Slot 9
+  - name: Slot 10
+  - name: Slot 11
+  - name: Slot 12
+  - name: Slot 13
+  - name: Slot 14
+  - name: Slot 15
+  - name: Slot 16

--- a/device-types/Rockwell Automation/1756-A17K.yaml
+++ b/device-types/Rockwell Automation/1756-A17K.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack K - 17 Slot
+part_number: 1756-A17K
+slug: 1756-a17k
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6
+  - name: Slot 7
+  - name: Slot 8
+  - name: Slot 9
+  - name: Slot 10
+  - name: Slot 11
+  - name: Slot 12
+  - name: Slot 13
+  - name: Slot 14
+  - name: Slot 15
+  - name: Slot 16

--- a/device-types/Rockwell Automation/1756-A4.yaml
+++ b/device-types/Rockwell Automation/1756-A4.yaml
@@ -1,0 +1,14 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack - 4 Slot
+part_number: 1756-a4
+slug: 1756-A4
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3

--- a/device-types/Rockwell Automation/1756-A4K.yaml
+++ b/device-types/Rockwell Automation/1756-A4K.yaml
@@ -1,0 +1,14 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack K - 4 Slot
+part_number: 1756-A4K
+slug: 1756-a4k
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3

--- a/device-types/Rockwell Automation/1756-A7.yaml
+++ b/device-types/Rockwell Automation/1756-A7.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack - 7 Slot
+part_number: 1756-A7
+slug: 1756-a7
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6

--- a/device-types/Rockwell Automation/1756-A7K.yaml
+++ b/device-types/Rockwell Automation/1756-A7K.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack K - 7 Slot
+part_number: 1756-a7k
+slug: 1756-A7K
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6

--- a/device-types/Rockwell Automation/1756-A7XT.yaml
+++ b/device-types/Rockwell Automation/1756-A7XT.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Rack XT - 7 Slot
+part_number: 1756-A7XT
+slug: 1756-a7xt
+u_height: 3
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: Power Supply
+  - name: Slot 0
+  - name: Slot 1
+  - name: Slot 2
+  - name: Slot 3
+  - name: Slot 4
+  - name: Slot 5
+  - name: Slot 6

--- a/device-types/Rockwell Automation/1756-CMS1B1.yaml
+++ b/device-types/Rockwell Automation/1756-CMS1B1.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Compute - Windows
+part_number: 1756-CMS1B1
+slug: 1756-cms1b1
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-CMS1C1.yaml
+++ b/device-types/Rockwell Automation/1756-CMS1C1.yaml
@@ -2,7 +2,7 @@
 manufacturer: Rockwell Automation
 model: ControlLogix Compute - Linux
 part_number: 1756-CMS1C1
-slug: 1756-cms1b1
+slug: 1756-cms1c1
 u_height: 3
 is_full_depth: false
 subdevice_role: child

--- a/device-types/Rockwell Automation/1756-CMS1C1.yaml
+++ b/device-types/Rockwell Automation/1756-CMS1C1.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Compute - Linux
+part_number: 1756-CMS1C1
+slug: 1756-cms1b1
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-EN2F.yaml
+++ b/device-types/Rockwell Automation/1756-EN2F.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Fiber Ethernet Adapter (EN2F)
+part_number: 1756-EN2F
+slug: 1756-en2f
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN2FK.yaml
+++ b/device-types/Rockwell Automation/1756-EN2FK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Fiber Ethernet Adapter K (EN2FK)
+part_number: 1756-EN2FK
+slug: 1756-en2fk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN2T.yaml
+++ b/device-types/Rockwell Automation/1756-EN2T.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter (EN2T)
+part_number: 1756-EN2T
+slug: 1756-en2t
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN2TK.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter K (EN2TK)
+part_number: 1756-EN2TK
+slug: 1756-en2tk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN2TP.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TP.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet PRP Adapter (EN2TP)
+part_number: 1756-EN2TP
+slug: 1756-en2tp
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx
+  - name: A2
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN2TPK.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TPK.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet PRP Adapter K (EN2TP)
+part_number: 1756-EN2TPK
+slug: 1756-en2tpk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx
+  - name: A2
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN2TR.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TR.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter (EN2TR)
+part_number: 1756-EN2TR
+slug: 1756-en2tr
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx
+  - name: A2
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN2TRK.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TRK.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter K (EN2TR)
+part_number: 1756-EN2TRK
+slug: 1756-en2trk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx
+  - name: A2
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN3TR.yaml
+++ b/device-types/Rockwell Automation/1756-EN3TR.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter (EN3TR)
+part_number: 1756-EN3TR
+slug: 1756-en3tr
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx
+  - name: A2
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN3TRK.yaml
+++ b/device-types/Rockwell Automation/1756-EN3TRK.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter K (EN3TR)
+part_number: 1756-EN3TRK
+slug: 1756-en3trk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx
+  - name: A2
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EN4TR.yaml
+++ b/device-types/Rockwell Automation/1756-EN4TR.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter (EN4TR)
+part_number: 1756-EN4TR
+slug: 1756-en4tr
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-EN4TRK.yaml
+++ b/device-types/Rockwell Automation/1756-EN4TRK.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter K (EN4TR)
+part_number: 1756-EN4TRK
+slug: 1756-en4trk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-ENBT.yaml
+++ b/device-types/Rockwell Automation/1756-ENBT.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter (ENBT)
+part_number: 1756-ENBT
+slug: 1756-enbt
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-ENBTK.yaml
+++ b/device-types/Rockwell Automation/1756-ENBTK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Ethernet Adapter K (ENBT)
+part_number: 1756-ENBTK
+slug: 1756-enbtk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-EWEB.yaml
+++ b/device-types/Rockwell Automation/1756-EWEB.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix Web Module (EWEB)
+part_number: 1756-EWEB
+slug: 1756-enweb
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 100base-tx

--- a/device-types/Rockwell Automation/1756-L81E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L81E-NSE.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L81E-NSE
+part_number: 1756-L81E-NSE
+slug: 1756-l81e-nse
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L81E.yaml
+++ b/device-types/Rockwell Automation/1756-L81E.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L81E
+part_number: 1756-L81E
+slug: 1756-l81e
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L81EK.yaml
+++ b/device-types/Rockwell Automation/1756-L81EK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L81EK
+part_number: 1756-L81EK
+slug: 1756-l81ek
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L81EP.yaml
+++ b/device-types/Rockwell Automation/1756-L81EP.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L81EP
+part_number: 1756-L81EP
+slug: 1756-l81ep
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L81ES.yaml
+++ b/device-types/Rockwell Automation/1756-L81ES.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: GuardLogix 5580 L81ES
+part_number: 1756-L81ES
+slug: 1756-l81es
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L81ESK.yaml
+++ b/device-types/Rockwell Automation/1756-L81ESK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: GuardLogix 5580 L81ESK
+part_number: 1756-L81ESK
+slug: 1756-l81esk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L82E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L82E-NSE.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L82E-NSE
+part_number: 1756-L82E-NSE
+slug: 1756-l82e-nse
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L82E.yaml
+++ b/device-types/Rockwell Automation/1756-L82E.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L82E
+part_number: 1756-L82E
+slug: 1756-l82e
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L82EK.yaml
+++ b/device-types/Rockwell Automation/1756-L82EK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L82EK
+part_number: 1756-L82EK
+slug: 1756-l82ek
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L82ES.yaml
+++ b/device-types/Rockwell Automation/1756-L82ES.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: GuardLogix 5580 L82ES
+part_number: 1756-L82ES
+slug: 1756-l82es
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L82ESK.yaml
+++ b/device-types/Rockwell Automation/1756-L82ESK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: GuardLogix 5580 L82ESK
+part_number: 1756-L82ESK
+slug: 1756-l82esk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L83E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L83E-NSE.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L83E-NSE
+part_number: 1756-L83E-NSE
+slug: 1756-l83e-nse
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L83E.yaml
+++ b/device-types/Rockwell Automation/1756-L83E.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L83E
+part_number: 1756-L83E
+slug: 1756-l83e
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L83EK.yaml
+++ b/device-types/Rockwell Automation/1756-L83EK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L83EK
+part_number: 1756-L83EK
+slug: 1756-l83ek
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L83EP.yaml
+++ b/device-types/Rockwell Automation/1756-L83EP.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L83EP
+part_number: 1756-L83EP
+slug: 1756-l83ep
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L83ES.yaml
+++ b/device-types/Rockwell Automation/1756-L83ES.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: GuardLogix 5580 L83ES
+part_number: 1756-L83ES
+slug: 1756-l83es
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L83ESK.yaml
+++ b/device-types/Rockwell Automation/1756-L83ESK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: GuardLogix 5580 L83ESK
+part_number: 1756-L83ESK
+slug: 1756-l83esk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L84E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L84E-NSE.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L84E-NSE
+part_number: 1756-L84E-NSE
+slug: 1756-l84e-nse
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L84E.yaml
+++ b/device-types/Rockwell Automation/1756-L84E.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L84E
+part_number: 1756-L84E
+slug: 1756-l84e
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L84EK.yaml
+++ b/device-types/Rockwell Automation/1756-L84EK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L84EK
+part_number: 1756-L84EK
+slug: 1756-l84ek
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L84ES.yaml
+++ b/device-types/Rockwell Automation/1756-L84ES.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: GuardLogix 5580 L84ES
+part_number: 1756-L84ES
+slug: 1756-l84es
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L84ESK.yaml
+++ b/device-types/Rockwell Automation/1756-L84ESK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: GuardLogix 5580 L84ESK
+part_number: 1756-L84ESK
+slug: 1756-l84esk
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L85E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L85E-NSE.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L85E-NSE
+part_number: 1756-L85E-NSE
+slug: 1756-l85e-nse
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L85E.yaml
+++ b/device-types/Rockwell Automation/1756-L85E.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L85E
+part_number: 1756-L85E
+slug: 1756-l85e
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L85EK.yaml
+++ b/device-types/Rockwell Automation/1756-L85EK.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L85EK
+part_number: 1756-L85EK
+slug: 1756-l85ek
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/1756-L85EP.yaml
+++ b/device-types/Rockwell Automation/1756-L85EP.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Rockwell Automation
+model: ControlLogix 5580 L85EP
+part_number: 1756-L85EP
+slug: 1756-l85ep
+u_height: 3
+is_full_depth: false
+subdevice_role: child
+interfaces:
+  - name: A1
+    type: 1000base-t

--- a/device-types/Rockwell Automation/5069-AEN2TR.yaml
+++ b/device-types/Rockwell Automation/5069-AEN2TR.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: Compact 5000 I/O Ethernet Adapter (AEN2TR)
+part_number: 5069-AEN2TR
+slug: 5069-aen2tr
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-AENTR.yaml
+++ b/device-types/Rockwell Automation/5069-AENTR.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: Compact 5000 I/O Ethernet Adapter (AENTR)
+part_number: 5069-AENTR
+slug: 5069-aentr
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-AENTRK.yaml
+++ b/device-types/Rockwell Automation/5069-AENTRK.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: Compact 5000 I/O Ethernet Adapter (AENTRK)
+part_number: 5069-AENTRK
+slug: 5069-aentrk
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L306ER.yaml
+++ b/device-types/Rockwell Automation/5069-L306ER.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L306ER
+part_number: 5069-L306ER
+slug: 5069-l306er
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L306ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L306ERM.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L306ERM
+part_number: 5069-L306ERM
+slug: 5069-l306erm
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L306ERMS2.yaml
+++ b/device-types/Rockwell Automation/5069-L306ERMS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L306ERMS2
+part_number: 5069-L306ERMS2
+slug: 5069-l306erms2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L306ERMS3.yaml
+++ b/device-types/Rockwell Automation/5069-L306ERMS3.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L306ERMS3
+part_number: 5069-L306ERMS3
+slug: 5069-l306erms3
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L306ERS2.yaml
+++ b/device-types/Rockwell Automation/5069-L306ERS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L306ERS2
+part_number: 5069-L306ERS2
+slug: 5069-l306ers2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L3100ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L3100ERM.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L3100ERM
+part_number: 5069-L3100ERM
+slug: 5069-l3100erm
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L3100ERMS2.yaml
+++ b/device-types/Rockwell Automation/5069-L3100ERMS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L3100ERMS2
+part_number: 5069-L3100ERMS2
+slug: 5069-l3100erms2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L3100ERMS3.yaml
+++ b/device-types/Rockwell Automation/5069-L3100ERMS3.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L3100ERMS3
+part_number: 5069-L3100ERMS3
+slug: 5069-l3100erms3
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L3100ERS2.yaml
+++ b/device-types/Rockwell Automation/5069-L3100ERS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L3100ERS2
+part_number: 5069-L3100ERS2
+slug: 5069-l3100ers2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L310ER-NSE.yaml
+++ b/device-types/Rockwell Automation/5069-L310ER-NSE.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L310ER-NSE
+part_number: 5069-L310ER-NSE
+slug: 5069-l310er-nse
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L310ER.yaml
+++ b/device-types/Rockwell Automation/5069-L310ER.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L310ER
+part_number: 5069-L310ER
+slug: 5069-l310er
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L310ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L310ERM.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L310ER
+part_number: 5069-L310ER
+slug: 5069-l310er
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L310ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L310ERM.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Rockwell Automation
-model: CompactLogix 5380 L310ER
-part_number: 5069-L310ER
-slug: 5069-l310er
+model: CompactLogix 5380 L310ERM
+part_number: 5069-L310ERM
+slug: 5069-l310erm
 u_height: 3
 is_full_depth: false
 interfaces:

--- a/device-types/Rockwell Automation/5069-L310ERMS2.yaml
+++ b/device-types/Rockwell Automation/5069-L310ERMS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L310ERMS2
+part_number: 5069-L310ERMS2
+slug: 5069-l310erms2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L310ERMS3.yaml
+++ b/device-types/Rockwell Automation/5069-L310ERMS3.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L310ERMS3
+part_number: 5069-L310ERMS3
+slug: 5069-l310erms3
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L310ERS2.yaml
+++ b/device-types/Rockwell Automation/5069-L310ERS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L310ERS2
+part_number: 5069-L310ERS2
+slug: 5069-l310ers2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L320ER.yaml
+++ b/device-types/Rockwell Automation/5069-L320ER.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L320ER
+part_number: 5069-L320ER
+slug: 5069-l320er
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L320ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERM.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L320ERM
+part_number: 5069-L320ERM
+slug: 5069-l320erm
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L320ERMK.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERMK.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L320ERMK
+part_number: 5069-L320ERMK
+slug: 5069-l320ermk
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L320ERMS2.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERMS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L320ERMS2
+part_number: 5069-L320ERMS2
+slug: 5069-l320erms2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L320ERMS2K.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERMS2K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L320ERMS2K
+part_number: 5069-L320ERMS2K
+slug: 5069-l320erms2k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L320ERMS3.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERMS3.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L320ERMS3
+part_number: 5069-L320ERMS3
+slug: 5069-l320erms3
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L320ERMS3K.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERMS3K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L320ERMS3K
+part_number: 5069-L320ERMS3K
+slug: 5069-l320erms3k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L320ERP.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERP.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L320ERP
+part_number: 5069-L320ERP
+slug: 5069-l320erp
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L320ERS2.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L320ERS2
+part_number: 5069-L320ERS2
+slug: 5069-l320ers2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L320ERS2K.yaml
+++ b/device-types/Rockwell Automation/5069-L320ERS2K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L320ERS2K
+part_number: 5069-L320ERS2K
+slug: 5069-l320ers2k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L330ER.yaml
+++ b/device-types/Rockwell Automation/5069-L330ER.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L330ER
+part_number: 5069-L330ER
+slug: 5069-l330er
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L330ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L330ERM.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L330ERM
+part_number: 5069-L330ERM
+slug: 5069-l330erm
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L330ERMK.yaml
+++ b/device-types/Rockwell Automation/5069-L330ERMK.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L330ERMK
+part_number: 5069-L330ERMK
+slug: 5069-l330ermk
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L330ERMS2.yaml
+++ b/device-types/Rockwell Automation/5069-L330ERMS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L330ERMS2
+part_number: 5069-L330ERMS2
+slug: 5069-l330erms2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L330ERMS2K.yaml
+++ b/device-types/Rockwell Automation/5069-L330ERMS2K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L330ERMS2K
+part_number: 5069-L330ERMS2K
+slug: 5069-l330erms2k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L330ERMS3.yaml
+++ b/device-types/Rockwell Automation/5069-L330ERMS3.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L330ERMS3
+part_number: 5069-L330ERMS3
+slug: 5069-l330erms3
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L330ERMS3K.yaml
+++ b/device-types/Rockwell Automation/5069-L330ERMS3K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L330ERMS3K
+part_number: 5069-L330ERMS3K
+slug: 5069-l330erms3k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L330ERS2.yaml
+++ b/device-types/Rockwell Automation/5069-L330ERS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L330ERS2
+part_number: 5069-L330ERS2
+slug: 5069-l330ers2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L330ERS2K.yaml
+++ b/device-types/Rockwell Automation/5069-L330ERS2K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L330ERS2K
+part_number: 5069-L330ERS2K
+slug: 5069-l330ers2k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L340ER.yaml
+++ b/device-types/Rockwell Automation/5069-L340ER.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L340ER
+part_number: 5069-L340ER
+slug: 5069-l340er
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L340ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L340ERM.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L340ERM
+part_number: 5069-L340ERM
+slug: 5069-l340erm
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L340ERMS2.yaml
+++ b/device-types/Rockwell Automation/5069-L340ERMS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L340ERMS2
+part_number: 5069-L340ERMS2
+slug: 5069-l340erms2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L340ERMS3.yaml
+++ b/device-types/Rockwell Automation/5069-L340ERMS3.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L340ERMS3
+part_number: 5069-L340ERMS3
+slug: 5069-l340erms3
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L340ERP.yaml
+++ b/device-types/Rockwell Automation/5069-L340ERP.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L340ERP
+part_number: 5069-L340ERP
+slug: 5069-l340erp
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L340ERS2.yaml
+++ b/device-types/Rockwell Automation/5069-L340ERS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L340ERS2
+part_number: 5069-L340ERS2
+slug: 5069-l340ers2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L350ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L350ERM.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L350ERM
+part_number: 5069-L350ERM
+slug: 5069-l350erm
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L350ERMK.yaml
+++ b/device-types/Rockwell Automation/5069-L350ERMK.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L350ERMK
+part_number: 5069-L350ERMK
+slug: 5069-l350ermk
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L350ERMS2.yaml
+++ b/device-types/Rockwell Automation/5069-L350ERMS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L350ERMS2
+part_number: 5069-L350ERMS2
+slug: 5069-l350erms2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L350ERMS2K.yaml
+++ b/device-types/Rockwell Automation/5069-L350ERMS2K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L350ERMS2K
+part_number: 5069-L350ERMS2K
+slug: 5069-l350erms2k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L350ERMS3.yaml
+++ b/device-types/Rockwell Automation/5069-L350ERMS3.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L350ERMS3
+part_number: 5069-L350ERMS3
+slug: 5069-l350erms3
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L350ERMS3K.yaml
+++ b/device-types/Rockwell Automation/5069-L350ERMS3K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L350ERMS3K
+part_number: 5069-L350ERMS3K
+slug: 5069-l350erms3k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L350ERS2.yaml
+++ b/device-types/Rockwell Automation/5069-L350ERS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L350ERS2
+part_number: 5069-L350ERS2
+slug: 5069-l350ers2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L350ERS2K.yaml
+++ b/device-types/Rockwell Automation/5069-L350ERS2K.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L350ERS2K
+part_number: 5069-L350ERS2K
+slug: 5069-l350ers2k
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L380ERM.yaml
+++ b/device-types/Rockwell Automation/5069-L380ERM.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5380 L380ERM
+part_number: 5069-L380ERM
+slug: 5069-l380erm
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 11
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L380ERMS2.yaml
+++ b/device-types/Rockwell Automation/5069-L380ERMS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L380ERMS2
+part_number: 5069-L380ERMS2
+slug: 5069-l380erms2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L380ERMS3.yaml
+++ b/device-types/Rockwell Automation/5069-L380ERMS3.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L380ERMS3
+part_number: 5069-L380ERMS3
+slug: 5069-l380erms3
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 18
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 18

--- a/device-types/Rockwell Automation/5069-L380ERS2.yaml
+++ b/device-types/Rockwell Automation/5069-L380ERS2.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Rockwell Automation
+model: CompactGuardLogix 5380 L380ERS2
+part_number: 5069-L380ERS2
+slug: 5069-l380ers2
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 120
+    allocated_draw: 9
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 9

--- a/device-types/Rockwell Automation/5069-L4100ERW.yaml
+++ b/device-types/Rockwell Automation/5069-L4100ERW.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5480 L4100ERMW
+part_number: 5069-L4100ERMW
+slug: 5069-l4100ermw
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+  - name: B1
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+console-server-port:
+  - name: usb-1
+    type: usb-a
+  - name: usb-2
+    type: usb-a
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 72
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 72

--- a/device-types/Rockwell Automation/5069-L4200ERW.yaml
+++ b/device-types/Rockwell Automation/5069-L4200ERW.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5480 L4200ERMW
+part_number: 5069-L4200ERMW
+slug: 5069-l4200ermw
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+  - name: B1
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+console-server-port:
+  - name: usb-1
+    type: usb-a
+  - name: usb-2
+    type: usb-a
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 72
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 72

--- a/device-types/Rockwell Automation/5069-L430ERW.yaml
+++ b/device-types/Rockwell Automation/5069-L430ERW.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5480 L430ERMW
+part_number: 5069-L430ERMW
+slug: 5069-l430ermw
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+  - name: B1
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+console-server-port:
+  - name: usb-1
+    type: usb-a
+  - name: usb-2
+    type: usb-a
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 72
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 72

--- a/device-types/Rockwell Automation/5069-L450ERW.yaml
+++ b/device-types/Rockwell Automation/5069-L450ERW.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: Rockwell Automation
+model: CompactLogix 5480 L450ERMW
+part_number: 5069-L450ERMW
+slug: 5069-l450ermw
+u_height: 3
+is_full_depth: false
+interfaces:
+  - name: A1
+    type: 1000base-t
+  - name: A2
+    type: 1000base-t
+  - name: B1
+    type: 1000base-t
+console-ports:
+  - name: usb
+    type: usb-b
+console-server-port:
+  - name: usb-1
+    type: usb-a
+  - name: usb-2
+    type: usb-a
+power-port:
+  - name: MOD
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 72
+  - name: SA
+    type: dc-terminal
+    maximum_draw: 240
+    allocated_draw: 72

--- a/device-types/Ubiquiti/USW-Lite-8-PoE.yaml
+++ b/device-types/Ubiquiti/USW-Lite-8-PoE.yaml
@@ -1,0 +1,32 @@
+---
+manufacturer: Ubiquiti
+model: UniFi Switch Lite 8 PoE
+slug: unifi-switch-lite-8-poe
+part_number: USW-Lite-8-PoE
+comments: |
+  UniFi Switch Lite 8 PoE (8) Gigabit, (1-4) Gigabit PoE+ IEEE 802.3af/at
+
+  Dimensions: 99.6 x 163.7 x 31.7 mm (3.92 x 6.44 x 1.25")
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: Port 1 (PoE+)
+    type: 1000base-t
+  - name: Port 2 (PoE+)
+    type: 1000base-t
+  - name: Port 3 (PoE+)
+    type: 1000base-t
+  - name: Port 4 (PoE+)
+    type: 1000base-t
+  - name: Port 5
+    type: 1000base-t
+  - name: Port 6
+    type: 1000base-t
+  - name: Port 7
+    type: 1000base-t
+  - name: Port 8
+    type: 1000base-t
+power-ports:
+  - name: Input
+    type: nema-5-15p
+    maximum_draw: 52


### PR DESCRIPTION
This PR adds the ethernet enabled variants of both the ControlLogix (1756) and CompactLogix (5069) PLC lines.