### PR TITLE
Update part-number for Arista DCS-7050TX3-48C8

### DIFF
--- a/device-types/Arista/DCS-7050TX3-48C8.yaml
+++ b/device-types/Arista/DCS-7050TX3-48C8.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Arista
-model: DDCS-7050TX3-48C8
+model: DCS-7050TX3-48C8
 slug: dcs-7050tx3-48c8
-part_number: DDCS-7050TX3-48C8
+part_number: DCS-7050TX3-48C8
 u_height: 1
 is_full_depth: false
 comments: ''


### PR DESCRIPTION
The title and product name is DCS-7050TX3-48C8 but `part-number` and `model` are set with DDCS-7050TX3-48C8.

This PR tend to fix the typo