### PR TITLE
Update CI for new Interface Type

### DIFF
--- a/tests/schema.json
+++ b/tests/schema.json
@@ -387,6 +387,7 @@
                         "ieee802.11ac",
                         "ieee802.11ad",
                         "ieee802.11ax",
+                        "ieee802.15.1",
                         "gsm",
                         "cdma",
                         "lte",


### PR DESCRIPTION
Updates the schema.json for CI to accept the new Interface Type "IEEE 802.15.1 (Bluetooth)" .
Refers to my PR on the main netbox repository: [PR#7816](https://github.com/netbox-community/netbox/pull/7816)

Marking as draft until the PR in the main repo is merged.