### PR TITLE
Add Catalyst 9600 and modules

### DIFF
--- a/device-types/Cisco/C9606R.yaml
+++ b/device-types/Cisco/C9606R.yaml
@@ -1,0 +1,41 @@
+---
+manufacturer: Cisco
+model: Catalyst 9606R
+slug: c9606r
+part_number: C9606R
+u_height: 8
+is_full_depth: true
+airflow: right-to-left
+comments: '[Cisco Catalyst 9600 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-series-data-sheet-cte-en.html)'
+module-bays:
+  - name: Slot 1
+    position: '1'
+    description: Line Card
+  - name: Slot 2
+    position: '2'
+    description: Line Card
+  - name: Slot 3
+    position: '3'
+    description: Supervisor Module
+  - name: Slot 4
+    position: '4'
+    description: Supervisor Module
+  - name: Slot 5
+    position: '5'
+    description: Line Card
+  - name: Slot 6
+    position: '6'
+    description: Line Card
+power-ports:
+  - name: PS-1
+    type: iec-60320-c16
+    maximum_draw: 2000
+  - name: PS-2
+    type: iec-60320-c16
+    maximum_draw: 2000
+  - name: PS-3
+    type: iec-60320-c16
+    maximum_draw: 2000
+  - name: PS-4
+    type: iec-60320-c16
+    maximum_draw: 2000

--- a/module-types/Cisco/C9600-LC-24C.yaml
+++ b/module-types/Cisco/C9600-LC-24C.yaml
@@ -1,0 +1,102 @@
+---
+manufacturer: Cisco
+model: C9600-LC-24C
+part_number: C9600-LC-24C
+comments: '[Cisco Catalyst 9600 Series Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-series-line-data-sheet-cte-en.html)'
+interfaces:
+  - name: FortyGigabitEthernet{module}/0/1
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/2
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/3
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/4
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/5
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/6
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/7
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/8
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/9
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/10
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/11
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/12
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/13
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/14
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/15
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/16
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/17
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/18
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/19
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/20
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/21
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/22
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/23
+    type: 40gbase-x-qsfpp
+  - name: FortyGigabitEthernet{module}/0/24
+    type: 40gbase-x-qsfpp
+  - name: HundredGigE{module}/0/25
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/26
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/27
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/28
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/29
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/30
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/31
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/32
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/33
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/34
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/35
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/36
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/37
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/38
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/39
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/40
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/41
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/42
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/43
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/44
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/45
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/46
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/47
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/48
+    type: 100gbase-x-qsfp28

--- a/module-types/Cisco/C9600-LC-48S.yaml
+++ b/module-types/Cisco/C9600-LC-48S.yaml
@@ -1,0 +1,102 @@
+---
+manufacturer: Cisco
+model: C9600-LC-48S
+part_number: C9600-LC-48S
+comments: '[Cisco Catalyst 9600 Series Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-series-line-data-sheet-cte-en.html)'
+interfaces:
+  - name: GigabitEthernet{module}/0/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/2
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/4
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/5
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/6
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/7
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/8
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/9
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/10
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/11
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/12
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/13
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/14
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/15
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/16
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/17
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/18
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/19
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/20
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/21
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/22
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/23
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/24
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/25
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/26
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/27
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/28
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/29
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/30
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/31
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/32
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/33
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/34
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/35
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/36
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/37
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/38
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/39
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/40
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/41
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/42
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/43
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/44
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/45
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/46
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/47
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/0/48
+    type: 1000base-x-sfp

--- a/module-types/Cisco/C9600-LC-48TX.yaml
+++ b/module-types/Cisco/C9600-LC-48TX.yaml
@@ -1,0 +1,102 @@
+---
+manufacturer: Cisco
+model: C9600-LC-48TX
+part_number: C9600-LC-48TX
+comments: '[Cisco Catalyst 9600 Series Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-series-line-data-sheet-cte-en.html)'
+interfaces:
+  - name: TenGigabitEthernet{module}/0/1
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/2
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/3
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/4
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/5
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/6
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/7
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/8
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/9
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/10
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/11
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/12
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/13
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/14
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/15
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/16
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/17
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/18
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/19
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/20
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/21
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/22
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/23
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/24
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/25
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/26
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/27
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/28
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/29
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/30
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/31
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/32
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/33
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/34
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/35
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/36
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/37
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/38
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/39
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/40
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/41
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/42
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/43
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/44
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/45
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/46
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/47
+    type: 10gbase-t
+  - name: TenGigabitEthernet{module}/0/48
+    type: 10gbase-t

--- a/module-types/Cisco/C9600-LC-48YL.yaml
+++ b/module-types/Cisco/C9600-LC-48YL.yaml
@@ -1,0 +1,102 @@
+---
+manufacturer: Cisco
+model: C9600-LC-48YL
+part_number: C9600-LC-48YL
+comments: '[Cisco Catalyst 9600 Series Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-series-line-data-sheet-cte-en.html)'
+interfaces:
+  - name: TwentyFiveGigE{module}/0/1
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/2
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/3
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/4
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/5
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/6
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/7
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/8
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/9
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/10
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/11
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/12
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/13
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/14
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/15
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/16
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/17
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/18
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/19
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/20
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/21
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/22
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/23
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/24
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/25
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/26
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/27
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/28
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/29
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/30
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/31
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/32
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/33
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/34
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/35
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/36
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/37
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/38
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/39
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/40
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/41
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/42
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/43
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/44
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/45
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/46
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/47
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/48
+    type: 25gbase-x-sfp28

--- a/module-types/Cisco/C9600-SUP-1.yaml
+++ b/module-types/Cisco/C9600-SUP-1.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Cisco
+model: C9600-SUP-1
+part_number: C9600-SUP-1
+comments: '[Cisco Catalyst 9600 Series Supervisor Engine Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-ser-sup-eng-data-sheet-cte-en.html)'
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-mini-b
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: TenGigabitEthernet{module}/0/0
+    type: 10gbase-x-sfpp
+    mgmt_only: true

--- a/module-types/Cisco/C9600X-SUP-2.yaml
+++ b/module-types/Cisco/C9600X-SUP-2.yaml
@@ -1,0 +1,20 @@
+---
+manufacturer: Cisco
+model: C9600X-SUP-2
+part_number: C9600X-SUP-2
+comments: '[Cisco Catalyst 9600 Series Supervisor Engine Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-ser-sup-eng-data-sheet-cte-en.html)'
+console-ports:
+  - name: con 0
+    type: rj-45
+  - name: usb
+    type: usb-mini-b
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
+  - name: TenGigabitEthernet{module}/0/0
+    type: 10gbase-x-sfpp
+    mgmt_only: true
+  - name: TenGigabitEthernet{module}/0/1
+    type: 10gbase-x-sfpp
+    mgmt_only: true


### PR DESCRIPTION
Add Cisco Catalyst 9606R with the following modules
- C9600-LC-24C
- C9600-LC-48S
- C9600-LC-48TX
- C9600-LC-48YL
- C9600-SUP-1
- C9600X-SUP-2