### PR TITLE
Rename optic type 128gfc-sfp28 to 128gfc-qsfp28

### DIFF
--- a/tests/schema.json
+++ b/tests/schema.json
@@ -404,7 +404,7 @@
                         "8gfc-sfpp",
                         "16gfc-sfpp",
                         "32gfc-sfp28",
-                        "128gfc-sfp28",
+                        "128gfc-qsfp28",
                         "infiniband-sdr",
                         "infiniband-ddr",
                         "infiniband-qdr",


### PR DESCRIPTION
Rename optic type 128gfc-sfp28 to 128gfc-qsfp28 in schema.json. This was fixed in Netbox with v3.1.0 (https://github.com/netbox-community/netbox/issues/7589) and should fix schema.json for pull request #503