### PR TITLE
[QFX5120-48T] rename interfaces and cleanup extra interfaces

### DIFF
--- a/device-types/Juniper/QFX5120-48T.yaml
+++ b/device-types/Juniper/QFX5120-48T.yaml
@@ -104,21 +104,17 @@ interfaces:
     type: 10gbase-t
   - name: xe-0/0/47
     type: 10gbase-t
-  - name: xe-0/0/48
+  - name: et-0/0/48
     type: 100gbase-x-qsfp28
-  - name: xe-0/0/49
+  - name: et-0/0/49
     type: 100gbase-x-qsfp28
-  - name: xe-0/0/50
+  - name: et-0/0/50
     type: 100gbase-x-qsfp28
-  - name: xe-0/0/51
+  - name: et-0/0/51
     type: 100gbase-x-qsfp28
-  - name: xe-0/0/52
+  - name: et-0/0/52
     type: 100gbase-x-qsfp28
-  - name: xe-0/0/53
-    type: 100gbase-x-qsfp28
-  - name: xe-0/0/54
-    type: 100gbase-x-qsfp28
-  - name: xe-0/0/55
+  - name: et-0/0/53
     type: 100gbase-x-qsfp28
 power-ports:
   - name: PSU0


### PR DESCRIPTION
- 100G interfaces are named `et-*` in JunOS
- QFX5120-48T has six, not eight 100G QSFP28 interfaces