### PR TITLE
Correct Cisco SG300-28 depth

### DIFF
--- a/device-types/Cisco/SG300-28.yaml
+++ b/device-types/Cisco/SG300-28.yaml
@@ -4,7 +4,7 @@ model: SG300-28
 part_number: SG300-28
 slug: sg300-28
 u_height: 1
-is_full_depth: true
+is_full_depth: false
 comments: '[SG300 Series Datasheet](https://www.cisco.com/c/en/us/products/collateral/switches/small-business-smart-switches/data_sheet_c78-610061.html)'
 console-ports:
   - name: con 0


### PR DESCRIPTION
The Cisco SG300-28 is not full depth, but was falsely flagged as such