### PR TITLE
Added Panduit FRME4

### DIFF
--- a/device-types/Panduit/FRME4.yaml
+++ b/device-types/Panduit/FRME4.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: Panduit
+model: Opticom Rack Mount Fiber Enclosure, 4 RU
+slug: frme4
+part_number: FRME4
+u_height: 4
+is_full_depth: false
+subdevice_role: parent
+device-bays:
+  - name: A
+  - name: B
+  - name: C
+  - name: D
+  - name: E
+  - name: F
+  - name: G
+  - name: H
+  - name: J
+  - name: K
+  - name: L
+  - name: M


### PR DESCRIPTION
This adds the Panduit FRME4 Rack Mount Fiber Enclosure.  All bays are lettered.

https://www.panduit.com/en/products/fiber-optic-systems/fiber-optic-panels-cassettes-enclosures/fiber-optic-enclosures/frme4.html