### PR TITLE
Added device type definitions for Ciena 5170 and 5171

### DIFF
--- a/device-types/Ciena/5170.yaml
+++ b/device-types/Ciena/5170.yaml
@@ -10,11 +10,11 @@ console-ports:
     type: rj-45
 power-ports:
   - name: PSA
-    type: iec-60320-c13
+    type: iec-60320-c14
     maximum_draw: 360
     allocated_draw: 285
   - name: PSB
-    type: iec-60320-c13
+    type: iec-60320-c14
     maximum_draw: 360
     allocated_draw: 285
 interfaces:

--- a/device-types/Ciena/5170.yaml
+++ b/device-types/Ciena/5170.yaml
@@ -1,0 +1,111 @@
+---
+manufacturer: Ciena
+model: '5170'
+slug: '5170'
+part_number: 170-5170-900
+u_height: 1
+is_full_depth: true
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+power-ports:
+  - name: PSA
+    type: iec-60320-c13
+    maximum_draw: 360
+    allocated_draw: 285
+  - name: PSB
+    type: iec-60320-c13
+    maximum_draw: 360
+    allocated_draw: 285
+interfaces:
+  - name: '1'
+    type: 10gbase-x-sfpp
+  - name: '2'
+    type: 10gbase-x-sfpp
+  - name: '3'
+    type: 10gbase-x-sfpp
+  - name: '4'
+    type: 10gbase-x-sfpp
+  - name: '5'
+    type: 10gbase-x-sfpp
+  - name: '6'
+    type: 10gbase-x-sfpp
+  - name: '7'
+    type: 10gbase-x-sfpp
+  - name: '8'
+    type: 10gbase-x-sfpp
+  - name: '9'
+    type: 10gbase-x-sfpp
+  - name: '10'
+    type: 25gbase-x-sfp28
+  - name: '11'
+    type: 10gbase-x-sfpp
+  - name: '12'
+    type: 10gbase-x-sfpp
+  - name: '13'
+    type: 10gbase-x-sfpp
+  - name: '14'
+    type: 10gbase-x-sfpp
+  - name: '15'
+    type: 10gbase-x-sfpp
+  - name: '16'
+    type: 10gbase-x-sfpp
+  - name: '17'
+    type: 10gbase-x-sfpp
+  - name: '18'
+    type: 10gbase-x-sfpp
+  - name: '19'
+    type: 10gbase-x-sfpp
+  - name: '20'
+    type: 10gbase-x-sfpp
+  - name: '21'
+    type: 10gbase-x-sfpp
+  - name: '22'
+    type: 10gbase-x-sfpp
+  - name: '23'
+    type: 10gbase-x-sfpp
+  - name: '24'
+    type: 10gbase-x-sfpp
+  - name: '25'
+    type: 10gbase-x-sfpp
+  - name: '26'
+    type: 10gbase-x-sfpp
+  - name: '27'
+    type: 10gbase-x-sfpp
+  - name: '28'
+    type: 25gbase-x-sfp28
+  - name: '29'
+    type: 25gbase-x-sfp28
+  - name: '30'
+    type: 25gbase-x-sfp28
+  - name: '31'
+    type: 10gbase-x-sfpp
+  - name: '32'
+    type: 10gbase-x-sfpp
+  - name: '33'
+    type: 10gbase-x-sfpp
+  - name: '34'
+    type: 10gbase-x-sfpp
+  - name: '35'
+    type: 10gbase-x-sfpp
+  - name: '36'
+    type: 10gbase-x-sfpp
+  - name: '37'
+    type: 10gbase-x-sfpp
+  - name: '38'
+    type: 10gbase-x-sfpp
+  - name: '39'
+    type: 10gbase-x-sfpp
+  - name: '40'
+    type: 10gbase-x-sfpp
+  - name: '41'
+    type: 100gbase-x-qsfp28
+  - name: '42'
+    type: 100gbase-x-qsfp28
+  - name: '43'
+    type: 100gbase-x-qsfp28
+  - name: '44'
+    type: 100gbase-x-qsfp28
+  - name: MGMT
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Ciena/5171.yaml
+++ b/device-types/Ciena/5171.yaml
@@ -1,0 +1,108 @@
+---
+manufacturer: Ciena
+model: '5171'
+slug: '5171'
+part_number: 170-5171-910
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+power-ports:
+  - name: PSA
+    type: iec-60320-c13
+    maximum_draw: 800
+    allocated_draw: 328
+  - name: PSB
+    type: iec-60320-c13
+    maximum_draw: 800
+    allocated_draw: 328
+module-bays:
+  - name: Slot 0
+    label: FRU 0
+  - name: Slot 1
+    label: FRU 1
+interfaces:
+  - name: '1'
+    type: 10gbase-x-sfpp
+  - name: '2'
+    type: 10gbase-x-sfpp
+  - name: '3'
+    type: 10gbase-x-sfpp
+  - name: '4'
+    type: 10gbase-x-sfpp
+  - name: '5'
+    type: 10gbase-x-sfpp
+  - name: '6'
+    type: 10gbase-x-sfpp
+  - name: '7'
+    type: 10gbase-x-sfpp
+  - name: '8'
+    type: 10gbase-x-sfpp
+  - name: '9'
+    type: 10gbase-x-sfpp
+  - name: '10'
+    type: 25gbase-x-sfp28
+  - name: '11'
+    type: 25gbase-x-sfp28
+  - name: '12'
+    type: 10gbase-x-sfpp
+  - name: '13'
+    type: 10gbase-x-sfpp
+  - name: '14'
+    type: 10gbase-x-sfpp
+  - name: '15'
+    type: 10gbase-x-sfpp
+  - name: '16'
+    type: 10gbase-x-sfpp
+  - name: '17'
+    type: 10gbase-x-sfpp
+  - name: '18'
+    type: 10gbase-x-sfpp
+  - name: '19'
+    type: 10gbase-x-sfpp
+  - name: '20'
+    type: 10gbase-x-sfpp
+  - name: '21'
+    type: 10gbase-x-sfpp
+  - name: '22'
+    type: 10gbase-x-sfpp
+  - name: '23'
+    type: 10gbase-x-sfpp
+  - name: '24'
+    type: 10gbase-x-sfpp
+  - name: '25'
+    type: 10gbase-x-sfpp
+  - name: '26'
+    type: 10gbase-x-sfpp
+  - name: '27'
+    type: 10gbase-x-sfpp
+  - name: '28'
+    type: 10gbase-x-sfpp
+  - name: '29'
+    type: 10gbase-x-sfpp
+  - name: '30'
+    type: 25gbase-x-sfp28
+  - name: '31'
+    type: 25gbase-x-sfp28
+  - name: '32'
+    type: 10gbase-x-sfpp
+  - name: '33'
+    type: 10gbase-x-sfpp
+  - name: '34'
+    type: 10gbase-x-sfpp
+  - name: '35'
+    type: 10gbase-x-sfpp
+  - name: '36'
+    type: 10gbase-x-sfpp
+  - name: '37'
+    type: 10gbase-x-sfpp
+  - name: '38'
+    type: 10gbase-x-sfpp
+  - name: '39'
+    type: 10gbase-x-sfpp
+  - name: '40'
+    type: 10gbase-x-sfpp
+  - name: MGMT
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Ciena/5171.yaml
+++ b/device-types/Ciena/5171.yaml
@@ -3,18 +3,19 @@ manufacturer: Ciena
 model: '5171'
 slug: '5171'
 part_number: 170-5171-910
-u_height: 1
+u_height: 2
 is_full_depth: false
+subdevice_role: parent
 console-ports:
   - name: CONSOLE
     type: rj-45
 power-ports:
   - name: PSA
-    type: iec-60320-c13
+    type: iec-60320-c14
     maximum_draw: 800
     allocated_draw: 328
   - name: PSB
-    type: iec-60320-c13
+    type: iec-60320-c14
     maximum_draw: 800
     allocated_draw: 328
 module-bays:


### PR DESCRIPTION
Added device type definitions for Ciena 5170 and 5171. All Pre-commit scripts ran and passed: 

```
devicetype-library % pre-commit run --all                                                 
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check YAML files.........................................................Passed
Format YAML files........................................................Passed
Lint YAML files..........................................................Passed
```

