### PR TITLE
Add Panduit Copper / Fiber Patch Panels

### DIFF
--- a/device-types/Panduit/CDPP8RG-S.yaml
+++ b/device-types/Panduit/CDPP8RG-S.yaml
@@ -1,0 +1,66 @@
+---
+manufacturer: Panduit
+model: Mini-Com Shielded DIN Rail Patch Panel (8 Port)
+slug: cdpp8rg-s
+part_number: CDPP8RG-S
+u_height: 3
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 110-punch
+    positions: 1
+  - name: '02'
+    type: 110-punch
+    positions: 1
+  - name: '03'
+    type: 110-punch
+    positions: 1
+  - name: '04'
+    type: 110-punch
+    positions: 1
+  - name: '05'
+    type: 110-punch
+    positions: 1
+  - name: '06'
+    type: 110-punch
+    positions: 1
+  - name: '07'
+    type: 110-punch
+    positions: 1
+  - name: '08'
+    type: 110-punch
+    positions: 1

--- a/device-types/Panduit/CDPP8RG.yaml
+++ b/device-types/Panduit/CDPP8RG.yaml
@@ -1,0 +1,66 @@
+---
+manufacturer: Panduit
+model: Mini-Com DIN Rail Patch Panel (8 Port)
+slug: cdpp8rg
+part_number: CDPP8RG
+u_height: 3
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 110-punch
+    positions: 1
+  - name: '02'
+    type: 110-punch
+    positions: 1
+  - name: '03'
+    type: 110-punch
+    positions: 1
+  - name: '04'
+    type: 110-punch
+    positions: 1
+  - name: '05'
+    type: 110-punch
+    positions: 1
+  - name: '06'
+    type: 110-punch
+    positions: 1
+  - name: '07'
+    type: 110-punch
+    positions: 1
+  - name: '08'
+    type: 110-punch
+    positions: 1

--- a/device-types/Panduit/CP24BLY.yaml
+++ b/device-types/Panduit/CP24BLY.yaml
@@ -1,0 +1,178 @@
+---
+manufacturer: Panduit
+model: Mini-Com Shielded Patch Panel (24 Port, 1RU)
+slug: cp24bly
+part_number: CP24BLY
+u_height: 1
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 110-punch
+    positions: 1
+  - name: '02'
+    type: 110-punch
+    positions: 1
+  - name: '03'
+    type: 110-punch
+    positions: 1
+  - name: '04'
+    type: 110-punch
+    positions: 1
+  - name: '05'
+    type: 110-punch
+    positions: 1
+  - name: '06'
+    type: 110-punch
+    positions: 1
+  - name: '07'
+    type: 110-punch
+    positions: 1
+  - name: '08'
+    type: 110-punch
+    positions: 1
+  - name: '09'
+    type: 110-punch
+    positions: 1
+  - name: '10'
+    type: 110-punch
+    positions: 1
+  - name: '11'
+    type: 110-punch
+    positions: 1
+  - name: '12'
+    type: 110-punch
+    positions: 1
+  - name: '13'
+    type: 110-punch
+    positions: 1
+  - name: '14'
+    type: 110-punch
+    positions: 1
+  - name: '15'
+    type: 110-punch
+    positions: 1
+  - name: '16'
+    type: 110-punch
+    positions: 1
+  - name: '17'
+    type: 110-punch
+    positions: 1
+  - name: '18'
+    type: 110-punch
+    positions: 1
+  - name: '19'
+    type: 110-punch
+    positions: 1
+  - name: '20'
+    type: 110-punch
+    positions: 1
+  - name: '21'
+    type: 110-punch
+    positions: 1
+  - name: '22'
+    type: 110-punch
+    positions: 1
+  - name: '23'
+    type: 110-punch
+    positions: 1
+  - name: '24'
+    type: 110-punch
+    positions: 1

--- a/device-types/Panduit/CP48BLY.yaml
+++ b/device-types/Panduit/CP48BLY.yaml
@@ -1,0 +1,346 @@
+---
+manufacturer: Panduit
+model: Mini-Com Shielded Patch Panel (48 Port, 2RU)
+slug: cp48bly
+part_number: CP48BLY
+u_height: 2
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+  - name: '25'
+    type: 8p8c
+    rear_port: '25'
+    rear_port_position: 1
+  - name: '26'
+    type: 8p8c
+    rear_port: '26'
+    rear_port_position: 1
+  - name: '27'
+    type: 8p8c
+    rear_port: '27'
+    rear_port_position: 1
+  - name: '28'
+    type: 8p8c
+    rear_port: '28'
+    rear_port_position: 1
+  - name: '29'
+    type: 8p8c
+    rear_port: '29'
+    rear_port_position: 1
+  - name: '30'
+    type: 8p8c
+    rear_port: '30'
+    rear_port_position: 1
+  - name: '31'
+    type: 8p8c
+    rear_port: '31'
+    rear_port_position: 1
+  - name: '32'
+    type: 8p8c
+    rear_port: '32'
+    rear_port_position: 1
+  - name: '33'
+    type: 8p8c
+    rear_port: '33'
+    rear_port_position: 1
+  - name: '34'
+    type: 8p8c
+    rear_port: '34'
+    rear_port_position: 1
+  - name: '35'
+    type: 8p8c
+    rear_port: '35'
+    rear_port_position: 1
+  - name: '36'
+    type: 8p8c
+    rear_port: '36'
+    rear_port_position: 1
+  - name: '37'
+    type: 8p8c
+    rear_port: '37'
+    rear_port_position: 1
+  - name: '38'
+    type: 8p8c
+    rear_port: '38'
+    rear_port_position: 1
+  - name: '39'
+    type: 8p8c
+    rear_port: '39'
+    rear_port_position: 1
+  - name: '40'
+    type: 8p8c
+    rear_port: '40'
+    rear_port_position: 1
+  - name: '41'
+    type: 8p8c
+    rear_port: '41'
+    rear_port_position: 1
+  - name: '42'
+    type: 8p8c
+    rear_port: '42'
+    rear_port_position: 1
+  - name: '43'
+    type: 8p8c
+    rear_port: '43'
+    rear_port_position: 1
+  - name: '44'
+    type: 8p8c
+    rear_port: '44'
+    rear_port_position: 1
+  - name: '45'
+    type: 8p8c
+    rear_port: '45'
+    rear_port_position: 1
+  - name: '46'
+    type: 8p8c
+    rear_port: '46'
+    rear_port_position: 1
+  - name: '47'
+    type: 8p8c
+    rear_port: '47'
+    rear_port_position: 1
+  - name: '48'
+    type: 8p8c
+    rear_port: '48'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 110-punch
+    positions: 1
+  - name: '02'
+    type: 110-punch
+    positions: 1
+  - name: '03'
+    type: 110-punch
+    positions: 1
+  - name: '04'
+    type: 110-punch
+    positions: 1
+  - name: '05'
+    type: 110-punch
+    positions: 1
+  - name: '06'
+    type: 110-punch
+    positions: 1
+  - name: '07'
+    type: 110-punch
+    positions: 1
+  - name: '08'
+    type: 110-punch
+    positions: 1
+  - name: '09'
+    type: 110-punch
+    positions: 1
+  - name: '10'
+    type: 110-punch
+    positions: 1
+  - name: '11'
+    type: 110-punch
+    positions: 1
+  - name: '12'
+    type: 110-punch
+    positions: 1
+  - name: '13'
+    type: 110-punch
+    positions: 1
+  - name: '14'
+    type: 110-punch
+    positions: 1
+  - name: '15'
+    type: 110-punch
+    positions: 1
+  - name: '16'
+    type: 110-punch
+    positions: 1
+  - name: '17'
+    type: 110-punch
+    positions: 1
+  - name: '18'
+    type: 110-punch
+    positions: 1
+  - name: '19'
+    type: 110-punch
+    positions: 1
+  - name: '20'
+    type: 110-punch
+    positions: 1
+  - name: '21'
+    type: 110-punch
+    positions: 1
+  - name: '22'
+    type: 110-punch
+    positions: 1
+  - name: '23'
+    type: 110-punch
+    positions: 1
+  - name: '24'
+    type: 110-punch
+    positions: 1
+  - name: '25'
+    type: 110-punch
+    positions: 1
+  - name: '26'
+    type: 110-punch
+    positions: 1
+  - name: '27'
+    type: 110-punch
+    positions: 1
+  - name: '28'
+    type: 110-punch
+    positions: 1
+  - name: '29'
+    type: 110-punch
+    positions: 1
+  - name: '30'
+    type: 110-punch
+    positions: 1
+  - name: '31'
+    type: 110-punch
+    positions: 1
+  - name: '32'
+    type: 110-punch
+    positions: 1
+  - name: '33'
+    type: 110-punch
+    positions: 1
+  - name: '34'
+    type: 110-punch
+    positions: 1
+  - name: '35'
+    type: 110-punch
+    positions: 1
+  - name: '36'
+    type: 110-punch
+    positions: 1
+  - name: '37'
+    type: 110-punch
+    positions: 1
+  - name: '38'
+    type: 110-punch
+    positions: 1
+  - name: '39'
+    type: 110-punch
+    positions: 1
+  - name: '40'
+    type: 110-punch
+    positions: 1
+  - name: '41'
+    type: 110-punch
+    positions: 1
+  - name: '42'
+    type: 110-punch
+    positions: 1
+  - name: '43'
+    type: 110-punch
+    positions: 1
+  - name: '44'
+    type: 110-punch
+    positions: 1
+  - name: '45'
+    type: 110-punch
+    positions: 1
+  - name: '46'
+    type: 110-punch
+    positions: 1
+  - name: '47'
+    type: 110-punch
+    positions: 1
+  - name: '48'
+    type: 110-punch
+    positions: 1

--- a/device-types/Panduit/CP48HDBL.yaml
+++ b/device-types/Panduit/CP48HDBL.yaml
@@ -1,0 +1,346 @@
+---
+manufacturer: Panduit
+model: Mini-Com Shielded High Density Patch Panel (48 Port, 1RU)
+slug: cp48hdbl
+part_number: CP48HDBL
+u_height: 1
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+  - name: '25'
+    type: 8p8c
+    rear_port: '25'
+    rear_port_position: 1
+  - name: '26'
+    type: 8p8c
+    rear_port: '26'
+    rear_port_position: 1
+  - name: '27'
+    type: 8p8c
+    rear_port: '27'
+    rear_port_position: 1
+  - name: '28'
+    type: 8p8c
+    rear_port: '28'
+    rear_port_position: 1
+  - name: '29'
+    type: 8p8c
+    rear_port: '29'
+    rear_port_position: 1
+  - name: '30'
+    type: 8p8c
+    rear_port: '30'
+    rear_port_position: 1
+  - name: '31'
+    type: 8p8c
+    rear_port: '31'
+    rear_port_position: 1
+  - name: '32'
+    type: 8p8c
+    rear_port: '32'
+    rear_port_position: 1
+  - name: '33'
+    type: 8p8c
+    rear_port: '33'
+    rear_port_position: 1
+  - name: '34'
+    type: 8p8c
+    rear_port: '34'
+    rear_port_position: 1
+  - name: '35'
+    type: 8p8c
+    rear_port: '35'
+    rear_port_position: 1
+  - name: '36'
+    type: 8p8c
+    rear_port: '36'
+    rear_port_position: 1
+  - name: '37'
+    type: 8p8c
+    rear_port: '37'
+    rear_port_position: 1
+  - name: '38'
+    type: 8p8c
+    rear_port: '38'
+    rear_port_position: 1
+  - name: '39'
+    type: 8p8c
+    rear_port: '39'
+    rear_port_position: 1
+  - name: '40'
+    type: 8p8c
+    rear_port: '40'
+    rear_port_position: 1
+  - name: '41'
+    type: 8p8c
+    rear_port: '41'
+    rear_port_position: 1
+  - name: '42'
+    type: 8p8c
+    rear_port: '42'
+    rear_port_position: 1
+  - name: '43'
+    type: 8p8c
+    rear_port: '43'
+    rear_port_position: 1
+  - name: '44'
+    type: 8p8c
+    rear_port: '44'
+    rear_port_position: 1
+  - name: '45'
+    type: 8p8c
+    rear_port: '45'
+    rear_port_position: 1
+  - name: '46'
+    type: 8p8c
+    rear_port: '46'
+    rear_port_position: 1
+  - name: '47'
+    type: 8p8c
+    rear_port: '47'
+    rear_port_position: 1
+  - name: '48'
+    type: 8p8c
+    rear_port: '48'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 110-punch
+    positions: 1
+  - name: '02'
+    type: 110-punch
+    positions: 1
+  - name: '03'
+    type: 110-punch
+    positions: 1
+  - name: '04'
+    type: 110-punch
+    positions: 1
+  - name: '05'
+    type: 110-punch
+    positions: 1
+  - name: '06'
+    type: 110-punch
+    positions: 1
+  - name: '07'
+    type: 110-punch
+    positions: 1
+  - name: '08'
+    type: 110-punch
+    positions: 1
+  - name: '09'
+    type: 110-punch
+    positions: 1
+  - name: '10'
+    type: 110-punch
+    positions: 1
+  - name: '11'
+    type: 110-punch
+    positions: 1
+  - name: '12'
+    type: 110-punch
+    positions: 1
+  - name: '13'
+    type: 110-punch
+    positions: 1
+  - name: '14'
+    type: 110-punch
+    positions: 1
+  - name: '15'
+    type: 110-punch
+    positions: 1
+  - name: '16'
+    type: 110-punch
+    positions: 1
+  - name: '17'
+    type: 110-punch
+    positions: 1
+  - name: '18'
+    type: 110-punch
+    positions: 1
+  - name: '19'
+    type: 110-punch
+    positions: 1
+  - name: '20'
+    type: 110-punch
+    positions: 1
+  - name: '21'
+    type: 110-punch
+    positions: 1
+  - name: '22'
+    type: 110-punch
+    positions: 1
+  - name: '23'
+    type: 110-punch
+    positions: 1
+  - name: '24'
+    type: 110-punch
+    positions: 1
+  - name: '25'
+    type: 110-punch
+    positions: 1
+  - name: '26'
+    type: 110-punch
+    positions: 1
+  - name: '27'
+    type: 110-punch
+    positions: 1
+  - name: '28'
+    type: 110-punch
+    positions: 1
+  - name: '29'
+    type: 110-punch
+    positions: 1
+  - name: '30'
+    type: 110-punch
+    positions: 1
+  - name: '31'
+    type: 110-punch
+    positions: 1
+  - name: '32'
+    type: 110-punch
+    positions: 1
+  - name: '33'
+    type: 110-punch
+    positions: 1
+  - name: '34'
+    type: 110-punch
+    positions: 1
+  - name: '35'
+    type: 110-punch
+    positions: 1
+  - name: '36'
+    type: 110-punch
+    positions: 1
+  - name: '37'
+    type: 110-punch
+    positions: 1
+  - name: '38'
+    type: 110-punch
+    positions: 1
+  - name: '39'
+    type: 110-punch
+    positions: 1
+  - name: '40'
+    type: 110-punch
+    positions: 1
+  - name: '41'
+    type: 110-punch
+    positions: 1
+  - name: '42'
+    type: 110-punch
+    positions: 1
+  - name: '43'
+    type: 110-punch
+    positions: 1
+  - name: '44'
+    type: 110-punch
+    positions: 1
+  - name: '45'
+    type: 110-punch
+    positions: 1
+  - name: '46'
+    type: 110-punch
+    positions: 1
+  - name: '47'
+    type: 110-punch
+    positions: 1
+  - name: '48'
+    type: 110-punch
+    positions: 1

--- a/device-types/Panduit/CPA24BLY.yaml
+++ b/device-types/Panduit/CPA24BLY.yaml
@@ -1,0 +1,178 @@
+---
+manufacturer: Panduit
+model: Mini-Com Shielded Angled Patch Panel (24 Port, 1RU)
+slug: cpa24bly
+part_number: CPA24BLY
+u_height: 1
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 110-punch
+    positions: 1
+  - name: '02'
+    type: 110-punch
+    positions: 1
+  - name: '03'
+    type: 110-punch
+    positions: 1
+  - name: '04'
+    type: 110-punch
+    positions: 1
+  - name: '05'
+    type: 110-punch
+    positions: 1
+  - name: '06'
+    type: 110-punch
+    positions: 1
+  - name: '07'
+    type: 110-punch
+    positions: 1
+  - name: '08'
+    type: 110-punch
+    positions: 1
+  - name: '09'
+    type: 110-punch
+    positions: 1
+  - name: '10'
+    type: 110-punch
+    positions: 1
+  - name: '11'
+    type: 110-punch
+    positions: 1
+  - name: '12'
+    type: 110-punch
+    positions: 1
+  - name: '13'
+    type: 110-punch
+    positions: 1
+  - name: '14'
+    type: 110-punch
+    positions: 1
+  - name: '15'
+    type: 110-punch
+    positions: 1
+  - name: '16'
+    type: 110-punch
+    positions: 1
+  - name: '17'
+    type: 110-punch
+    positions: 1
+  - name: '18'
+    type: 110-punch
+    positions: 1
+  - name: '19'
+    type: 110-punch
+    positions: 1
+  - name: '20'
+    type: 110-punch
+    positions: 1
+  - name: '21'
+    type: 110-punch
+    positions: 1
+  - name: '22'
+    type: 110-punch
+    positions: 1
+  - name: '23'
+    type: 110-punch
+    positions: 1
+  - name: '24'
+    type: 110-punch
+    positions: 1

--- a/device-types/Panduit/CPA48BLY.yaml
+++ b/device-types/Panduit/CPA48BLY.yaml
@@ -1,0 +1,346 @@
+---
+manufacturer: Panduit
+model: Mini-Com Shielded Angled Patch Panel (48 Port, 2RU)
+slug: cpa48bly
+part_number: CPA48BLY
+u_height: 2
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+  - name: '25'
+    type: 8p8c
+    rear_port: '25'
+    rear_port_position: 1
+  - name: '26'
+    type: 8p8c
+    rear_port: '26'
+    rear_port_position: 1
+  - name: '27'
+    type: 8p8c
+    rear_port: '27'
+    rear_port_position: 1
+  - name: '28'
+    type: 8p8c
+    rear_port: '28'
+    rear_port_position: 1
+  - name: '29'
+    type: 8p8c
+    rear_port: '29'
+    rear_port_position: 1
+  - name: '30'
+    type: 8p8c
+    rear_port: '30'
+    rear_port_position: 1
+  - name: '31'
+    type: 8p8c
+    rear_port: '31'
+    rear_port_position: 1
+  - name: '32'
+    type: 8p8c
+    rear_port: '32'
+    rear_port_position: 1
+  - name: '33'
+    type: 8p8c
+    rear_port: '33'
+    rear_port_position: 1
+  - name: '34'
+    type: 8p8c
+    rear_port: '34'
+    rear_port_position: 1
+  - name: '35'
+    type: 8p8c
+    rear_port: '35'
+    rear_port_position: 1
+  - name: '36'
+    type: 8p8c
+    rear_port: '36'
+    rear_port_position: 1
+  - name: '37'
+    type: 8p8c
+    rear_port: '37'
+    rear_port_position: 1
+  - name: '38'
+    type: 8p8c
+    rear_port: '38'
+    rear_port_position: 1
+  - name: '39'
+    type: 8p8c
+    rear_port: '39'
+    rear_port_position: 1
+  - name: '40'
+    type: 8p8c
+    rear_port: '40'
+    rear_port_position: 1
+  - name: '41'
+    type: 8p8c
+    rear_port: '41'
+    rear_port_position: 1
+  - name: '42'
+    type: 8p8c
+    rear_port: '42'
+    rear_port_position: 1
+  - name: '43'
+    type: 8p8c
+    rear_port: '43'
+    rear_port_position: 1
+  - name: '44'
+    type: 8p8c
+    rear_port: '44'
+    rear_port_position: 1
+  - name: '45'
+    type: 8p8c
+    rear_port: '45'
+    rear_port_position: 1
+  - name: '46'
+    type: 8p8c
+    rear_port: '46'
+    rear_port_position: 1
+  - name: '47'
+    type: 8p8c
+    rear_port: '47'
+    rear_port_position: 1
+  - name: '48'
+    type: 8p8c
+    rear_port: '48'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 110-punch
+    positions: 1
+  - name: '02'
+    type: 110-punch
+    positions: 1
+  - name: '03'
+    type: 110-punch
+    positions: 1
+  - name: '04'
+    type: 110-punch
+    positions: 1
+  - name: '05'
+    type: 110-punch
+    positions: 1
+  - name: '06'
+    type: 110-punch
+    positions: 1
+  - name: '07'
+    type: 110-punch
+    positions: 1
+  - name: '08'
+    type: 110-punch
+    positions: 1
+  - name: '09'
+    type: 110-punch
+    positions: 1
+  - name: '10'
+    type: 110-punch
+    positions: 1
+  - name: '11'
+    type: 110-punch
+    positions: 1
+  - name: '12'
+    type: 110-punch
+    positions: 1
+  - name: '13'
+    type: 110-punch
+    positions: 1
+  - name: '14'
+    type: 110-punch
+    positions: 1
+  - name: '15'
+    type: 110-punch
+    positions: 1
+  - name: '16'
+    type: 110-punch
+    positions: 1
+  - name: '17'
+    type: 110-punch
+    positions: 1
+  - name: '18'
+    type: 110-punch
+    positions: 1
+  - name: '19'
+    type: 110-punch
+    positions: 1
+  - name: '20'
+    type: 110-punch
+    positions: 1
+  - name: '21'
+    type: 110-punch
+    positions: 1
+  - name: '22'
+    type: 110-punch
+    positions: 1
+  - name: '23'
+    type: 110-punch
+    positions: 1
+  - name: '24'
+    type: 110-punch
+    positions: 1
+  - name: '25'
+    type: 110-punch
+    positions: 1
+  - name: '26'
+    type: 110-punch
+    positions: 1
+  - name: '27'
+    type: 110-punch
+    positions: 1
+  - name: '28'
+    type: 110-punch
+    positions: 1
+  - name: '29'
+    type: 110-punch
+    positions: 1
+  - name: '30'
+    type: 110-punch
+    positions: 1
+  - name: '31'
+    type: 110-punch
+    positions: 1
+  - name: '32'
+    type: 110-punch
+    positions: 1
+  - name: '33'
+    type: 110-punch
+    positions: 1
+  - name: '34'
+    type: 110-punch
+    positions: 1
+  - name: '35'
+    type: 110-punch
+    positions: 1
+  - name: '36'
+    type: 110-punch
+    positions: 1
+  - name: '37'
+    type: 110-punch
+    positions: 1
+  - name: '38'
+    type: 110-punch
+    positions: 1
+  - name: '39'
+    type: 110-punch
+    positions: 1
+  - name: '40'
+    type: 110-punch
+    positions: 1
+  - name: '41'
+    type: 110-punch
+    positions: 1
+  - name: '42'
+    type: 110-punch
+    positions: 1
+  - name: '43'
+    type: 110-punch
+    positions: 1
+  - name: '44'
+    type: 110-punch
+    positions: 1
+  - name: '45'
+    type: 110-punch
+    positions: 1
+  - name: '46'
+    type: 110-punch
+    positions: 1
+  - name: '47'
+    type: 110-punch
+    positions: 1
+  - name: '48'
+    type: 110-punch
+    positions: 1

--- a/device-types/Panduit/CPA48HDBL.yaml
+++ b/device-types/Panduit/CPA48HDBL.yaml
@@ -1,0 +1,346 @@
+---
+manufacturer: Panduit
+model: Mini-Com Shielded High Density Angled Patch Panel (48 Port, 1RU)
+slug: cpa48hdbl
+part_number: CPA48HDBL
+u_height: 1
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+  - name: '25'
+    type: 8p8c
+    rear_port: '25'
+    rear_port_position: 1
+  - name: '26'
+    type: 8p8c
+    rear_port: '26'
+    rear_port_position: 1
+  - name: '27'
+    type: 8p8c
+    rear_port: '27'
+    rear_port_position: 1
+  - name: '28'
+    type: 8p8c
+    rear_port: '28'
+    rear_port_position: 1
+  - name: '29'
+    type: 8p8c
+    rear_port: '29'
+    rear_port_position: 1
+  - name: '30'
+    type: 8p8c
+    rear_port: '30'
+    rear_port_position: 1
+  - name: '31'
+    type: 8p8c
+    rear_port: '31'
+    rear_port_position: 1
+  - name: '32'
+    type: 8p8c
+    rear_port: '32'
+    rear_port_position: 1
+  - name: '33'
+    type: 8p8c
+    rear_port: '33'
+    rear_port_position: 1
+  - name: '34'
+    type: 8p8c
+    rear_port: '34'
+    rear_port_position: 1
+  - name: '35'
+    type: 8p8c
+    rear_port: '35'
+    rear_port_position: 1
+  - name: '36'
+    type: 8p8c
+    rear_port: '36'
+    rear_port_position: 1
+  - name: '37'
+    type: 8p8c
+    rear_port: '37'
+    rear_port_position: 1
+  - name: '38'
+    type: 8p8c
+    rear_port: '38'
+    rear_port_position: 1
+  - name: '39'
+    type: 8p8c
+    rear_port: '39'
+    rear_port_position: 1
+  - name: '40'
+    type: 8p8c
+    rear_port: '40'
+    rear_port_position: 1
+  - name: '41'
+    type: 8p8c
+    rear_port: '41'
+    rear_port_position: 1
+  - name: '42'
+    type: 8p8c
+    rear_port: '42'
+    rear_port_position: 1
+  - name: '43'
+    type: 8p8c
+    rear_port: '43'
+    rear_port_position: 1
+  - name: '44'
+    type: 8p8c
+    rear_port: '44'
+    rear_port_position: 1
+  - name: '45'
+    type: 8p8c
+    rear_port: '45'
+    rear_port_position: 1
+  - name: '46'
+    type: 8p8c
+    rear_port: '46'
+    rear_port_position: 1
+  - name: '47'
+    type: 8p8c
+    rear_port: '47'
+    rear_port_position: 1
+  - name: '48'
+    type: 8p8c
+    rear_port: '48'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 110-punch
+    positions: 1
+  - name: '02'
+    type: 110-punch
+    positions: 1
+  - name: '03'
+    type: 110-punch
+    positions: 1
+  - name: '04'
+    type: 110-punch
+    positions: 1
+  - name: '05'
+    type: 110-punch
+    positions: 1
+  - name: '06'
+    type: 110-punch
+    positions: 1
+  - name: '07'
+    type: 110-punch
+    positions: 1
+  - name: '08'
+    type: 110-punch
+    positions: 1
+  - name: '09'
+    type: 110-punch
+    positions: 1
+  - name: '10'
+    type: 110-punch
+    positions: 1
+  - name: '11'
+    type: 110-punch
+    positions: 1
+  - name: '12'
+    type: 110-punch
+    positions: 1
+  - name: '13'
+    type: 110-punch
+    positions: 1
+  - name: '14'
+    type: 110-punch
+    positions: 1
+  - name: '15'
+    type: 110-punch
+    positions: 1
+  - name: '16'
+    type: 110-punch
+    positions: 1
+  - name: '17'
+    type: 110-punch
+    positions: 1
+  - name: '18'
+    type: 110-punch
+    positions: 1
+  - name: '19'
+    type: 110-punch
+    positions: 1
+  - name: '20'
+    type: 110-punch
+    positions: 1
+  - name: '21'
+    type: 110-punch
+    positions: 1
+  - name: '22'
+    type: 110-punch
+    positions: 1
+  - name: '23'
+    type: 110-punch
+    positions: 1
+  - name: '24'
+    type: 110-punch
+    positions: 1
+  - name: '25'
+    type: 110-punch
+    positions: 1
+  - name: '26'
+    type: 110-punch
+    positions: 1
+  - name: '27'
+    type: 110-punch
+    positions: 1
+  - name: '28'
+    type: 110-punch
+    positions: 1
+  - name: '29'
+    type: 110-punch
+    positions: 1
+  - name: '30'
+    type: 110-punch
+    positions: 1
+  - name: '31'
+    type: 110-punch
+    positions: 1
+  - name: '32'
+    type: 110-punch
+    positions: 1
+  - name: '33'
+    type: 110-punch
+    positions: 1
+  - name: '34'
+    type: 110-punch
+    positions: 1
+  - name: '35'
+    type: 110-punch
+    positions: 1
+  - name: '36'
+    type: 110-punch
+    positions: 1
+  - name: '37'
+    type: 110-punch
+    positions: 1
+  - name: '38'
+    type: 110-punch
+    positions: 1
+  - name: '39'
+    type: 110-punch
+    positions: 1
+  - name: '40'
+    type: 110-punch
+    positions: 1
+  - name: '41'
+    type: 110-punch
+    positions: 1
+  - name: '42'
+    type: 110-punch
+    positions: 1
+  - name: '43'
+    type: 110-punch
+    positions: 1
+  - name: '44'
+    type: 110-punch
+    positions: 1
+  - name: '45'
+    type: 110-punch
+    positions: 1
+  - name: '46'
+    type: 110-punch
+    positions: 1
+  - name: '47'
+    type: 110-punch
+    positions: 1
+  - name: '48'
+    type: 110-punch
+    positions: 1

--- a/device-types/Panduit/CPP24FMWBLY.yaml
+++ b/device-types/Panduit/CPP24FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: CPP24FMWBLY
+model: Mini-Com Patch Panel (24 Port, 1RU)
 slug: cpp24fmwbly
 part_number: CPP24FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPP24FMWBLY.yaml
+++ b/device-types/Panduit/CPP24FMWBLY.yaml
@@ -1,0 +1,178 @@
+---
+manufacturer: Panduit
+model: CPP24FMWBLY
+slug: cpp24fmwbly
+part_number: CPP24FMWBLY
+u_height: 2
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 8p8c
+    positions: 1
+  - name: '02'
+    type: 8p8c
+    positions: 1
+  - name: '03'
+    type: 8p8c
+    positions: 1
+  - name: '04'
+    type: 8p8c
+    positions: 1
+  - name: '05'
+    type: 8p8c
+    positions: 1
+  - name: '06'
+    type: 8p8c
+    positions: 1
+  - name: '07'
+    type: 8p8c
+    positions: 1
+  - name: '08'
+    type: 8p8c
+    positions: 1
+  - name: '09'
+    type: 8p8c
+    positions: 1
+  - name: '10'
+    type: 8p8c
+    positions: 1
+  - name: '11'
+    type: 8p8c
+    positions: 1
+  - name: '12'
+    type: 8p8c
+    positions: 1
+  - name: '13'
+    type: 8p8c
+    positions: 1
+  - name: '14'
+    type: 8p8c
+    positions: 1
+  - name: '15'
+    type: 8p8c
+    positions: 1
+  - name: '16'
+    type: 8p8c
+    positions: 1
+  - name: '17'
+    type: 8p8c
+    positions: 1
+  - name: '18'
+    type: 8p8c
+    positions: 1
+  - name: '19'
+    type: 8p8c
+    positions: 1
+  - name: '20'
+    type: 8p8c
+    positions: 1
+  - name: '21'
+    type: 8p8c
+    positions: 1
+  - name: '22'
+    type: 8p8c
+    positions: 1
+  - name: '23'
+    type: 8p8c
+    positions: 1
+  - name: '24'
+    type: 8p8c
+    positions: 1

--- a/device-types/Panduit/CPP24FMWBLY.yaml
+++ b/device-types/Panduit/CPP24FMWBLY.yaml
@@ -105,74 +105,74 @@ front-ports:
 
 rear-ports:
   - name: '01'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '02'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '03'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '04'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '05'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '06'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '07'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '08'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '09'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '10'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '11'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '12'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '13'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '14'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '15'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '16'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '17'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '18'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '19'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '20'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '21'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '22'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '23'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '24'
-    type: 8p8c
+    type: 110-punch
     positions: 1

--- a/device-types/Panduit/CPP24FMWBLY.yaml
+++ b/device-types/Panduit/CPP24FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Patch Panel (24 Port, 1RU)
+model: Mini-Com Flush Mount Patch Panel (24 Port, 1RU)
 slug: cpp24fmwbly
 part_number: CPP24FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPP24FMWBLY.yaml
+++ b/device-types/Panduit/CPP24FMWBLY.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Mini-Com Flush Mount Patch Panel (24 Port, 1RU)
 slug: cpp24fmwbly
 part_number: CPP24FMWBLY
-u_height: 2
+u_height: 1
 is_full_depth: false
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPP24WBLY.yaml
+++ b/device-types/Panduit/CPP24WBLY.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Mini-Com Front Access Patch Panel (24 Port, 1RU)
 slug: cpp24wbly
 part_number: CPP24WBLY
-u_height: 2
+u_height: 1
 is_full_depth: false
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPP24WBLY.yaml
+++ b/device-types/Panduit/CPP24WBLY.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Flush Mount Angled Patch Panel (24 Port, 1RU)
-slug: cppa24fmwbly
-part_number: CPPA24FMWBLY
+model: Mini-Com Front Access Patch Panel (24 Port, 1RU)
+slug: cpp24wbly
+part_number: CPP24WBLY
 u_height: 2
 is_full_depth: false
 front-ports:

--- a/device-types/Panduit/CPP48FMWBLY.yaml
+++ b/device-types/Panduit/CPP48FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: CPP48FMWBLY
+model: Mini-Com Patch Panel (48 Port, 2RU)
 slug: cpp48fmwbly
 part_number: CPP48FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPP48FMWBLY.yaml
+++ b/device-types/Panduit/CPP48FMWBLY.yaml
@@ -1,0 +1,346 @@
+---
+manufacturer: Panduit
+model: CPP48FMWBLY
+slug: cpp48fmwbly
+part_number: CPP48FMWBLY
+u_height: 2
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+  - name: '25'
+    type: 8p8c
+    rear_port: '25'
+    rear_port_position: 1
+  - name: '26'
+    type: 8p8c
+    rear_port: '26'
+    rear_port_position: 1
+  - name: '27'
+    type: 8p8c
+    rear_port: '27'
+    rear_port_position: 1
+  - name: '28'
+    type: 8p8c
+    rear_port: '28'
+    rear_port_position: 1
+  - name: '29'
+    type: 8p8c
+    rear_port: '29'
+    rear_port_position: 1
+  - name: '30'
+    type: 8p8c
+    rear_port: '30'
+    rear_port_position: 1
+  - name: '31'
+    type: 8p8c
+    rear_port: '31'
+    rear_port_position: 1
+  - name: '32'
+    type: 8p8c
+    rear_port: '32'
+    rear_port_position: 1
+  - name: '33'
+    type: 8p8c
+    rear_port: '33'
+    rear_port_position: 1
+  - name: '34'
+    type: 8p8c
+    rear_port: '34'
+    rear_port_position: 1
+  - name: '35'
+    type: 8p8c
+    rear_port: '35'
+    rear_port_position: 1
+  - name: '36'
+    type: 8p8c
+    rear_port: '36'
+    rear_port_position: 1
+  - name: '37'
+    type: 8p8c
+    rear_port: '37'
+    rear_port_position: 1
+  - name: '38'
+    type: 8p8c
+    rear_port: '38'
+    rear_port_position: 1
+  - name: '39'
+    type: 8p8c
+    rear_port: '39'
+    rear_port_position: 1
+  - name: '40'
+    type: 8p8c
+    rear_port: '40'
+    rear_port_position: 1
+  - name: '41'
+    type: 8p8c
+    rear_port: '41'
+    rear_port_position: 1
+  - name: '42'
+    type: 8p8c
+    rear_port: '42'
+    rear_port_position: 1
+  - name: '43'
+    type: 8p8c
+    rear_port: '43'
+    rear_port_position: 1
+  - name: '44'
+    type: 8p8c
+    rear_port: '44'
+    rear_port_position: 1
+  - name: '45'
+    type: 8p8c
+    rear_port: '45'
+    rear_port_position: 1
+  - name: '46'
+    type: 8p8c
+    rear_port: '46'
+    rear_port_position: 1
+  - name: '47'
+    type: 8p8c
+    rear_port: '47'
+    rear_port_position: 1
+  - name: '48'
+    type: 8p8c
+    rear_port: '48'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 8p8c
+    positions: 1
+  - name: '02'
+    type: 8p8c
+    positions: 1
+  - name: '03'
+    type: 8p8c
+    positions: 1
+  - name: '04'
+    type: 8p8c
+    positions: 1
+  - name: '05'
+    type: 8p8c
+    positions: 1
+  - name: '06'
+    type: 8p8c
+    positions: 1
+  - name: '07'
+    type: 8p8c
+    positions: 1
+  - name: '08'
+    type: 8p8c
+    positions: 1
+  - name: '09'
+    type: 8p8c
+    positions: 1
+  - name: '10'
+    type: 8p8c
+    positions: 1
+  - name: '11'
+    type: 8p8c
+    positions: 1
+  - name: '12'
+    type: 8p8c
+    positions: 1
+  - name: '13'
+    type: 8p8c
+    positions: 1
+  - name: '14'
+    type: 8p8c
+    positions: 1
+  - name: '15'
+    type: 8p8c
+    positions: 1
+  - name: '16'
+    type: 8p8c
+    positions: 1
+  - name: '17'
+    type: 8p8c
+    positions: 1
+  - name: '18'
+    type: 8p8c
+    positions: 1
+  - name: '19'
+    type: 8p8c
+    positions: 1
+  - name: '20'
+    type: 8p8c
+    positions: 1
+  - name: '21'
+    type: 8p8c
+    positions: 1
+  - name: '22'
+    type: 8p8c
+    positions: 1
+  - name: '23'
+    type: 8p8c
+    positions: 1
+  - name: '24'
+    type: 8p8c
+    positions: 1
+  - name: '25'
+    type: 8p8c
+    positions: 1
+  - name: '26'
+    type: 8p8c
+    positions: 1
+  - name: '27'
+    type: 8p8c
+    positions: 1
+  - name: '28'
+    type: 8p8c
+    positions: 1
+  - name: '29'
+    type: 8p8c
+    positions: 1
+  - name: '30'
+    type: 8p8c
+    positions: 1
+  - name: '31'
+    type: 8p8c
+    positions: 1
+  - name: '32'
+    type: 8p8c
+    positions: 1
+  - name: '33'
+    type: 8p8c
+    positions: 1
+  - name: '34'
+    type: 8p8c
+    positions: 1
+  - name: '35'
+    type: 8p8c
+    positions: 1
+  - name: '36'
+    type: 8p8c
+    positions: 1
+  - name: '37'
+    type: 8p8c
+    positions: 1
+  - name: '38'
+    type: 8p8c
+    positions: 1
+  - name: '39'
+    type: 8p8c
+    positions: 1
+  - name: '40'
+    type: 8p8c
+    positions: 1
+  - name: '41'
+    type: 8p8c
+    positions: 1
+  - name: '42'
+    type: 8p8c
+    positions: 1
+  - name: '43'
+    type: 8p8c
+    positions: 1
+  - name: '44'
+    type: 8p8c
+    positions: 1
+  - name: '45'
+    type: 8p8c
+    positions: 1
+  - name: '46'
+    type: 8p8c
+    positions: 1
+  - name: '47'
+    type: 8p8c
+    positions: 1
+  - name: '48'
+    type: 8p8c
+    positions: 1

--- a/device-types/Panduit/CPP48FMWBLY.yaml
+++ b/device-types/Panduit/CPP48FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Patch Panel (48 Port, 2RU)
+model: Mini-Com Flush Mount Patch Panel (48 Port, 2RU)
 slug: cpp48fmwbly
 part_number: CPP48FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPP48FMWBLY.yaml
+++ b/device-types/Panduit/CPP48FMWBLY.yaml
@@ -201,146 +201,146 @@ front-ports:
 
 rear-ports:
   - name: '01'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '02'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '03'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '04'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '05'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '06'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '07'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '08'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '09'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '10'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '11'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '12'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '13'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '14'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '15'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '16'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '17'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '18'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '19'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '20'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '21'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '22'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '23'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '24'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '25'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '26'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '27'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '28'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '29'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '30'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '31'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '32'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '33'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '34'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '35'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '36'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '37'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '38'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '39'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '40'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '41'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '42'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '43'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '44'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '45'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '46'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '47'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '48'
-    type: 8p8c
+    type: 110-punch
     positions: 1

--- a/device-types/Panduit/CPP48HDEWBL.yaml
+++ b/device-types/Panduit/CPP48HDEWBL.yaml
@@ -1,9 +1,9 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Flush Mount Angled Patch Panel (48 Port, 2RU)
-slug: cppa48fmwbly
-part_number: CPPA48FMWBLY
-u_height: 2
+model: Mini-Com High Density Patch Panel (48 Port, 1RU)
+slug: cpp48hdewbl
+part_number: CPP48HDEWBL
+u_height: 1
 is_full_depth: false
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPP48WBLY.yaml
+++ b/device-types/Panduit/CPP48WBLY.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Flush Mount Angled Patch Panel (48 Port, 2RU)
-slug: cppa48fmwbly
-part_number: CPPA48FMWBLY
+model: Mini-Com Front Access Patch Panel (48 Port, 2RU)
+slug: cpp48wbly
+part_number: CPP48WBLY
 u_height: 2
 is_full_depth: false
 front-ports:

--- a/device-types/Panduit/CPP72FMWBLY.yaml
+++ b/device-types/Panduit/CPP72FMWBLY.yaml
@@ -297,218 +297,218 @@ front-ports:
 
 rear-ports:
   - name: '01'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '02'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '03'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '04'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '05'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '06'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '07'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '08'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '09'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '10'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '11'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '12'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '13'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '14'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '15'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '16'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '17'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '18'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '19'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '20'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '21'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '22'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '23'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '24'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '25'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '26'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '27'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '28'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '29'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '30'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '31'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '32'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '33'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '34'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '35'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '36'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '37'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '38'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '39'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '40'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '41'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '42'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '43'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '44'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '45'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '46'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '47'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '48'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '49'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '50'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '51'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '52'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '53'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '54'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '55'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '56'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '57'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '58'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '59'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '60'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '61'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '62'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '63'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '64'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '65'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '66'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '67'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '68'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '69'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '70'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '71'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '72'
-    type: 8p8c
+    type: 110-punch
     positions: 1

--- a/device-types/Panduit/CPP72FMWBLY.yaml
+++ b/device-types/Panduit/CPP72FMWBLY.yaml
@@ -1,0 +1,514 @@
+---
+manufacturer: Panduit
+model: Mini-Com Patch Panel (72 Port, 2RU)
+slug: cpp72fmwbly
+part_number: CPP72FMWBLY
+u_height: 2
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+  - name: '25'
+    type: 8p8c
+    rear_port: '25'
+    rear_port_position: 1
+  - name: '26'
+    type: 8p8c
+    rear_port: '26'
+    rear_port_position: 1
+  - name: '27'
+    type: 8p8c
+    rear_port: '27'
+    rear_port_position: 1
+  - name: '28'
+    type: 8p8c
+    rear_port: '28'
+    rear_port_position: 1
+  - name: '29'
+    type: 8p8c
+    rear_port: '29'
+    rear_port_position: 1
+  - name: '30'
+    type: 8p8c
+    rear_port: '30'
+    rear_port_position: 1
+  - name: '31'
+    type: 8p8c
+    rear_port: '31'
+    rear_port_position: 1
+  - name: '32'
+    type: 8p8c
+    rear_port: '32'
+    rear_port_position: 1
+  - name: '33'
+    type: 8p8c
+    rear_port: '33'
+    rear_port_position: 1
+  - name: '34'
+    type: 8p8c
+    rear_port: '34'
+    rear_port_position: 1
+  - name: '35'
+    type: 8p8c
+    rear_port: '35'
+    rear_port_position: 1
+  - name: '36'
+    type: 8p8c
+    rear_port: '36'
+    rear_port_position: 1
+  - name: '37'
+    type: 8p8c
+    rear_port: '37'
+    rear_port_position: 1
+  - name: '38'
+    type: 8p8c
+    rear_port: '38'
+    rear_port_position: 1
+  - name: '39'
+    type: 8p8c
+    rear_port: '39'
+    rear_port_position: 1
+  - name: '40'
+    type: 8p8c
+    rear_port: '40'
+    rear_port_position: 1
+  - name: '41'
+    type: 8p8c
+    rear_port: '41'
+    rear_port_position: 1
+  - name: '42'
+    type: 8p8c
+    rear_port: '42'
+    rear_port_position: 1
+  - name: '43'
+    type: 8p8c
+    rear_port: '43'
+    rear_port_position: 1
+  - name: '44'
+    type: 8p8c
+    rear_port: '44'
+    rear_port_position: 1
+  - name: '45'
+    type: 8p8c
+    rear_port: '45'
+    rear_port_position: 1
+  - name: '46'
+    type: 8p8c
+    rear_port: '46'
+    rear_port_position: 1
+  - name: '47'
+    type: 8p8c
+    rear_port: '47'
+    rear_port_position: 1
+  - name: '48'
+    type: 8p8c
+    rear_port: '48'
+    rear_port_position: 1
+  - name: '49'
+    type: 8p8c
+    rear_port: '49'
+    rear_port_position: 1
+  - name: '50'
+    type: 8p8c
+    rear_port: '50'
+    rear_port_position: 1
+  - name: '51'
+    type: 8p8c
+    rear_port: '51'
+    rear_port_position: 1
+  - name: '52'
+    type: 8p8c
+    rear_port: '52'
+    rear_port_position: 1
+  - name: '53'
+    type: 8p8c
+    rear_port: '53'
+    rear_port_position: 1
+  - name: '54'
+    type: 8p8c
+    rear_port: '54'
+    rear_port_position: 1
+  - name: '55'
+    type: 8p8c
+    rear_port: '55'
+    rear_port_position: 1
+  - name: '56'
+    type: 8p8c
+    rear_port: '56'
+    rear_port_position: 1
+  - name: '57'
+    type: 8p8c
+    rear_port: '57'
+    rear_port_position: 1
+  - name: '58'
+    type: 8p8c
+    rear_port: '58'
+    rear_port_position: 1
+  - name: '59'
+    type: 8p8c
+    rear_port: '59'
+    rear_port_position: 1
+  - name: '60'
+    type: 8p8c
+    rear_port: '60'
+    rear_port_position: 1
+  - name: '61'
+    type: 8p8c
+    rear_port: '61'
+    rear_port_position: 1
+  - name: '62'
+    type: 8p8c
+    rear_port: '62'
+    rear_port_position: 1
+  - name: '63'
+    type: 8p8c
+    rear_port: '63'
+    rear_port_position: 1
+  - name: '64'
+    type: 8p8c
+    rear_port: '64'
+    rear_port_position: 1
+  - name: '65'
+    type: 8p8c
+    rear_port: '65'
+    rear_port_position: 1
+  - name: '66'
+    type: 8p8c
+    rear_port: '66'
+    rear_port_position: 1
+  - name: '67'
+    type: 8p8c
+    rear_port: '67'
+    rear_port_position: 1
+  - name: '68'
+    type: 8p8c
+    rear_port: '68'
+    rear_port_position: 1
+  - name: '69'
+    type: 8p8c
+    rear_port: '69'
+    rear_port_position: 1
+  - name: '70'
+    type: 8p8c
+    rear_port: '70'
+    rear_port_position: 1
+  - name: '71'
+    type: 8p8c
+    rear_port: '71'
+    rear_port_position: 1
+  - name: '72'
+    type: 8p8c
+    rear_port: '72'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 8p8c
+    positions: 1
+  - name: '02'
+    type: 8p8c
+    positions: 1
+  - name: '03'
+    type: 8p8c
+    positions: 1
+  - name: '04'
+    type: 8p8c
+    positions: 1
+  - name: '05'
+    type: 8p8c
+    positions: 1
+  - name: '06'
+    type: 8p8c
+    positions: 1
+  - name: '07'
+    type: 8p8c
+    positions: 1
+  - name: '08'
+    type: 8p8c
+    positions: 1
+  - name: '09'
+    type: 8p8c
+    positions: 1
+  - name: '10'
+    type: 8p8c
+    positions: 1
+  - name: '11'
+    type: 8p8c
+    positions: 1
+  - name: '12'
+    type: 8p8c
+    positions: 1
+  - name: '13'
+    type: 8p8c
+    positions: 1
+  - name: '14'
+    type: 8p8c
+    positions: 1
+  - name: '15'
+    type: 8p8c
+    positions: 1
+  - name: '16'
+    type: 8p8c
+    positions: 1
+  - name: '17'
+    type: 8p8c
+    positions: 1
+  - name: '18'
+    type: 8p8c
+    positions: 1
+  - name: '19'
+    type: 8p8c
+    positions: 1
+  - name: '20'
+    type: 8p8c
+    positions: 1
+  - name: '21'
+    type: 8p8c
+    positions: 1
+  - name: '22'
+    type: 8p8c
+    positions: 1
+  - name: '23'
+    type: 8p8c
+    positions: 1
+  - name: '24'
+    type: 8p8c
+    positions: 1
+  - name: '25'
+    type: 8p8c
+    positions: 1
+  - name: '26'
+    type: 8p8c
+    positions: 1
+  - name: '27'
+    type: 8p8c
+    positions: 1
+  - name: '28'
+    type: 8p8c
+    positions: 1
+  - name: '29'
+    type: 8p8c
+    positions: 1
+  - name: '30'
+    type: 8p8c
+    positions: 1
+  - name: '31'
+    type: 8p8c
+    positions: 1
+  - name: '32'
+    type: 8p8c
+    positions: 1
+  - name: '33'
+    type: 8p8c
+    positions: 1
+  - name: '34'
+    type: 8p8c
+    positions: 1
+  - name: '35'
+    type: 8p8c
+    positions: 1
+  - name: '36'
+    type: 8p8c
+    positions: 1
+  - name: '37'
+    type: 8p8c
+    positions: 1
+  - name: '38'
+    type: 8p8c
+    positions: 1
+  - name: '39'
+    type: 8p8c
+    positions: 1
+  - name: '40'
+    type: 8p8c
+    positions: 1
+  - name: '41'
+    type: 8p8c
+    positions: 1
+  - name: '42'
+    type: 8p8c
+    positions: 1
+  - name: '43'
+    type: 8p8c
+    positions: 1
+  - name: '44'
+    type: 8p8c
+    positions: 1
+  - name: '45'
+    type: 8p8c
+    positions: 1
+  - name: '46'
+    type: 8p8c
+    positions: 1
+  - name: '47'
+    type: 8p8c
+    positions: 1
+  - name: '48'
+    type: 8p8c
+    positions: 1
+  - name: '49'
+    type: 8p8c
+    positions: 1
+  - name: '50'
+    type: 8p8c
+    positions: 1
+  - name: '51'
+    type: 8p8c
+    positions: 1
+  - name: '52'
+    type: 8p8c
+    positions: 1
+  - name: '53'
+    type: 8p8c
+    positions: 1
+  - name: '54'
+    type: 8p8c
+    positions: 1
+  - name: '55'
+    type: 8p8c
+    positions: 1
+  - name: '56'
+    type: 8p8c
+    positions: 1
+  - name: '57'
+    type: 8p8c
+    positions: 1
+  - name: '58'
+    type: 8p8c
+    positions: 1
+  - name: '59'
+    type: 8p8c
+    positions: 1
+  - name: '60'
+    type: 8p8c
+    positions: 1
+  - name: '61'
+    type: 8p8c
+    positions: 1
+  - name: '62'
+    type: 8p8c
+    positions: 1
+  - name: '63'
+    type: 8p8c
+    positions: 1
+  - name: '64'
+    type: 8p8c
+    positions: 1
+  - name: '65'
+    type: 8p8c
+    positions: 1
+  - name: '66'
+    type: 8p8c
+    positions: 1
+  - name: '67'
+    type: 8p8c
+    positions: 1
+  - name: '68'
+    type: 8p8c
+    positions: 1
+  - name: '69'
+    type: 8p8c
+    positions: 1
+  - name: '70'
+    type: 8p8c
+    positions: 1
+  - name: '71'
+    type: 8p8c
+    positions: 1
+  - name: '72'
+    type: 8p8c
+    positions: 1

--- a/device-types/Panduit/CPP72FMWBLY.yaml
+++ b/device-types/Panduit/CPP72FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Patch Panel (72 Port, 2RU)
+model: Mini-Com Flush Mount Patch Panel (72 Port, 2RU)
 slug: cpp72fmwbly
 part_number: CPP72FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPPA24FMWBLY.yaml
+++ b/device-types/Panduit/CPPA24FMWBLY.yaml
@@ -1,0 +1,178 @@
+---
+manufacturer: Panduit
+model: CPPA24FMWBLY
+slug: cppa24fmwbly
+part_number: CPPA24FMWBLY
+u_height: 2
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 8p8c
+    positions: 1
+  - name: '02'
+    type: 8p8c
+    positions: 1
+  - name: '03'
+    type: 8p8c
+    positions: 1
+  - name: '04'
+    type: 8p8c
+    positions: 1
+  - name: '05'
+    type: 8p8c
+    positions: 1
+  - name: '06'
+    type: 8p8c
+    positions: 1
+  - name: '07'
+    type: 8p8c
+    positions: 1
+  - name: '08'
+    type: 8p8c
+    positions: 1
+  - name: '09'
+    type: 8p8c
+    positions: 1
+  - name: '10'
+    type: 8p8c
+    positions: 1
+  - name: '11'
+    type: 8p8c
+    positions: 1
+  - name: '12'
+    type: 8p8c
+    positions: 1
+  - name: '13'
+    type: 8p8c
+    positions: 1
+  - name: '14'
+    type: 8p8c
+    positions: 1
+  - name: '15'
+    type: 8p8c
+    positions: 1
+  - name: '16'
+    type: 8p8c
+    positions: 1
+  - name: '17'
+    type: 8p8c
+    positions: 1
+  - name: '18'
+    type: 8p8c
+    positions: 1
+  - name: '19'
+    type: 8p8c
+    positions: 1
+  - name: '20'
+    type: 8p8c
+    positions: 1
+  - name: '21'
+    type: 8p8c
+    positions: 1
+  - name: '22'
+    type: 8p8c
+    positions: 1
+  - name: '23'
+    type: 8p8c
+    positions: 1
+  - name: '24'
+    type: 8p8c
+    positions: 1

--- a/device-types/Panduit/CPPA24FMWBLY.yaml
+++ b/device-types/Panduit/CPPA24FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Angled Patch Panel (24 Port, 1RU)
+model: Mini-Com Flush Mount Angled Patch Panel (24 Port, 1RU)
 slug: cppa24fmwbly
 part_number: CPPA24FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPPA24FMWBLY.yaml
+++ b/device-types/Panduit/CPPA24FMWBLY.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Mini-Com Flush Mount Angled Patch Panel (24 Port, 1RU)
 slug: cppa24fmwbly
 part_number: CPPA24FMWBLY
-u_height: 2
+u_height: 1
 is_full_depth: false
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPPA24FMWBLY.yaml
+++ b/device-types/Panduit/CPPA24FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: CPPA24FMWBLY
+model: Mini-Com Angled Patch Panel (24 Port, 1RU)
 slug: cppa24fmwbly
 part_number: CPPA24FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPPA48FMWBLY.yaml
+++ b/device-types/Panduit/CPPA48FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: CPPA48FMWBLY
+model: Mini-Com Angled Patch Panel (48 Port, 2RU)
 slug: cppa48fmwbly
 part_number: CPPA48FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPPA48FMWBLY.yaml
+++ b/device-types/Panduit/CPPA48FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Angled Patch Panel (48 Port, 2RU)
+model: Mini-Com Flush Mount Angled Patch Panel (48 Port, 2RU)
 slug: cppa48fmwbly
 part_number: CPPA48FMWBLY
 u_height: 2

--- a/device-types/Panduit/CPPA48FMWBLY.yaml
+++ b/device-types/Panduit/CPPA48FMWBLY.yaml
@@ -1,0 +1,346 @@
+---
+manufacturer: Panduit
+model: CPPA48FMWBLY
+slug: cppa48fmwbly
+part_number: CPPA48FMWBLY
+u_height: 2
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+  - name: '25'
+    type: 8p8c
+    rear_port: '25'
+    rear_port_position: 1
+  - name: '26'
+    type: 8p8c
+    rear_port: '26'
+    rear_port_position: 1
+  - name: '27'
+    type: 8p8c
+    rear_port: '27'
+    rear_port_position: 1
+  - name: '28'
+    type: 8p8c
+    rear_port: '28'
+    rear_port_position: 1
+  - name: '29'
+    type: 8p8c
+    rear_port: '29'
+    rear_port_position: 1
+  - name: '30'
+    type: 8p8c
+    rear_port: '30'
+    rear_port_position: 1
+  - name: '31'
+    type: 8p8c
+    rear_port: '31'
+    rear_port_position: 1
+  - name: '32'
+    type: 8p8c
+    rear_port: '32'
+    rear_port_position: 1
+  - name: '33'
+    type: 8p8c
+    rear_port: '33'
+    rear_port_position: 1
+  - name: '34'
+    type: 8p8c
+    rear_port: '34'
+    rear_port_position: 1
+  - name: '35'
+    type: 8p8c
+    rear_port: '35'
+    rear_port_position: 1
+  - name: '36'
+    type: 8p8c
+    rear_port: '36'
+    rear_port_position: 1
+  - name: '37'
+    type: 8p8c
+    rear_port: '37'
+    rear_port_position: 1
+  - name: '38'
+    type: 8p8c
+    rear_port: '38'
+    rear_port_position: 1
+  - name: '39'
+    type: 8p8c
+    rear_port: '39'
+    rear_port_position: 1
+  - name: '40'
+    type: 8p8c
+    rear_port: '40'
+    rear_port_position: 1
+  - name: '41'
+    type: 8p8c
+    rear_port: '41'
+    rear_port_position: 1
+  - name: '42'
+    type: 8p8c
+    rear_port: '42'
+    rear_port_position: 1
+  - name: '43'
+    type: 8p8c
+    rear_port: '43'
+    rear_port_position: 1
+  - name: '44'
+    type: 8p8c
+    rear_port: '44'
+    rear_port_position: 1
+  - name: '45'
+    type: 8p8c
+    rear_port: '45'
+    rear_port_position: 1
+  - name: '46'
+    type: 8p8c
+    rear_port: '46'
+    rear_port_position: 1
+  - name: '47'
+    type: 8p8c
+    rear_port: '47'
+    rear_port_position: 1
+  - name: '48'
+    type: 8p8c
+    rear_port: '48'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 8p8c
+    positions: 1
+  - name: '02'
+    type: 8p8c
+    positions: 1
+  - name: '03'
+    type: 8p8c
+    positions: 1
+  - name: '04'
+    type: 8p8c
+    positions: 1
+  - name: '05'
+    type: 8p8c
+    positions: 1
+  - name: '06'
+    type: 8p8c
+    positions: 1
+  - name: '07'
+    type: 8p8c
+    positions: 1
+  - name: '08'
+    type: 8p8c
+    positions: 1
+  - name: '09'
+    type: 8p8c
+    positions: 1
+  - name: '10'
+    type: 8p8c
+    positions: 1
+  - name: '11'
+    type: 8p8c
+    positions: 1
+  - name: '12'
+    type: 8p8c
+    positions: 1
+  - name: '13'
+    type: 8p8c
+    positions: 1
+  - name: '14'
+    type: 8p8c
+    positions: 1
+  - name: '15'
+    type: 8p8c
+    positions: 1
+  - name: '16'
+    type: 8p8c
+    positions: 1
+  - name: '17'
+    type: 8p8c
+    positions: 1
+  - name: '18'
+    type: 8p8c
+    positions: 1
+  - name: '19'
+    type: 8p8c
+    positions: 1
+  - name: '20'
+    type: 8p8c
+    positions: 1
+  - name: '21'
+    type: 8p8c
+    positions: 1
+  - name: '22'
+    type: 8p8c
+    positions: 1
+  - name: '23'
+    type: 8p8c
+    positions: 1
+  - name: '24'
+    type: 8p8c
+    positions: 1
+  - name: '25'
+    type: 8p8c
+    positions: 1
+  - name: '26'
+    type: 8p8c
+    positions: 1
+  - name: '27'
+    type: 8p8c
+    positions: 1
+  - name: '28'
+    type: 8p8c
+    positions: 1
+  - name: '29'
+    type: 8p8c
+    positions: 1
+  - name: '30'
+    type: 8p8c
+    positions: 1
+  - name: '31'
+    type: 8p8c
+    positions: 1
+  - name: '32'
+    type: 8p8c
+    positions: 1
+  - name: '33'
+    type: 8p8c
+    positions: 1
+  - name: '34'
+    type: 8p8c
+    positions: 1
+  - name: '35'
+    type: 8p8c
+    positions: 1
+  - name: '36'
+    type: 8p8c
+    positions: 1
+  - name: '37'
+    type: 8p8c
+    positions: 1
+  - name: '38'
+    type: 8p8c
+    positions: 1
+  - name: '39'
+    type: 8p8c
+    positions: 1
+  - name: '40'
+    type: 8p8c
+    positions: 1
+  - name: '41'
+    type: 8p8c
+    positions: 1
+  - name: '42'
+    type: 8p8c
+    positions: 1
+  - name: '43'
+    type: 8p8c
+    positions: 1
+  - name: '44'
+    type: 8p8c
+    positions: 1
+  - name: '45'
+    type: 8p8c
+    positions: 1
+  - name: '46'
+    type: 8p8c
+    positions: 1
+  - name: '47'
+    type: 8p8c
+    positions: 1
+  - name: '48'
+    type: 8p8c
+    positions: 1

--- a/device-types/Panduit/CPPA48HDWBLY.yaml
+++ b/device-types/Panduit/CPPA48HDWBLY.yaml
@@ -1,9 +1,9 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Flush Mount Angled Patch Panel (48 Port, 2RU)
-slug: cppa48fmwbly
-part_number: CPPA48FMWBLY
-u_height: 2
+model: Mini-Com High Density Angled Patch Panel (48 Port, 1RU)
+slug: cppa48hdwbly
+part_number: CPPA48HDWBLY
+u_height: 1
 is_full_depth: false
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPPA72FMWBLY.yaml
+++ b/device-types/Panduit/CPPA72FMWBLY.yaml
@@ -297,218 +297,218 @@ front-ports:
 
 rear-ports:
   - name: '01'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '02'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '03'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '04'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '05'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '06'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '07'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '08'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '09'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '10'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '11'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '12'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '13'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '14'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '15'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '16'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '17'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '18'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '19'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '20'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '21'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '22'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '23'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '24'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '25'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '26'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '27'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '28'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '29'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '30'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '31'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '32'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '33'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '34'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '35'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '36'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '37'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '38'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '39'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '40'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '41'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '42'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '43'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '44'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '45'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '46'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '47'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '48'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '49'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '50'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '51'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '52'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '53'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '54'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '55'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '56'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '57'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '58'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '59'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '60'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '61'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '62'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '63'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '64'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '65'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '66'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '67'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '68'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '69'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '70'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '71'
-    type: 8p8c
+    type: 110-punch
     positions: 1
   - name: '72'
-    type: 8p8c
+    type: 110-punch
     positions: 1

--- a/device-types/Panduit/CPPA72FMWBLY.yaml
+++ b/device-types/Panduit/CPPA72FMWBLY.yaml
@@ -1,0 +1,514 @@
+---
+manufacturer: Panduit
+model: Mini-Com Angled Patch Panel (72 Port, 2RU)
+slug: cppa72fmwbly
+part_number: CPPA72FMWBLY
+u_height: 2
+is_full_depth: false
+front-ports:
+  - name: '01'
+    type: 8p8c
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: 8p8c
+    rear_port: '02'
+    rear_port_position: 1
+  - name: '03'
+    type: 8p8c
+    rear_port: '03'
+    rear_port_position: 1
+  - name: '04'
+    type: 8p8c
+    rear_port: '04'
+    rear_port_position: 1
+  - name: '05'
+    type: 8p8c
+    rear_port: '05'
+    rear_port_position: 1
+  - name: '06'
+    type: 8p8c
+    rear_port: '06'
+    rear_port_position: 1
+  - name: '07'
+    type: 8p8c
+    rear_port: '07'
+    rear_port_position: 1
+  - name: 08
+    type: 8p8c
+    rear_port: 08
+    rear_port_position: 1
+  - name: 09
+    type: 8p8c
+    rear_port: 09
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+  - name: '25'
+    type: 8p8c
+    rear_port: '25'
+    rear_port_position: 1
+  - name: '26'
+    type: 8p8c
+    rear_port: '26'
+    rear_port_position: 1
+  - name: '27'
+    type: 8p8c
+    rear_port: '27'
+    rear_port_position: 1
+  - name: '28'
+    type: 8p8c
+    rear_port: '28'
+    rear_port_position: 1
+  - name: '29'
+    type: 8p8c
+    rear_port: '29'
+    rear_port_position: 1
+  - name: '30'
+    type: 8p8c
+    rear_port: '30'
+    rear_port_position: 1
+  - name: '31'
+    type: 8p8c
+    rear_port: '31'
+    rear_port_position: 1
+  - name: '32'
+    type: 8p8c
+    rear_port: '32'
+    rear_port_position: 1
+  - name: '33'
+    type: 8p8c
+    rear_port: '33'
+    rear_port_position: 1
+  - name: '34'
+    type: 8p8c
+    rear_port: '34'
+    rear_port_position: 1
+  - name: '35'
+    type: 8p8c
+    rear_port: '35'
+    rear_port_position: 1
+  - name: '36'
+    type: 8p8c
+    rear_port: '36'
+    rear_port_position: 1
+  - name: '37'
+    type: 8p8c
+    rear_port: '37'
+    rear_port_position: 1
+  - name: '38'
+    type: 8p8c
+    rear_port: '38'
+    rear_port_position: 1
+  - name: '39'
+    type: 8p8c
+    rear_port: '39'
+    rear_port_position: 1
+  - name: '40'
+    type: 8p8c
+    rear_port: '40'
+    rear_port_position: 1
+  - name: '41'
+    type: 8p8c
+    rear_port: '41'
+    rear_port_position: 1
+  - name: '42'
+    type: 8p8c
+    rear_port: '42'
+    rear_port_position: 1
+  - name: '43'
+    type: 8p8c
+    rear_port: '43'
+    rear_port_position: 1
+  - name: '44'
+    type: 8p8c
+    rear_port: '44'
+    rear_port_position: 1
+  - name: '45'
+    type: 8p8c
+    rear_port: '45'
+    rear_port_position: 1
+  - name: '46'
+    type: 8p8c
+    rear_port: '46'
+    rear_port_position: 1
+  - name: '47'
+    type: 8p8c
+    rear_port: '47'
+    rear_port_position: 1
+  - name: '48'
+    type: 8p8c
+    rear_port: '48'
+    rear_port_position: 1
+  - name: '49'
+    type: 8p8c
+    rear_port: '49'
+    rear_port_position: 1
+  - name: '50'
+    type: 8p8c
+    rear_port: '50'
+    rear_port_position: 1
+  - name: '51'
+    type: 8p8c
+    rear_port: '51'
+    rear_port_position: 1
+  - name: '52'
+    type: 8p8c
+    rear_port: '52'
+    rear_port_position: 1
+  - name: '53'
+    type: 8p8c
+    rear_port: '53'
+    rear_port_position: 1
+  - name: '54'
+    type: 8p8c
+    rear_port: '54'
+    rear_port_position: 1
+  - name: '55'
+    type: 8p8c
+    rear_port: '55'
+    rear_port_position: 1
+  - name: '56'
+    type: 8p8c
+    rear_port: '56'
+    rear_port_position: 1
+  - name: '57'
+    type: 8p8c
+    rear_port: '57'
+    rear_port_position: 1
+  - name: '58'
+    type: 8p8c
+    rear_port: '58'
+    rear_port_position: 1
+  - name: '59'
+    type: 8p8c
+    rear_port: '59'
+    rear_port_position: 1
+  - name: '60'
+    type: 8p8c
+    rear_port: '60'
+    rear_port_position: 1
+  - name: '61'
+    type: 8p8c
+    rear_port: '61'
+    rear_port_position: 1
+  - name: '62'
+    type: 8p8c
+    rear_port: '62'
+    rear_port_position: 1
+  - name: '63'
+    type: 8p8c
+    rear_port: '63'
+    rear_port_position: 1
+  - name: '64'
+    type: 8p8c
+    rear_port: '64'
+    rear_port_position: 1
+  - name: '65'
+    type: 8p8c
+    rear_port: '65'
+    rear_port_position: 1
+  - name: '66'
+    type: 8p8c
+    rear_port: '66'
+    rear_port_position: 1
+  - name: '67'
+    type: 8p8c
+    rear_port: '67'
+    rear_port_position: 1
+  - name: '68'
+    type: 8p8c
+    rear_port: '68'
+    rear_port_position: 1
+  - name: '69'
+    type: 8p8c
+    rear_port: '69'
+    rear_port_position: 1
+  - name: '70'
+    type: 8p8c
+    rear_port: '70'
+    rear_port_position: 1
+  - name: '71'
+    type: 8p8c
+    rear_port: '71'
+    rear_port_position: 1
+  - name: '72'
+    type: 8p8c
+    rear_port: '72'
+    rear_port_position: 1
+
+rear-ports:
+  - name: '01'
+    type: 8p8c
+    positions: 1
+  - name: '02'
+    type: 8p8c
+    positions: 1
+  - name: '03'
+    type: 8p8c
+    positions: 1
+  - name: '04'
+    type: 8p8c
+    positions: 1
+  - name: '05'
+    type: 8p8c
+    positions: 1
+  - name: '06'
+    type: 8p8c
+    positions: 1
+  - name: '07'
+    type: 8p8c
+    positions: 1
+  - name: '08'
+    type: 8p8c
+    positions: 1
+  - name: '09'
+    type: 8p8c
+    positions: 1
+  - name: '10'
+    type: 8p8c
+    positions: 1
+  - name: '11'
+    type: 8p8c
+    positions: 1
+  - name: '12'
+    type: 8p8c
+    positions: 1
+  - name: '13'
+    type: 8p8c
+    positions: 1
+  - name: '14'
+    type: 8p8c
+    positions: 1
+  - name: '15'
+    type: 8p8c
+    positions: 1
+  - name: '16'
+    type: 8p8c
+    positions: 1
+  - name: '17'
+    type: 8p8c
+    positions: 1
+  - name: '18'
+    type: 8p8c
+    positions: 1
+  - name: '19'
+    type: 8p8c
+    positions: 1
+  - name: '20'
+    type: 8p8c
+    positions: 1
+  - name: '21'
+    type: 8p8c
+    positions: 1
+  - name: '22'
+    type: 8p8c
+    positions: 1
+  - name: '23'
+    type: 8p8c
+    positions: 1
+  - name: '24'
+    type: 8p8c
+    positions: 1
+  - name: '25'
+    type: 8p8c
+    positions: 1
+  - name: '26'
+    type: 8p8c
+    positions: 1
+  - name: '27'
+    type: 8p8c
+    positions: 1
+  - name: '28'
+    type: 8p8c
+    positions: 1
+  - name: '29'
+    type: 8p8c
+    positions: 1
+  - name: '30'
+    type: 8p8c
+    positions: 1
+  - name: '31'
+    type: 8p8c
+    positions: 1
+  - name: '32'
+    type: 8p8c
+    positions: 1
+  - name: '33'
+    type: 8p8c
+    positions: 1
+  - name: '34'
+    type: 8p8c
+    positions: 1
+  - name: '35'
+    type: 8p8c
+    positions: 1
+  - name: '36'
+    type: 8p8c
+    positions: 1
+  - name: '37'
+    type: 8p8c
+    positions: 1
+  - name: '38'
+    type: 8p8c
+    positions: 1
+  - name: '39'
+    type: 8p8c
+    positions: 1
+  - name: '40'
+    type: 8p8c
+    positions: 1
+  - name: '41'
+    type: 8p8c
+    positions: 1
+  - name: '42'
+    type: 8p8c
+    positions: 1
+  - name: '43'
+    type: 8p8c
+    positions: 1
+  - name: '44'
+    type: 8p8c
+    positions: 1
+  - name: '45'
+    type: 8p8c
+    positions: 1
+  - name: '46'
+    type: 8p8c
+    positions: 1
+  - name: '47'
+    type: 8p8c
+    positions: 1
+  - name: '48'
+    type: 8p8c
+    positions: 1
+  - name: '49'
+    type: 8p8c
+    positions: 1
+  - name: '50'
+    type: 8p8c
+    positions: 1
+  - name: '51'
+    type: 8p8c
+    positions: 1
+  - name: '52'
+    type: 8p8c
+    positions: 1
+  - name: '53'
+    type: 8p8c
+    positions: 1
+  - name: '54'
+    type: 8p8c
+    positions: 1
+  - name: '55'
+    type: 8p8c
+    positions: 1
+  - name: '56'
+    type: 8p8c
+    positions: 1
+  - name: '57'
+    type: 8p8c
+    positions: 1
+  - name: '58'
+    type: 8p8c
+    positions: 1
+  - name: '59'
+    type: 8p8c
+    positions: 1
+  - name: '60'
+    type: 8p8c
+    positions: 1
+  - name: '61'
+    type: 8p8c
+    positions: 1
+  - name: '62'
+    type: 8p8c
+    positions: 1
+  - name: '63'
+    type: 8p8c
+    positions: 1
+  - name: '64'
+    type: 8p8c
+    positions: 1
+  - name: '65'
+    type: 8p8c
+    positions: 1
+  - name: '66'
+    type: 8p8c
+    positions: 1
+  - name: '67'
+    type: 8p8c
+    positions: 1
+  - name: '68'
+    type: 8p8c
+    positions: 1
+  - name: '69'
+    type: 8p8c
+    positions: 1
+  - name: '70'
+    type: 8p8c
+    positions: 1
+  - name: '71'
+    type: 8p8c
+    positions: 1
+  - name: '72'
+    type: 8p8c
+    positions: 1

--- a/device-types/Panduit/CPPA72FMWBLY.yaml
+++ b/device-types/Panduit/CPPA72FMWBLY.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Panduit
-model: Mini-Com Angled Patch Panel (72 Port, 2RU)
+model: Mini-Com Flush Mount Angled Patch Panel (72 Port, 2RU)
 slug: cppa72fmwbly
 part_number: CPPA72FMWBLY
 u_height: 2

--- a/device-types/Panduit/FAP12WAGDLCZ.yaml
+++ b/device-types/Panduit/FAP12WAGDLCZ.yaml
@@ -1,0 +1,61 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (12 LC Duplex APC/24 Strand, Green)
+slug: fap12wagdlcz
+part_number: FAP12WAGDLCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+  - name: '07'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 7
+  - name: '08'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 8
+  - name: '09'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 9
+  - name: '10'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 10
+  - name: '11'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 11
+  - name: '12'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 12
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 12

--- a/device-types/Panduit/FAP12WAGDLCZ.yaml
+++ b/device-types/Panduit/FAP12WAGDLCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (12 LC Duplex APC/24 Strand, Green)
 slug: fap12wagdlcz
 part_number: FAP12WAGDLCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:

--- a/device-types/Panduit/FAP12WAQDLCZ.yaml
+++ b/device-types/Panduit/FAP12WAQDLCZ.yaml
@@ -1,0 +1,61 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (12 LC Duplex/24 Strand, Aqua)
+slug: fap12waqdlcz
+part_number: FAP12WAQDLCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+  - name: '07'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 7
+  - name: '08'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 8
+  - name: '09'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 9
+  - name: '10'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 10
+  - name: '11'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 11
+  - name: '12'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 12
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 12

--- a/device-types/Panduit/FAP12WAQDLCZ.yaml
+++ b/device-types/Panduit/FAP12WAQDLCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (12 LC Duplex/24 Strand, Aqua)
 slug: fap12waqdlcz
 part_number: FAP12WAQDLCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:

--- a/device-types/Panduit/FAP12WBUDLCZ.yaml
+++ b/device-types/Panduit/FAP12WBUDLCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (12 LC Duplex/24 Strand, Blue)
 slug: fap12wbudlcz
 part_number: FAP12WBUDLCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:

--- a/device-types/Panduit/FAP12WBUDLCZ.yaml
+++ b/device-types/Panduit/FAP12WBUDLCZ.yaml
@@ -1,0 +1,61 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (12 LC Duplex/24 Strand, Blue)
+slug: fap12wbudlcz
+part_number: FAP12WBUDLCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+  - name: '07'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 7
+  - name: '08'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 8
+  - name: '09'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 9
+  - name: '10'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 10
+  - name: '11'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 11
+  - name: '12'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 12
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 12

--- a/device-types/Panduit/FAP12WBULCZ.yaml
+++ b/device-types/Panduit/FAP12WBULCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (12 LC Simplex/12 Strand, Blue)
 slug: fap12wbulcz
 part_number: FAP12WBULCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:
@@ -31,6 +31,10 @@ front-ports:
     type: lc
     rear_port: '01'
     rear_port_position: 6
+  - name: '07'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 7
   - name: '08'
     type: lc
     rear_port: '01'

--- a/device-types/Panduit/FAP12WBULCZ.yaml
+++ b/device-types/Panduit/FAP12WBULCZ.yaml
@@ -1,0 +1,57 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (12 LC Simplex/12 Strand, Blue)
+slug: fap12wbulcz
+part_number: FAP12WBULCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+  - name: '08'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 8
+  - name: '09'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 9
+  - name: '10'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 10
+  - name: '11'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 11
+  - name: '12'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 12
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 12

--- a/device-types/Panduit/FAP6WAGDLCZ.yaml
+++ b/device-types/Panduit/FAP6WAGDLCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (6 LC Duplex APC/12 Strand, Green)
 slug: fap6wagdlcz
 part_number: FAP6WAGDLCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:

--- a/device-types/Panduit/FAP6WAGDLCZ.yaml
+++ b/device-types/Panduit/FAP6WAGDLCZ.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (6 LC Duplex APC/12 Strand, Green)
+slug: fap6wagdlcz
+part_number: FAP6WAGDLCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 6

--- a/device-types/Panduit/FAP6WAQDLCZ.yaml
+++ b/device-types/Panduit/FAP6WAQDLCZ.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (6 LC Duplex/12 Strand, Aqua)
+slug: fap6waqdlcz
+part_number: FAP6WAQDLCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 6

--- a/device-types/Panduit/FAP6WAQDLCZ.yaml
+++ b/device-types/Panduit/FAP6WAQDLCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (6 LC Duplex/12 Strand, Aqua)
 slug: fap6waqdlcz
 part_number: FAP6WAQDLCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:

--- a/device-types/Panduit/FAP6WBUDLCZ.yaml
+++ b/device-types/Panduit/FAP6WBUDLCZ.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (6 LC Duplex/12 Strand, Blue)
+slug: fap6wbudlcz
+part_number: FAP6WBUDLCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 6

--- a/device-types/Panduit/FAP6WBUDLCZ.yaml
+++ b/device-types/Panduit/FAP6WBUDLCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (6 LC Duplex/12 Strand, Blue)
 slug: fap6wbudlcz
 part_number: FAP6WBUDLCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:

--- a/device-types/Panduit/FAP8WAQDLCZ.yaml
+++ b/device-types/Panduit/FAP8WAQDLCZ.yaml
@@ -1,0 +1,45 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (8 LC Duplex/16 Strand, Aqua)
+slug: fap8waqdlcz
+part_number: FAP8WAQDLCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+  - name: '07'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 7
+  - name: '08'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 8
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 8

--- a/device-types/Panduit/FAP8WAQDLCZ.yaml
+++ b/device-types/Panduit/FAP8WAQDLCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (8 LC Duplex/16 Strand, Aqua)
 slug: fap8waqdlcz
 part_number: FAP8WAQDLCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:

--- a/device-types/Panduit/FAP8WBUDLCZ.yaml
+++ b/device-types/Panduit/FAP8WBUDLCZ.yaml
@@ -1,0 +1,45 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Adapter Panel (8 LC Duplex/16 Strand, Blue)
+slug: fap8wbudlcz
+part_number: FAP8WBUDLCZ
+u_height: 1
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '01'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 1
+  - name: '02'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 2
+  - name: '03'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 3
+  - name: '04'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 4
+  - name: '05'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 5
+  - name: '06'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 6
+  - name: '07'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 7
+  - name: '08'
+    type: lc
+    rear_port: '01'
+    rear_port_position: 8
+rear-ports:
+  - name: '01'
+    type: lc
+    positions: 8

--- a/device-types/Panduit/FAP8WBUDLCZ.yaml
+++ b/device-types/Panduit/FAP8WBUDLCZ.yaml
@@ -3,7 +3,7 @@ manufacturer: Panduit
 model: Opticom Fiber Adapter Panel (8 LC Duplex/16 Strand, Blue)
 slug: fap8wbudlcz
 part_number: FAP8WBUDLCZ
-u_height: 1
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 front-ports:

--- a/device-types/Panduit/FMD1.yaml
+++ b/device-types/Panduit/FMD1.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Drawer (4 Adapters, 1RU)
+slug: fmd1
+part_number: FMD1
+u_height: 1
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: '01'
+  - name: '02'
+  - name: '03'
+  - name: '04'

--- a/device-types/Panduit/FMD2.yaml
+++ b/device-types/Panduit/FMD2.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Panduit
+model: Opticom Fiber Drawer (8 Adapters, 2RU)
+slug: fmd2
+part_number: FMD2
+u_height: 2
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: '01'
+  - name: '02'
+  - name: '03'
+  - name: '04'
+  - name: '05'
+  - name: '06'
+  - name: '07'
+  - name: '08'

--- a/device-types/Panduit/FWME2.yaml
+++ b/device-types/Panduit/FWME2.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Panduit
+model: Opticom Wallmount Fiber Enclosure (2 Adapters)
+slug: fwme2
+part_number: FWME2
+u_height: 0
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: '01'
+  - name: '02'

--- a/device-types/Panduit/FWME4.yaml
+++ b/device-types/Panduit/FWME4.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: Panduit
+model: Opticom Wallmount Fiber Enclosure (4 Adapters)
+slug: fwme4
+part_number: FWME4
+u_height: 0
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: '01'
+  - name: '02'
+  - name: '03'
+  - name: '04'

--- a/device-types/Panduit/FWME8.yaml
+++ b/device-types/Panduit/FWME8.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Panduit
+model: Opticom Wallmount Fiber Enclosure (8 Adapters)
+slug: fwme8
+part_number: FWME8
+u_height: 0
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: '01'
+  - name: '02'
+  - name: '03'
+  - name: '04'
+  - name: '05'
+  - name: '06'
+  - name: '07'
+  - name: '08'


### PR DESCRIPTION
This PR adds a collection of Panduit's copper (Mini-Com) and fiber (Opticom) patch panels and related components.