### PR TITLE
Add Ubiquiti UAP-AC-LR

### DIFF
--- a/device-types/Ubiquiti/UAP-AC-LR.yaml
+++ b/device-types/Ubiquiti/UAP-AC-LR.yaml
@@ -1,0 +1,15 @@
+---
+manufacturer: Ubiquiti
+model: UAP-AC-LR
+slug: uap-ac-lr
+u_height: 0
+is_full_depth: false
+comments: '[Unifi AP AC Long Range](https://www.ui.com/unifi/unifi-ap-ac-lr/)'
+interfaces:
+  - name: lan0
+    type: 1000base-t
+    mgmt_only: false
+  - name: wlan0
+    type: ieee802.11n
+  - name: wlan1
+    type: ieee802.11ac


### PR DESCRIPTION
Adds Ubiquiti's [UAP-AC-LR](https://www.ui.com/unifi/unifi-ap-ac-lr/)

- Follows same format as similar UAP-AC-* devices.