### PR TITLE
Add ubnt af 5xhd

### DIFF
--- a/device-types/Ubiquiti/AF-5XHD.yml
+++ b/device-types/Ubiquiti/AF-5XHD.yml
@@ -16,8 +16,10 @@ interfaces:
     type: bridge
     mgmt_only: true
   - name: eth0
+    label: Ethernet
     type: 1000base-t
     mgmt_only: false
   - name: ath0
+    label: Wireless
     type: ieee802.11ax
     mgmt_only: false

--- a/device-types/Ubiquiti/AF-5XHD.yml
+++ b/device-types/Ubiquiti/AF-5XHD.yml
@@ -12,8 +12,6 @@ interfaces:
   - name: eth0
     type: 1000base-t
     mgmt_only: false
-    bridge: br0
   - name: ath0
     type: ieee802.11ax
     mgmt_only: false
-    bridge: br0

--- a/device-types/Ubiquiti/AF-5XHD.yml
+++ b/device-types/Ubiquiti/AF-5XHD.yml
@@ -13,7 +13,7 @@ u_height: 0
 is_full_depth: false
 interfaces:
   - name: br0
-    type: bridge
+    type: virtual
     mgmt_only: true
   - name: eth0
     type: 1000base-t

--- a/device-types/Ubiquiti/AF-5XHD.yml
+++ b/device-types/Ubiquiti/AF-5XHD.yml
@@ -7,13 +7,13 @@ u_height: 0
 is_full_depth: false
 interfaces:
   - name: br0
-    type: Bridge
+    type: bridge
     mgmt_only: true
   - name: eth0
     type: 1000base-t
     mgmt_only: false
     bridge: br0
   - name: ath0
-    type: IEEE 802.11ax
+    type: ieee802.11ax
     mgmt_only: false
     bridge: br0

--- a/device-types/Ubiquiti/AF-5XHD.yml
+++ b/device-types/Ubiquiti/AF-5XHD.yml
@@ -3,6 +3,12 @@ manufacturer: Ubiquiti
 model: airFiber AF-5XHD
 slug: airfiber-af-5xhd
 part_number: AF-5XHD
+comments: |
+  ath0 is setup to use ieee802.11ax as LTE currently doesn't allow wireless
+  parameters to be specified despite the fact that the airFiber is a LTE-U
+  device.
+
+  The eth0 and ath0 are permanently bridged as this is a L2 bridge device.
 u_height: 0
 is_full_depth: false
 interfaces:

--- a/device-types/Ubiquiti/AF-5XHD.yml
+++ b/device-types/Ubiquiti/AF-5XHD.yml
@@ -1,0 +1,19 @@
+---
+manufacturer: Ubiquiti
+model: airFiber AF-5XHD
+slug: airfiber-af-5xhd
+part_number: AF-5XHD
+u_height: 0
+is_full_depth: false
+interfaces:
+  - name: br0
+    type: Bridge
+    mgmt_only: true
+  - name: eth0
+    type: 1000base-t
+    mgmt_only: false
+    bridge: br0
+  - name: ath0
+    type: IEEE 802.11ax
+    mgmt_only: false
+    bridge: br0

--- a/device-types/Ubiquiti/AF-5XHD.yml
+++ b/device-types/Ubiquiti/AF-5XHD.yml
@@ -13,7 +13,7 @@ u_height: 0
 is_full_depth: false
 interfaces:
   - name: br0
-    type: virtual
+    type: bridge
     mgmt_only: true
   - name: eth0
     type: 1000base-t

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -388,6 +388,7 @@
                     "enum": [
                         "virtual",
                         "lag",
+                        "bridge",
                         "100base-tx",
                         "1000base-t",
                         "2.5gbase-t",


### PR DESCRIPTION
Adding the Ubiquiti airFiber 5XHD

https://dl.ubnt.com/datasheets/airfiber/airFiber_5XHD_DS.pdf

Used ieee802.11ax as it doesn't allow wireless parameters to be specified despite the fact that it is a LTE-U device.

Has been tested to import fine into my v3.1.6 instance of netbox.