### PR TITLE
Fixed port type to SFP+ for ports 33 and 34

### DIFF
--- a/device-types/Dell/networking-s5232f-on.yaml
+++ b/device-types/Dell/networking-s5232f-on.yaml
@@ -114,10 +114,10 @@ interfaces:
     type: 100gbase-x-qsfp28
     mgmt_only: false
   - name: Ethernet 1/1/33
-    type: 100gbase-x-qsfp28
+    type: 10gbase-x-sfpp
     mgmt_only: false
   - name: Ethernet 1/1/34
-    type: 100gbase-x-qsfp28
+    type: 10gbase-x-sfpp
     mgmt_only: false
   - name: mgmt 1/1/1
     type: 1000base-t


### PR DESCRIPTION
  * The Dell S5232F-ON has 32 QSFP28 ports, 1/1/1-32 and 2 SFP+
ports, 1/1/33 and 1/1/34. The current template incorrectly lists
these two ports as QSFP28
https://www.delltechnologies.com/asset/en-us/products/networking/technical-support/dell_emc_networking-s5200_on_spec_sheet.pdf