### PR TITLE
Fix Issue with Rockwell Automation CLX PLCs

### DIFF
--- a/device-types/Rockwell Automation/1756-CMS1B1.yaml
+++ b/device-types/Rockwell Automation/1756-CMS1B1.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Compute - Windows
 part_number: 1756-CMS1B1
 slug: 1756-cms1b1
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-CMS1C1.yaml
+++ b/device-types/Rockwell Automation/1756-CMS1C1.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Compute - Linux
 part_number: 1756-CMS1C1
 slug: 1756-cms1c1
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN2F.yaml
+++ b/device-types/Rockwell Automation/1756-EN2F.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Fiber Ethernet Adapter (EN2F)
 part_number: 1756-EN2F
 slug: 1756-en2f
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN2FK.yaml
+++ b/device-types/Rockwell Automation/1756-EN2FK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Fiber Ethernet Adapter K (EN2FK)
 part_number: 1756-EN2FK
 slug: 1756-en2fk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN2T.yaml
+++ b/device-types/Rockwell Automation/1756-EN2T.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter (EN2T)
 part_number: 1756-EN2T
 slug: 1756-en2t
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN2TK.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter K (EN2TK)
 part_number: 1756-EN2TK
 slug: 1756-en2tk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN2TP.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TP.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet PRP Adapter (EN2TP)
 part_number: 1756-EN2TP
 slug: 1756-en2tp
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN2TPK.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TPK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet PRP Adapter K (EN2TP)
 part_number: 1756-EN2TPK
 slug: 1756-en2tpk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN2TR.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TR.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter (EN2TR)
 part_number: 1756-EN2TR
 slug: 1756-en2tr
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN2TRK.yaml
+++ b/device-types/Rockwell Automation/1756-EN2TRK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter K (EN2TR)
 part_number: 1756-EN2TRK
 slug: 1756-en2trk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN3TR.yaml
+++ b/device-types/Rockwell Automation/1756-EN3TR.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter (EN3TR)
 part_number: 1756-EN3TR
 slug: 1756-en3tr
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN3TRK.yaml
+++ b/device-types/Rockwell Automation/1756-EN3TRK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter K (EN3TR)
 part_number: 1756-EN3TRK
 slug: 1756-en3trk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN4TR.yaml
+++ b/device-types/Rockwell Automation/1756-EN4TR.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter (EN4TR)
 part_number: 1756-EN4TR
 slug: 1756-en4tr
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EN4TRK.yaml
+++ b/device-types/Rockwell Automation/1756-EN4TRK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter K (EN4TR)
 part_number: 1756-EN4TRK
 slug: 1756-en4trk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-ENBT.yaml
+++ b/device-types/Rockwell Automation/1756-ENBT.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter (ENBT)
 part_number: 1756-ENBT
 slug: 1756-enbt
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-ENBTK.yaml
+++ b/device-types/Rockwell Automation/1756-ENBTK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Ethernet Adapter K (ENBT)
 part_number: 1756-ENBTK
 slug: 1756-enbtk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-EWEB.yaml
+++ b/device-types/Rockwell Automation/1756-EWEB.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix Web Module (EWEB)
 part_number: 1756-EWEB
 slug: 1756-enweb
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L81E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L81E-NSE.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L81E-NSE
 part_number: 1756-L81E-NSE
 slug: 1756-l81e-nse
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L81E.yaml
+++ b/device-types/Rockwell Automation/1756-L81E.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L81E
 part_number: 1756-L81E
 slug: 1756-l81e
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L81EK.yaml
+++ b/device-types/Rockwell Automation/1756-L81EK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L81EK
 part_number: 1756-L81EK
 slug: 1756-l81ek
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L81EP.yaml
+++ b/device-types/Rockwell Automation/1756-L81EP.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L81EP
 part_number: 1756-L81EP
 slug: 1756-l81ep
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L81ES.yaml
+++ b/device-types/Rockwell Automation/1756-L81ES.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: GuardLogix 5580 L81ES
 part_number: 1756-L81ES
 slug: 1756-l81es
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L81ESK.yaml
+++ b/device-types/Rockwell Automation/1756-L81ESK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: GuardLogix 5580 L81ESK
 part_number: 1756-L81ESK
 slug: 1756-l81esk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L82E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L82E-NSE.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L82E-NSE
 part_number: 1756-L82E-NSE
 slug: 1756-l82e-nse
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L82E.yaml
+++ b/device-types/Rockwell Automation/1756-L82E.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L82E
 part_number: 1756-L82E
 slug: 1756-l82e
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L82EK.yaml
+++ b/device-types/Rockwell Automation/1756-L82EK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L82EK
 part_number: 1756-L82EK
 slug: 1756-l82ek
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L82ES.yaml
+++ b/device-types/Rockwell Automation/1756-L82ES.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: GuardLogix 5580 L82ES
 part_number: 1756-L82ES
 slug: 1756-l82es
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L82ESK.yaml
+++ b/device-types/Rockwell Automation/1756-L82ESK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: GuardLogix 5580 L82ESK
 part_number: 1756-L82ESK
 slug: 1756-l82esk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L83E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L83E-NSE.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L83E-NSE
 part_number: 1756-L83E-NSE
 slug: 1756-l83e-nse
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L83E.yaml
+++ b/device-types/Rockwell Automation/1756-L83E.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L83E
 part_number: 1756-L83E
 slug: 1756-l83e
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L83EK.yaml
+++ b/device-types/Rockwell Automation/1756-L83EK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L83EK
 part_number: 1756-L83EK
 slug: 1756-l83ek
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L83EP.yaml
+++ b/device-types/Rockwell Automation/1756-L83EP.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L83EP
 part_number: 1756-L83EP
 slug: 1756-l83ep
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L83ES.yaml
+++ b/device-types/Rockwell Automation/1756-L83ES.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: GuardLogix 5580 L83ES
 part_number: 1756-L83ES
 slug: 1756-l83es
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L83ESK.yaml
+++ b/device-types/Rockwell Automation/1756-L83ESK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: GuardLogix 5580 L83ESK
 part_number: 1756-L83ESK
 slug: 1756-l83esk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L84E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L84E-NSE.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L84E-NSE
 part_number: 1756-L84E-NSE
 slug: 1756-l84e-nse
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L84E.yaml
+++ b/device-types/Rockwell Automation/1756-L84E.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L84E
 part_number: 1756-L84E
 slug: 1756-l84e
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L84EK.yaml
+++ b/device-types/Rockwell Automation/1756-L84EK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L84EK
 part_number: 1756-L84EK
 slug: 1756-l84ek
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L84ES.yaml
+++ b/device-types/Rockwell Automation/1756-L84ES.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: GuardLogix 5580 L84ES
 part_number: 1756-L84ES
 slug: 1756-l84es
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L84ESK.yaml
+++ b/device-types/Rockwell Automation/1756-L84ESK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: GuardLogix 5580 L84ESK
 part_number: 1756-L84ESK
 slug: 1756-l84esk
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L85E-NSE.yaml
+++ b/device-types/Rockwell Automation/1756-L85E-NSE.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L85E-NSE
 part_number: 1756-L85E-NSE
 slug: 1756-l85e-nse
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L85E.yaml
+++ b/device-types/Rockwell Automation/1756-L85E.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L85E
 part_number: 1756-L85E
 slug: 1756-l85e
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L85EK.yaml
+++ b/device-types/Rockwell Automation/1756-L85EK.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L85EK
 part_number: 1756-L85EK
 slug: 1756-l85ek
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:

--- a/device-types/Rockwell Automation/1756-L85EP.yaml
+++ b/device-types/Rockwell Automation/1756-L85EP.yaml
@@ -3,7 +3,7 @@ manufacturer: Rockwell Automation
 model: ControlLogix 5580 L85EP
 part_number: 1756-L85EP
 slug: 1756-l85ep
-u_height: 3
+u_height: 0
 is_full_depth: false
 subdevice_role: child
 interfaces:


### PR DESCRIPTION
This PR resolves and issue with import of the previously added Rockwell Automation ControlLogix PLC device types. Specifically, this PR changes the u_height parameter to 0 for each child object to allow for successful import. 