### PR TITLE
Add device-type RB962UiGS-5HacT2HnT

### DIFF
--- a/device-types/MikroTik/RB962UiGS-5HacT2HnT.yaml
+++ b/device-types/MikroTik/RB962UiGS-5HacT2HnT.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: MikroTik
+model: RB962UiGS-5HacT2HnT
+slug: rb962uigs-5hact2hnt 
+interfaces:
+  - name: ether1
+    type: 1000base-t
+  - name: ether2
+    type: 1000base-t
+  - name: ether3
+    type: 1000base-t
+  - name: ether4
+    type: 1000base-t
+  - name: ether5
+    type: 1000base-t
+  - name: sfp1
+    type: 1000base-x-sfp


### PR DESCRIPTION
Device type for MikroTik RB962UiGS-5HacT2HnT added to the respository