### PR TITLE
Update C9200L-48T-4X.yaml

### DIFF
--- a/device-types/Cisco/C9200L-48T-4X.yaml
+++ b/device-types/Cisco/C9200L-48T-4X.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Cisco
-model: C9200-48T-4X
-part_number: C9200-48T-4X
-slug: c9200-48t-4x
+model: C9200L-48T-4X
+part_number: C9200L-48T-4X
+slug: c9200l-48t-4x
 u_height: 1
 is_full_depth: false
 comments: '[Cisco Catalyst 9200 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9200-series-switches/nb-06-cat9200-ser-data-sheet-cte-en.html)'


### PR DESCRIPTION
The title is C9200L but the model, partnumber and slug were missing the L causing search and groupings in netbox to not work properly.