### PR TITLE
Update Juniper SRX 300-series devices

### DIFF
--- a/device-types/Juniper/SRX300.yaml
+++ b/device-types/Juniper/SRX300.yaml
@@ -28,3 +28,4 @@ interfaces:
 power-ports:
   - name: PSU0
     type: iec-60320-c14
+    allocated_draw: 25

--- a/device-types/Juniper/SRX320.yaml
+++ b/device-types/Juniper/SRX320.yaml
@@ -4,7 +4,7 @@ model: SRX320
 slug: srx320
 u_height: 1
 is_full_depth: false
-comments: '[Juniper SRX320 Data Sheet](https://www.juniper.net/assets/us/en/local/pdf/datasheets/1000550-en.pdf)'
+comments: '[Juniper SRX320 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/security/srx300-line-services-gateways-branch-datasheet.pdf)'
 console-ports:
   - name: Console
     type: rj-45
@@ -28,3 +28,4 @@ interfaces:
 power-ports:
   - name: PSU0
     type: iec-60320-c14
+    allocated_draw: 46

--- a/device-types/Juniper/SRX340.yaml
+++ b/device-types/Juniper/SRX340.yaml
@@ -2,6 +2,12 @@
 manufacturer: Juniper
 model: SRX340
 slug: srx340
+u_height: 1
+is_full_depth: false
+comments: '[Juniper SRX340 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/security/srx300-line-services-gateways-branch-datasheet.pdf)'
+console-ports:
+  - name: Console
+    type: rj-45
 interfaces:
   - name: ge-0/0/0
     type: 1000base-t
@@ -37,9 +43,6 @@ interfaces:
     type: 1000base-x-sfp
   - name: me0
     type: 1000base-t
-console-ports:
-  - name: Console
-    type: rj-45
 power-ports:
   - name: PSU0
     type: iec-60320-c14

--- a/device-types/Juniper/SRX345.yaml
+++ b/device-types/Juniper/SRX345.yaml
@@ -2,7 +2,12 @@
 manufacturer: Juniper
 model: SRX345
 slug: srx345
+u_height: 1
 is_full_depth: false
+comments: '[Juniper SRX345 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/security/srx300-line-services-gateways-branch-datasheet.pdf)'
+console-ports:
+  - name: Console
+    type: rj-45
 interfaces:
   - name: fxp0
     type: 1000base-t
@@ -42,6 +47,4 @@ interfaces:
 power-ports:
   - name: PSU0
     type: iec-60320-c14
-console-ports:
-  - name: Console
-    type: rj-45
+    allocated_draw: 122


### PR DESCRIPTION
- include power draw
- include link to datasheet
- include height
- include full depth indicator
- use same attribute order for devices

I've left out srx380 in this as I'm not sure what the intention with that one was, its attributes are inconsistent with the rest of the series.