### PR TITLE
Cisco ISR1111-8P fixes and Adds ISR1161-8P

### DIFF
--- a/device-types/Cisco/ISR1111-8P.yaml
+++ b/device-types/Cisco/ISR1111-8P.yaml
@@ -26,18 +26,11 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet0/1/7
     type: 1000base-t
-  - name: GigabitEthernet0/1/8
-    type: 1000base-t
-  - name: Wlan-GigabitEthernet0/1/8
-    type: ieee802.11ac
-  - name: Cellular0/2/0
-    type: lte
-
 console-ports:
   - name: con 0
     type: rj-45
   - name: usb
-    type: usb-mini-b
+    type: usb-micro-b
 power-ports:
   - name: PSU0
     type: iec-60320-c14

--- a/device-types/Cisco/ISR1111-8PLTEEA.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEA.yaml
@@ -1,0 +1,41 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEA
+part_number: C1111-8PLTEEA
+slug: isr1111-8plteae
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWA.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWA.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWA
+part_number: C1111-8PLTEEAWA
+slug: isr1111-8plteeawa
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWB.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWB.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWB
+part_number: C1111-8PLTEEAWB
+slug: isr1111-8plteeawb
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWE.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWE.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWE
+part_number: C1111-8PLTEEAWE
+slug: isr1111-8plteawe
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWF.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWF.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWF
+part_number: C1111-8PLTEEAWF
+slug: isr1111-8plteeawf
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWH.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWH.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWH
+part_number: C1111-8PLTEEAWH
+slug: isr1111-8plteeawh
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWN.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWN.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWN
+part_number: C1111-8PLTEEAWN
+slug: isr1111-8plteeawn
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWQ.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWQ.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWQ
+part_number: C1111-8PLTEEAWQ
+slug: isr1111-8plteeawq
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWR.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWR.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWR
+part_number: C1111-8PLTEEAWR
+slug: isr1111-8plteeawr
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWX.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWX.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWX
+part_number: C1111-8PLTEEAWX
+slug: isr1111-8plteeawx
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTEEAWZ.yaml
+++ b/device-types/Cisco/ISR1111-8PLTEEAWZ.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTEEAWZ
+part_number: C1111-8PLTEEAWZ
+slug: isr1111-8plteeawz
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELA.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELA.yaml
@@ -1,0 +1,41 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELA
+part_number: C1111-8PLTELA
+slug: isr1111-8pltela
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELAWA.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWA.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELAWA
+part_number: C1111-8PLTELAWA
+slug: isr1111-8pltelawa
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELAWB.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWB.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELAWB
+part_number: C1111-8PLTELAWB
+slug: isr1111-8pltelawb
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELAWE.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWE.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELAWE
+part_number: C1111-8PLTELAWE
+slug: isr1111-8pltelawe
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELAWF.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWF.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELAWF
+part_number: C1111-8PLTELAWF
+slug: isr1111-8pltelawf
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELAWH.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWH.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELAWH
+part_number: C1111-8PLTELAWH
+slug: isr1111-8pltelawh
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELAWN.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWN.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Cisco
-model: ISR 1111-8PLTEEAWX
-part_number: C1111-8PLTEEAWX
-slug: isr1111-8plteeawx
+model: ISR 1111-8PLTELAWN
+part_number: C1111-8PLTELAWN
+slug: isr1111-8pltelawn
 u_height: 1
 is_full_depth: false
 interfaces:

--- a/device-types/Cisco/ISR1111-8PLTELAWQ.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWQ.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELAWQ
+part_number: C1111-8PLTELAWQ
+slug: isr1111-8pltelawq
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELAWR.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWR.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELAWR
+part_number: C1111-8PLTELAWR
+slug: isr1111-8pltelawr
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PLTELAWZ.yaml
+++ b/device-types/Cisco/ISR1111-8PLTELAWZ.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PLTELAWZ
+part_number: C1111-8PLTELAWZ
+slug: isr1111-8pltelawz
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+  - name: Cellular0/2/0
+    type: lte
+  - name: Cellular0/2/1
+    type: lte
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWA.yaml
+++ b/device-types/Cisco/ISR1111-8PWA.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWA
+part_number: C1111-8PWA
+slug: isr1111-8pwa
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWB.yaml
+++ b/device-types/Cisco/ISR1111-8PWB.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWB
+part_number: C1111-8PWB
+slug: isr1111-8pwb
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWE.yaml
+++ b/device-types/Cisco/ISR1111-8PWE.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWE
+part_number: C1111-8PWE
+slug: isr1111-8pwe
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWF.yaml
+++ b/device-types/Cisco/ISR1111-8PWF.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWF
+part_number: C1111-8PWF
+slug: isr1111-8pwf
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWH.yaml
+++ b/device-types/Cisco/ISR1111-8PWH.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWH
+part_number: C1111-8PWH
+slug: isr1111-8pwh
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWN.yaml
+++ b/device-types/Cisco/ISR1111-8PWN.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWN
+part_number: C1111-8PWN
+slug: isr1111-8pwn
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWQ.yaml
+++ b/device-types/Cisco/ISR1111-8PWQ.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWQ
+part_number: C1111-8PWQ
+slug: isr1111-8pwq
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWR.yaml
+++ b/device-types/Cisco/ISR1111-8PWR.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWR
+part_number: C1111-8PWR
+slug: isr1111-8pwr
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1111-8PWZy.yaml
+++ b/device-types/Cisco/ISR1111-8PWZy.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Cisco
+model: ISR 1111-8PWZ
+part_number: C1111-8PWZ
+slug: isr1111-8pwz
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+  - name: Wlan-GigabitEthernet0/1/8
+    type: ieee802.11ac
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/device-types/Cisco/ISR1161-8P.yaml
+++ b/device-types/Cisco/ISR1161-8P.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: Cisco
+model: ISR 1161-8P
+part_number: C1161-8P
+slug: isr1161-8p
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-x-sfp
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/0
+    type: 1000base-t
+  - name: GigabitEthernet0/1/1
+    type: 1000base-t
+  - name: GigabitEthernet0/1/2
+    type: 1000base-t
+  - name: GigabitEthernet0/1/3
+    type: 1000base-t
+  - name: GigabitEthernet0/1/4
+    type: 1000base-t
+  - name: GigabitEthernet0/1/5
+    type: 1000base-t
+  - name: GigabitEthernet0/1/6
+    type: 1000base-t
+  - name: GigabitEthernet0/1/7
+    type: 1000base-t
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-micro-b
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150


### PR DESCRIPTION
here is updated models for the ISR1111-8P routers. Note that there are many different models, each 1111-8P comes in a model with LTE in Emea/US and LTE in LATAM/APAC, then there are also wifi for each regulatory domains (A, B, E, F, H, N, Q, R, Z) and finally combined models with both LTE and wifi.
It also adds the ISR1161-8P platform (it also comes in LTE and wifi models, but I have not included those yet)