### PR TITLE
Update Ubiquiti USW-Aggregation and UDM-Pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .idea
 .DS_Store
+venv/

--- a/device-types/Ubiquiti/UDM-Pro.yaml
+++ b/device-types/Ubiquiti/UDM-Pro.yaml
@@ -1,7 +1,9 @@
 ---
 manufacturer: Ubiquiti
-model: UDM-PRO
+model: Dream Machine Pro
 slug: udm-pro
+airflow: front-to-rear
+part_number: UDM-Pro
 comments: |
   [UniFi Dream Machine Pro](https://store.ui.com/products/udm-pro)
 
@@ -9,7 +11,7 @@ comments: |
 
   Dimensions: 442.4 x 43.7 x 285.6 mm (17.42 x 1.72 x 11.24")
 u_height: 1
-is_full_depth: true
+is_full_depth: false
 interfaces:
   - name: eth0
     type: 1000base-t

--- a/device-types/Ubiquiti/UDM-Pro.yaml
+++ b/device-types/Ubiquiti/UDM-Pro.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Ubiquiti
-model: Dream Machine Pro
+model: UniFi Dream Machine Pro
 slug: udm-pro
 airflow: front-to-rear
 part_number: UDM-Pro

--- a/device-types/Ubiquiti/USW-Aggregation.yaml
+++ b/device-types/Ubiquiti/USW-Aggregation.yaml
@@ -4,7 +4,7 @@ model: UniFi Switch Aggregation
 slug: unifi-switch-aggregation
 part_number: USW-Aggregation
 comments: |
-  UniFi Switch 16 Aggregation, 10G 10-Port Managed Aggregation Switch, 30W, (10) SFP+
+  UniFi Switch Aggregation, 10G 8-Port Managed Aggregation Switch, 30W, (8) SFP+
 
   Dimensions: 442.4 x 120 x 43.7 mm (17.42 x 4.72 x 1.72")
 u_height: 1
@@ -25,10 +25,6 @@ interfaces:
   - name: SFP+ 7
     type: 10gbase-x-sfpp
   - name: SFP+ 8
-    type: 10gbase-x-sfpp
-  - name: SFP+ 9
-    type: 10gbase-x-sfpp
-  - name: SFP+ 10
     type: 10gbase-x-sfpp
 power-ports:
   - name: Input

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -21,6 +21,17 @@
         "is_full_depth": {
             "type": "boolean"
         },
+        "airflow": {
+            "type": "string",
+            "enum": [
+                "front-to-rear",
+                "rear-to-front",
+                "left-to-right",
+                "right-to-left",
+                "side-to-rear",
+                "passive"
+            ]
+        },
         "subdevice_role": {
             "type": "string",
             "enum": [


### PR DESCRIPTION
I was adding these two devices to a new NetBox install today and noticed a few discrepancies in the definitions.

**USW-Aggregation**
I was unable to find a 10-port version of this switch and the datasheet I found from 2020 only lists an 8-port variation, which is the only one I could find. I updated the device to only include 8 ports now.

**UDM-Pro**
The primary change here is to mark it as not a full-depth device. As long as I was updating it I thought I'd add the airflow and update the model name to match the data sheet's name and add the part number.

**Airflow Direction in Schema**
I added the "airflow" field to the device type schema. I added airflow direction to the UDM-Pro on a whim, so this was required to allow the tests to pass.

I may have more updates coming and I know I'll have a definition for the USW-Pro-Aggregation to add soon as I have one of those coming!