### PR TITLE
Extend tests to check for null/empty values

### DIFF
--- a/device-types/Arista/CCS-720XP-24Y6.yaml
+++ b/device-types/Arista/CCS-720XP-24Y6.yaml
@@ -5,7 +5,6 @@ slug: ccs-720xp-24y6
 part_number: CCS-720XP-24Y6
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/CCS-720XP-24ZY4.yaml
+++ b/device-types/Arista/CCS-720XP-24ZY4.yaml
@@ -5,7 +5,6 @@ slug: ccs-720xp-24zy4
 part_number: CCS-720XP-24ZY4
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/CCS-720XP-48Y6.yaml
+++ b/device-types/Arista/CCS-720XP-48Y6.yaml
@@ -5,7 +5,6 @@ slug: ccs-720xp-48y6
 part_number: CCS-720XP-48Y6
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/CCS-720XP-48ZC2.yaml
+++ b/device-types/Arista/CCS-720XP-48ZC2.yaml
@@ -5,7 +5,6 @@ slug: ccs-720xp-48zc2
 part_number: CCS-720XP-48ZC2
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/CCS-720XP-96ZC2.yaml
+++ b/device-types/Arista/CCS-720XP-96ZC2.yaml
@@ -5,7 +5,6 @@ slug: ccs-720xp-96zc2
 part_number: CCS-720XP-96ZC2
 u_height: 2
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7010T-48.yaml
+++ b/device-types/Arista/DCS-7010T-48.yaml
@@ -5,7 +5,6 @@ slug: dcs-7010t-48
 part_number: DCS-7010T-48
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7010TX-48.yaml
+++ b/device-types/Arista/DCS-7010TX-48.yaml
@@ -5,7 +5,6 @@ slug: dcs-7010tx-48
 part_number: DCS-7010TX-48
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7020SR-24C2.yaml
+++ b/device-types/Arista/DCS-7020SR-24C2.yaml
@@ -5,7 +5,6 @@ slug: dcs-7020sr-24c2
 part_number: DCS-7020SR-24C2
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7020SR-32C2.yaml
+++ b/device-types/Arista/DCS-7020SR-32C2.yaml
@@ -5,7 +5,6 @@ slug: dcs-7020sr-32c2
 part_number: DCS-7020SR-32C2
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7020TR-48.yaml
+++ b/device-types/Arista/DCS-7020TR-48.yaml
@@ -5,7 +5,6 @@ slug: dcs-7020tr-48
 part_number: DCS-7020TR-48
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7050CX3-32S.yaml
+++ b/device-types/Arista/DCS-7050CX3-32S.yaml
@@ -5,7 +5,6 @@ slug: dcs-7050cx3-32s
 part_number: DCS-7050CX3-32S
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7050QX-32S.yaml
+++ b/device-types/Arista/DCS-7050QX-32S.yaml
@@ -5,7 +5,6 @@ slug: dcs-7050QX-32s
 part_number: DCS-7050QX-32S
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7050SX3-48YC12.yaml
+++ b/device-types/Arista/DCS-7050SX3-48YC12.yaml
@@ -5,7 +5,6 @@ slug: dcs-7050sx3-48yc12
 part_number: DCS-7050SX3-48YC12
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7050SX3-48YC8.yaml
+++ b/device-types/Arista/DCS-7050SX3-48YC8.yaml
@@ -5,7 +5,6 @@ slug: dcs-7050sx3-48yc8
 part_number: DCS-7050SX3-48YC8
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7050TX3-48C8.yaml
+++ b/device-types/Arista/DCS-7050TX3-48C8.yaml
@@ -5,7 +5,6 @@ slug: dcs-7050tx3-48c8
 part_number: DCS-7050TX3-48C8
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7124SX.yaml
+++ b/device-types/Arista/DCS-7124SX.yaml
@@ -5,7 +5,6 @@ slug: dcs-7124sx
 part_number: DCS-7124SX
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7148SX.yaml
+++ b/device-types/Arista/DCS-7148SX.yaml
@@ -5,7 +5,6 @@ slug: dcs-7148sx
 part_number: DCS-7148SX
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7150S-24.yaml
+++ b/device-types/Arista/DCS-7150S-24.yaml
@@ -5,7 +5,6 @@ slug: dcs-7150s-24
 part_number: DCS-7150S-24
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7150S-52.yaml
+++ b/device-types/Arista/DCS-7150S-52.yaml
@@ -5,7 +5,6 @@ slug: dcs-7150s-52
 part_number: DCS-7150S-52
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7150S-64.yaml
+++ b/device-types/Arista/DCS-7150S-64.yaml
@@ -5,7 +5,6 @@ slug: dcs-7150s-64
 part_number: DCS-7150S-64
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7150SC-24.yaml
+++ b/device-types/Arista/DCS-7150SC-24.yaml
@@ -5,7 +5,6 @@ slug: dcs-7150sc-24
 part_number: DCS-7150SC-24
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7150SC-64.yaml
+++ b/device-types/Arista/DCS-7150SC-64.yaml
@@ -5,7 +5,6 @@ slug: dcs-7150sc-64
 part_number: DCS-7150SC-64
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7260CX3-64-F.yaml
+++ b/device-types/Arista/DCS-7260CX3-64-F.yaml
@@ -5,7 +5,6 @@ slug: dcs-7260cx3-64-f
 part_number: DCS-7260CX3-64-F
 u_height: 2
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280CR2-60.yaml
+++ b/device-types/Arista/DCS-7280CR2-60.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280cr2-60
 part_number: DCS-7280CR2-60
 u_height: 2
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280CR2A-30.yaml
+++ b/device-types/Arista/DCS-7280CR2A-30.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280cr2a-30
 part_number: DCS-7280CR2A-30
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280CR3-32D4.yaml
+++ b/device-types/Arista/DCS-7280CR3-32D4.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280cr3-32d4
 part_number: DCS-7280CR3-32D4
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280CR3-32P4.yaml
+++ b/device-types/Arista/DCS-7280CR3-32P4.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280cr3-32p4
 part_number: DCS-7280CR3-32P4
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280QR-C36.yaml
+++ b/device-types/Arista/DCS-7280QR-C36.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280qr-c36
 part_number: DCS-7280QR-C36
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280SR-48C6.yaml
+++ b/device-types/Arista/DCS-7280SR-48C6.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280sr-48c6
 part_number: DCS-7280SR-48C6
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280SR-48YC6.yaml
+++ b/device-types/Arista/DCS-7280SR-48YC6.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280sr-48yc6
 part_number: DCS-7280SR-48YC6
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280SR2-48YC6.yaml
+++ b/device-types/Arista/DCS-7280SR2-48YC6.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280sr2-48yc6
 part_number: DCS-7280SR2-48YC6
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280SR2K-48C6-M.yaml
+++ b/device-types/Arista/DCS-7280SR2K-48C6-M.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280sr2k-48c6-m
 part_number: DCS-7280SR2K-48C6-M
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280SR3-48YC8.yaml
+++ b/device-types/Arista/DCS-7280SR3-48YC8.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280sr3-48yc8
 part_number: DCS-7280SR3-48YC8
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280SRA-48C6-M.yaml
+++ b/device-types/Arista/DCS-7280SRA-48C6-M.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280sra-48c6-m
 part_number: DCS-7280SRA-48C6-M
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280SRA-48C6.yaml
+++ b/device-types/Arista/DCS-7280SRA-48C6.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280sra-48c6
 part_number: DCS-7280SRA-48C6
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Arista/DCS-7280TR-48C6.yaml
+++ b/device-types/Arista/DCS-7280TR-48C6.yaml
@@ -5,7 +5,6 @@ slug: dcs-7280tr-48c6
 part_number: DCS-7280TR-48C6
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Aruba/6000-12G-R8N89A.yaml
+++ b/device-types/Aruba/6000-12G-R8N89A.yaml
@@ -5,7 +5,6 @@ slug: 6000-12g-poe4-2sfp-139w
 part_number: R8N89A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6000-24G-PoE-370W-R8N87A.yaml
+++ b/device-types/Aruba/6000-24G-PoE-370W-R8N87A.yaml
@@ -5,7 +5,6 @@ slug: 6000-24g-poe4-4sfp-370w
 part_number: R8N87A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6000-24G-R8N88A.yaml
+++ b/device-types/Aruba/6000-24G-R8N88A.yaml
@@ -5,7 +5,6 @@ slug: 6000-24g-4sfp
 part_number: R8N88A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6000-48G-PoE-370W-R8N85A.yaml
+++ b/device-types/Aruba/6000-48G-PoE-370W-R8N85A.yaml
@@ -5,7 +5,6 @@ slug: 6000-48g-poe4-4sfp-370w
 part_number: R8N85A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6000-48G-R8N86A.yaml
+++ b/device-types/Aruba/6000-48G-R8N86A.yaml
@@ -5,7 +5,6 @@ slug: 6000-48g-4sfp
 part_number: R8N86A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6100-12G-JL679A.yaml
+++ b/device-types/Aruba/6100-12G-JL679A.yaml
@@ -5,7 +5,6 @@ slug: 6100-12g-poe4-2sfpp-139w
 part_number: JL679A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6100-24G-JL678A.yaml
+++ b/device-types/Aruba/6100-24G-JL678A.yaml
@@ -5,7 +5,6 @@ slug: 6100-24g-4sfpp
 part_number: JL678A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6100-24G-PoE-370W-JL677A.yaml
+++ b/device-types/Aruba/6100-24G-PoE-370W-JL677A.yaml
@@ -5,7 +5,6 @@ slug: 6100-24g-poe4-4sfpp-370w
 part_number: JL677A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6100-48G-JL676A.yaml
+++ b/device-types/Aruba/6100-48G-JL676A.yaml
@@ -5,7 +5,6 @@ slug: 6100-48g-4sfpp
 part_number: JL675A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6100-48G-PoE-370W-JL675A.yaml
+++ b/device-types/Aruba/6100-48G-PoE-370W-JL675A.yaml
@@ -5,7 +5,6 @@ slug: 6100-48g-poe4-4sfpp-370w
 part_number: JL675A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6200F-24G-JL724A.yaml
+++ b/device-types/Aruba/6200F-24G-JL724A.yaml
@@ -5,7 +5,6 @@ slug: 6200f-24g-poe4-4sfpp-370w
 part_number: JL725A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6200F-24G-PoE-370W-JL725A.yaml
+++ b/device-types/Aruba/6200F-24G-PoE-370W-JL725A.yaml
@@ -5,7 +5,6 @@ slug: 6200f-24g-4sfpp
 part_number: JL724A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6200F-48G-JL726A.yaml
+++ b/device-types/Aruba/6200F-48G-JL726A.yaml
@@ -5,7 +5,6 @@ slug: 6200f-48g-4sfpp
 part_number: JL726A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6200F-48G-PoE-370W-JL727A.yaml
+++ b/device-types/Aruba/6200F-48G-PoE-370W-JL727A.yaml
@@ -5,7 +5,6 @@ slug: 6200f-48g-poe4-4sfpp-370w
 part_number: JL727A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6200F-48G-PoE-740W-JL728A.yaml
+++ b/device-types/Aruba/6200F-48G-PoE-740W-JL728A.yaml
@@ -5,7 +5,6 @@ slug: 6200f-48g-poe4-4sfpp-740w
 part_number: JL728A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300F-24G-JL666A.yaml
+++ b/device-types/Aruba/6300F-24G-JL666A.yaml
@@ -5,7 +5,6 @@ slug: 6300f-24g-poe4-4sfp56
 part_number: JL666A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300F-24G-JL668A.yaml
+++ b/device-types/Aruba/6300F-24G-JL668A.yaml
@@ -5,7 +5,6 @@ slug: 6300f-24g-4sfp56
 part_number: JL668A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300F-48G-JL665A.yaml
+++ b/device-types/Aruba/6300F-48G-JL665A.yaml
@@ -5,7 +5,6 @@ slug: 6300f-48g-poe4-4sfp56
 part_number: JL665A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300F-48G-JL667A.yaml
+++ b/device-types/Aruba/6300F-48G-JL667A.yaml
@@ -5,7 +5,6 @@ slug: 6300f-48g-4sfp56
 part_number: JL667A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300M-24G-JL658A.yaml
+++ b/device-types/Aruba/6300M-24G-JL658A.yaml
@@ -5,7 +5,6 @@ slug: 6300m-24sfpp-4sfp56
 part_number: JL658A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300M-24G-JL660A.yaml
+++ b/device-types/Aruba/6300M-24G-JL660A.yaml
@@ -5,7 +5,6 @@ slug: 6300m-24gsr-poe6-4sfp56
 part_number: JL660A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300M-24G-JL662A.yaml
+++ b/device-types/Aruba/6300M-24G-JL662A.yaml
@@ -5,7 +5,6 @@ slug: 6300m-24g-poe4-4sfp56
 part_number: JL662A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300M-24G-JL664A.yaml
+++ b/device-types/Aruba/6300M-24G-JL664A.yaml
@@ -5,7 +5,6 @@ slug: 6300m-24g-4sfp56
 part_number: JL664A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300M-48G-JL659A.yaml
+++ b/device-types/Aruba/6300M-48G-JL659A.yaml
@@ -5,7 +5,6 @@ slug: 6300m-48gsr-poe6-4sfp56
 part_number: JL659A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300M-48G-JL661A.yaml
+++ b/device-types/Aruba/6300M-48G-JL661A.yaml
@@ -5,7 +5,6 @@ slug: 6300m-48g-poe4-4sfp56
 part_number: JL661A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/6300M-48G-JL663A.yaml
+++ b/device-types/Aruba/6300M-48G-JL663A.yaml
@@ -5,7 +5,6 @@ slug: 6300m-48g-4sfp56
 part_number: JL663A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: usb-c
     type: usb-c

--- a/device-types/Aruba/8320-32Q.yaml
+++ b/device-types/Aruba/8320-32Q.yaml
@@ -5,7 +5,6 @@ slug: 8320-32q
 part_number: JL579A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: rj45-console
     type: rj-45

--- a/device-types/Aruba/8320-48XF6Q.yaml
+++ b/device-types/Aruba/8320-48XF6Q.yaml
@@ -5,7 +5,6 @@ slug: 8320-48xf6q
 part_number: JL479A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: rj45-console
     type: rj-45

--- a/device-types/Aruba/8320-48XT6Q.yaml
+++ b/device-types/Aruba/8320-48XT6Q.yaml
@@ -5,7 +5,6 @@ slug: 8320-48xt6q
 part_number: JL581A
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: rj45-console
     type: rj-45

--- a/device-types/Calix/E7-2.yaml
+++ b/device-types/Calix/E7-2.yaml
@@ -5,11 +5,8 @@ slug: e7-2
 part_number: 000-00372
 u_height: 1
 is_full_depth: false
-comments: ''
 module-bays:
   - name: slot 1
-    label: ''
     position: '1'
   - name: slot 2
-    label: ''
     position: '2'

--- a/device-types/Calix/E7-20.yaml
+++ b/device-types/Calix/E7-20.yaml
@@ -5,87 +5,58 @@ slug: e7-20
 part_number: 100-02089
 u_height: 13
 is_full_depth: false
-comments: ''
 interfaces:
   - name: mgmt 1
     type: 1000base-t
     mgmt_only: true
-    label: ''
-    description: ''
   - name: mgmt 3A
     type: 1000base-t
     mgmt_only: true
-    label: ''
-    description: ''
   - name: mgmt 3B
     type: 1000base-t
     mgmt_only: true
-    label: ''
-    description: ''
 module-bays:
   - name: slot 1
-    label: ''
     position: '1'
   - name: slot 2
-    label: ''
     position: '2'
   - name: slot 3
-    label: ''
     position: '3'
   - name: slot 4
-    label: ''
     position: '4'
   - name: slot 5
-    label: ''
     position: '5'
   - name: slot 6
-    label: ''
     position: '6'
   - name: slot 7
-    label: ''
     position: '7'
   - name: slot 8
-    label: ''
     position: '8'
   - name: slot 9
-    label: ''
     position: '9'
   - name: slot 10
-    label: ''
     position: '10'
   - name: slot 11
-    label: ''
     position: '11'
   - name: slot 12
-    label: ''
     position: '12'
   - name: slot 13
-    label: ''
     position: '13'
   - name: slot 14
-    label: ''
     position: '14'
   - name: slot 15
-    label: ''
     position: '15'
   - name: slot 16
-    label: ''
     position: '16'
   - name: slot 17
-    label: ''
     position: '17'
   - name: slot 18
-    label: ''
     position: '18'
   - name: slot 19
-    label: ''
     position: '19'
   - name: slot 20
-    label: ''
     position: '20'
   - name: slot A
-    label: ''
-    position: 'A'
+    position: A
   - name: slot B
-    label: ''
-    position: 'B'
+    position: B

--- a/device-types/Cisco/WS-C3750E-24TD.yaml
+++ b/device-types/Cisco/WS-C3750E-24TD.yaml
@@ -61,13 +61,9 @@ interfaces:
   - name: StackPort1
     type: cisco-stackwise-plus
     mgmt_only: false
-    label: ''
-    description: ''
   - name: StackPort2
     type: cisco-stackwise-plus
     mgmt_only: false
-    label: ''
-    description: ''
 console-ports:
   - name: con0
     type: rj-45

--- a/device-types/Extreme Networks/BR-MLXE-16-MR2-M-AC.yaml
+++ b/device-types/Extreme Networks/BR-MLXE-16-MR2-M-AC.yaml
@@ -5,7 +5,6 @@ slug: br-mlxe-16-mr2
 part_number: BR-MLXE-16-MR2-AC
 u_height: 14
 is_full_depth: true
-comments: ''
 power-ports:
   - name: PSU1
     type: iec-60320-c20

--- a/device-types/Extreme Networks/BR-MLXE-32-MR2-M-AC.yaml
+++ b/device-types/Extreme Networks/BR-MLXE-32-MR2-M-AC.yaml
@@ -5,7 +5,6 @@ slug: br-mlxe-32-mr2
 part_number: BR-MLXE-32-MR2-AC
 u_height: 33
 is_full_depth: true
-comments: ''
 power-ports:
   - name: PSU1
     type: iec-60320-c20

--- a/device-types/Extreme Networks/BR-MLXE-4-MR2-M-AC.yaml
+++ b/device-types/Extreme Networks/BR-MLXE-4-MR2-M-AC.yaml
@@ -5,7 +5,6 @@ slug: br-mlxe-4-mr2
 part_number: BR-MLXE-4-MR2-AC
 u_height: 5
 is_full_depth: true
-comments: ''
 power-ports:
   - name: PSU1
     type: iec-60320-c20

--- a/device-types/Extreme Networks/BR-MLXE-8-MR2-M-AC.yaml
+++ b/device-types/Extreme Networks/BR-MLXE-8-MR2-M-AC.yaml
@@ -5,7 +5,6 @@ slug: br-mlxe-8-mr2
 part_number: BR-MLXE-8-MR2-AC
 u_height: 7
 is_full_depth: true
-comments: ''
 power-ports:
   - name: PSU1
     type: iec-60320-c20

--- a/device-types/Extreme Networks/BR-SLX-9140-48V-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9140-48V-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9140-48v
 part_number: BR-SLX-9140-48V
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: usb-mini-b

--- a/device-types/Extreme Networks/BR-SLX-9150-48XT-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9150-48XT-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9150-48xt
 part_number: BR-SLX-9150-48XT
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Extreme Networks/BR-SLX-9150-48Y-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9150-48Y-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9150-48y
 part_number: BR-SLX-9150-48Y
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Extreme Networks/BR-SLX-9240-32C-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9240-32C-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9240-32c
 part_number: BR-SLX-9240-32C
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: usb-mini-b

--- a/device-types/Extreme Networks/BR-SLX-9250-32C-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9250-32C-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9250-32c
 part_number: BR-SLX-9250-32C
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Extreme Networks/BR-SLX-9540-48S-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9540-48S-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9540-48s
 part_number: BR-SLX-9540-48S
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Extreme Networks/BR-SLX-9640-24S-12C-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9640-24S-12C-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9640-24s-12c
 part_number: BR-SLX-9640-24S-12C
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: usb-mini-b

--- a/device-types/Extreme Networks/BR-SLX-9740-40C-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9740-40C-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9740-40c
 part_number: BR-SLX-9740-40C
 u_height: 1
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Extreme Networks/BR-SLX-9740-80C-AC.yaml
+++ b/device-types/Extreme Networks/BR-SLX-9740-80C-AC.yaml
@@ -5,7 +5,6 @@ slug: br-slx-9740-80c
 part_number: BR-SLX-9740-80C
 u_height: 2
 is_full_depth: true
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/FS/FMU-C182761M.yaml
+++ b/device-types/FS/FMU-C182761M.yaml
@@ -5,119 +5,81 @@ slug: fmu-c182761m
 part_number: FMU-C182761M
 u_height: 1
 is_full_depth: false
-comments: '18 Channels 1270-1610nm, with Monitor Port, LC/UPC, Dual Fiber CWDM Mux Demux, 1U Rack Mount'
+comments: 18 Channels 1270-1610nm, with Monitor Port, LC/UPC, Dual Fiber CWDM Mux Demux, 1U Rack Mount
 front-ports:
-  - name: '1270nm'
+  - name: 1270nm
     type: lc
     rear_port: LINE
     rear_port_position: 1
-    label: ''
-    description: ''
-  - name: '1290nm'
+  - name: 1290nm
     type: lc
     rear_port: LINE
     rear_port_position: 2
-    label: ''
-    description: ''
-  - name: '1310nm'
+  - name: 1310nm
     type: lc
     rear_port: LINE
     rear_port_position: 3
-    label: ''
-    description: ''
-  - name: '1330nm'
+  - name: 1330nm
     type: lc
     rear_port: LINE
     rear_port_position: 4
-    label: ''
-    description: ''
-  - name: '1350nm'
+  - name: 1350nm
     type: lc
     rear_port: LINE
     rear_port_position: 5
-    label: ''
-    description: ''
-  - name: '1370nm'
+  - name: 1370nm
     type: lc
     rear_port: LINE
     rear_port_position: 6
-    label: ''
-    description: ''
-  - name: '1390nm'
+  - name: 1390nm
     type: lc
     rear_port: LINE
     rear_port_position: 7
-    label: ''
-    description: ''
-  - name: '1410nm'
+  - name: 1410nm
     type: lc
     rear_port: LINE
     rear_port_position: 8
-    label: ''
-    description: ''
-  - name: '1430nm'
+  - name: 1430nm
     type: lc
     rear_port: LINE
     rear_port_position: 9
-    label: ''
-    description: ''
-  - name: '1450nm'
+  - name: 1450nm
     type: lc
     rear_port: LINE
     rear_port_position: 10
-    label: ''
-    description: ''
-  - name: '1470nm'
+  - name: 1470nm
     type: lc
     rear_port: LINE
     rear_port_position: 11
-    label: ''
-    description: ''
-  - name: '1490nm'
+  - name: 1490nm
     type: lc
     rear_port: LINE
     rear_port_position: 12
-    label: ''
-    description: ''
-  - name: '1510nm'
+  - name: 1510nm
     type: lc
     rear_port: LINE
     rear_port_position: 13
-    label: ''
-    description: ''
-  - name: '1530nm'
+  - name: 1530nm
     type: lc
     rear_port: LINE
     rear_port_position: 14
-    label: ''
-    description: ''
-  - name: '1550nm'
+  - name: 1550nm
     type: lc
     rear_port: LINE
     rear_port_position: 15
-    label: ''
-    description: ''
-  - name: '1570nm'
+  - name: 1570nm
     type: lc
     rear_port: LINE
     rear_port_position: 16
-    label: ''
-    description: ''
-  - name: '1590nm'
+  - name: 1590nm
     type: lc
     rear_port: LINE
     rear_port_position: 17
-    label: ''
-    description: ''
-  - name: '1610nm'
+  - name: 1610nm
     type: lc
     rear_port: LINE
     rear_port_position: 18
-    label: ''
-    description: ''
 rear-ports:
-  - name: 'LINE'
+  - name: LINE
     type: lc
     positions: 18
-    label: ''
-    description: ''

--- a/device-types/FS/FMU-D402160M.yaml
+++ b/device-types/FS/FMU-D402160M.yaml
@@ -5,251 +5,169 @@ slug: fmu-d402160m
 part_number: FMU-D402160M
 u_height: 1
 is_full_depth: false
-comments: '40 Channels 100GHz C21-C60, with Monitor Port, LC/UPC, Dual Fiber DWDM Mux Demux, 1U Rack Mount'
+comments: 40 Channels 100GHz C21-C60, with Monitor Port, LC/UPC, Dual Fiber DWDM Mux Demux, 1U Rack Mount
 front-ports:
-  - name: 'C21'
+  - name: C21
     type: lc
     rear_port: LINE
     rear_port_position: 1
-    label: ''
-    description: ''
-  - name: 'C22'
+  - name: C22
     type: lc
     rear_port: LINE
     rear_port_position: 2
-    label: ''
-    description: ''
-  - name: 'C23'
+  - name: C23
     type: lc
     rear_port: LINE
     rear_port_position: 3
-    label: ''
-    description: ''
-  - name: 'C24'
+  - name: C24
     type: lc
     rear_port: LINE
     rear_port_position: 4
-    label: ''
-    description: ''
-  - name: 'C25'
+  - name: C25
     type: lc
     rear_port: LINE
     rear_port_position: 5
-    label: ''
-    description: ''
-  - name: 'C26'
+  - name: C26
     type: lc
     rear_port: LINE
     rear_port_position: 6
-    label: ''
-    description: ''
-  - name: 'C27'
+  - name: C27
     type: lc
     rear_port: LINE
     rear_port_position: 7
-    label: ''
-    description: ''
-  - name: 'C28'
+  - name: C28
     type: lc
     rear_port: LINE
     rear_port_position: 8
-    label: ''
-    description: ''
-  - name: 'C29'
+  - name: C29
     type: lc
     rear_port: LINE
     rear_port_position: 9
-    label: ''
-    description: ''
-  - name: 'C30'
+  - name: C30
     type: lc
     rear_port: LINE
     rear_port_position: 10
-    label: ''
-    description: ''
-  - name: 'C31'
+  - name: C31
     type: lc
     rear_port: LINE
     rear_port_position: 11
-    label: ''
-    description: ''
-  - name: 'C32'
+  - name: C32
     type: lc
     rear_port: LINE
     rear_port_position: 12
-    label: ''
-    description: ''
-  - name: 'C33'
+  - name: C33
     type: lc
     rear_port: LINE
     rear_port_position: 13
-    label: ''
-    description: ''
-  - name: 'C34'
+  - name: C34
     type: lc
     rear_port: LINE
     rear_port_position: 14
-    label: ''
-    description: ''
-  - name: 'C35'
+  - name: C35
     type: lc
     rear_port: LINE
     rear_port_position: 15
-    label: ''
-    description: ''
-  - name: 'C36'
+  - name: C36
     type: lc
     rear_port: LINE
     rear_port_position: 16
-    label: ''
-    description: ''
-  - name: 'C37'
+  - name: C37
     type: lc
     rear_port: LINE
     rear_port_position: 17
-    label: ''
-    description: ''
-  - name: 'C38'
+  - name: C38
     type: lc
     rear_port: LINE
     rear_port_position: 18
-    label: ''
-    description: ''
-  - name: 'C39'
+  - name: C39
     type: lc
     rear_port: LINE
     rear_port_position: 19
-    label: ''
-    description: ''
-  - name: 'C40'
+  - name: C40
     type: lc
     rear_port: LINE
     rear_port_position: 20
-    label: ''
-    description: ''
-  - name: 'C41'
+  - name: C41
     type: lc
     rear_port: LINE
     rear_port_position: 21
-    label: ''
-    description: ''
-  - name: 'C42'
+  - name: C42
     type: lc
     rear_port: LINE
     rear_port_position: 22
-    label: ''
-    description: ''
-  - name: 'C43'
+  - name: C43
     type: lc
     rear_port: LINE
     rear_port_position: 23
-    label: ''
-    description: ''
-  - name: 'C44'
+  - name: C44
     type: lc
     rear_port: LINE
     rear_port_position: 24
-    label: ''
-    description: ''
-  - name: 'C45'
+  - name: C45
     type: lc
     rear_port: LINE
     rear_port_position: 25
-    label: ''
-    description: ''
-  - name: 'C46'
+  - name: C46
     type: lc
     rear_port: LINE
     rear_port_position: 26
-    label: ''
-    description: ''
-  - name: 'C47'
+  - name: C47
     type: lc
     rear_port: LINE
     rear_port_position: 27
-    label: ''
-    description: ''
-  - name: 'C48'
+  - name: C48
     type: lc
     rear_port: LINE
     rear_port_position: 28
-    label: ''
-    description: ''
-  - name: 'C49'
+  - name: C49
     type: lc
     rear_port: LINE
     rear_port_position: 29
-    label: ''
-    description: ''
-  - name: 'C50'
+  - name: C50
     type: lc
     rear_port: LINE
     rear_port_position: 30
-    label: ''
-    description: ''
-  - name: 'C51'
+  - name: C51
     type: lc
     rear_port: LINE
     rear_port_position: 31
-    label: ''
-    description: ''
-  - name: 'C52'
+  - name: C52
     type: lc
     rear_port: LINE
     rear_port_position: 32
-    label: ''
-    description: ''
-  - name: 'C53'
+  - name: C53
     type: lc
     rear_port: LINE
     rear_port_position: 33
-    label: ''
-    description: ''
-  - name: 'C54'
+  - name: C54
     type: lc
     rear_port: LINE
     rear_port_position: 34
-    label: ''
-    description: ''
-  - name: 'C55'
+  - name: C55
     type: lc
     rear_port: LINE
     rear_port_position: 35
-    label: ''
-    description: ''
-  - name: 'C56'
+  - name: C56
     type: lc
     rear_port: LINE
     rear_port_position: 36
-    label: ''
-    description: ''
-  - name: 'C57'
+  - name: C57
     type: lc
     rear_port: LINE
     rear_port_position: 37
-    label: ''
-    description: ''
-  - name: 'C58'
+  - name: C58
     type: lc
     rear_port: LINE
     rear_port_position: 38
-    label: ''
-    description: ''
-  - name: 'C59'
+  - name: C59
     type: lc
     rear_port: LINE
     rear_port_position: 39
-    label: ''
-    description: ''
-  - name: 'C60'
+  - name: C60
     type: lc
     rear_port: LINE
     rear_port_position: 40
-    label: ''
-    description: ''
 rear-ports:
-  - name: 'LINE'
+  - name: LINE
     type: lc
     positions: 40
-    label: ''
-    description: ''

--- a/device-types/FS/FMU-MD085360EM3.yaml
+++ b/device-types/FS/FMU-MD085360EM3.yaml
@@ -6,59 +6,41 @@ part_number: FMU-MD085360EM3
 u_height: 0
 is_full_depth: false
 subdevice_role: child
-comments: '8 Channels 100GHz C53-C60, with Monitor, Expansion and 1310nm Port, LC/UPC, Dual Fiber DWDM Mux Demux, FMU Plug-in Module'
+comments: 8 Channels 100GHz C53-C60, with Monitor, Expansion and 1310nm Port, LC/UPC, Dual Fiber DWDM Mux Demux, FMU Plug-in Module
 front-ports:
-  - name: 'C53'
+  - name: C53
     type: lc
     rear_port: LINE
     rear_port_position: 33
-    label: ''
-    description: ''
-  - name: 'C54'
+  - name: C54
     type: lc
     rear_port: LINE
     rear_port_position: 34
-    label: ''
-    description: ''
-  - name: 'C55'
+  - name: C55
     type: lc
     rear_port: LINE
     rear_port_position: 35
-    label: ''
-    description: ''
-  - name: 'C56'
+  - name: C56
     type: lc
     rear_port: LINE
     rear_port_position: 36
-    label: ''
-    description: ''
-  - name: 'C57'
+  - name: C57
     type: lc
     rear_port: LINE
     rear_port_position: 37
-    label: ''
-    description: ''
-  - name: 'C58'
+  - name: C58
     type: lc
     rear_port: LINE
     rear_port_position: 38
-    label: ''
-    description: ''
-  - name: 'C59'
+  - name: C59
     type: lc
     rear_port: LINE
     rear_port_position: 39
-    label: ''
-    description: ''
-  - name: 'C60'
+  - name: C60
     type: lc
     rear_port: LINE
     rear_port_position: 40
-    label: ''
-    description: ''
 rear-ports:
-  - name: 'LINE'
+  - name: LINE
     type: lc
     positions: 40
-    label: ''
-    description: ''

--- a/device-types/Factor-TS/DIONIS-DPS-2004-RM-4E.yaml
+++ b/device-types/Factor-TS/DIONIS-DPS-2004-RM-4E.yaml
@@ -5,7 +5,6 @@ slug: dionis-dps-2004-rm-4e
 part_number: RM-4E
 u_height: 1
 is_full_depth: true
-comments: ''
 power-ports:
   - name: PSU0
     type: iec-60320-c14

--- a/device-types/Factor-TS/DIONIS-DPS-3010-RM-6E-4S.yaml
+++ b/device-types/Factor-TS/DIONIS-DPS-3010-RM-6E-4S.yaml
@@ -5,7 +5,6 @@ slug: dionis-dps-3010-rm-6e-4s
 part_number: RM-6E-4S
 u_height: 1
 is_full_depth: true
-comments: ''
 power-ports:
   - name: PSU0
     type: iec-60320-c14

--- a/device-types/Huawei/ATN910I-D.yaml
+++ b/device-types/Huawei/ATN910I-D.yaml
@@ -2,10 +2,8 @@
 manufacturer: Huawei
 model: ATN910I-D
 slug: atn910i-d
-part_number: ''
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: Input
     type: iec-60320-c14

--- a/device-types/Infotecs/VIPNET-COORDINATOR-HW1000C.yaml
+++ b/device-types/Infotecs/VIPNET-COORDINATOR-HW1000C.yaml
@@ -2,10 +2,8 @@
 manufacturer: Infotecs
 model: ViPNet Coordinator HW1000C
 slug: vipnet-coordinator-hw1000c
-part_number: ''
 u_height: 1
 is_full_depth: true
-comments: ''
 power-ports:
   - name: PSU0
     type: iec-60320-c14

--- a/device-types/Juniper/ACX4000.yaml
+++ b/device-types/Juniper/ACX4000.yaml
@@ -2,7 +2,6 @@
 manufacturer: Juniper
 model: ACX4000
 slug: acx4000
-part_number: ''
 u_height: 3
 is_full_depth: false
 comments: 2.5U Height

--- a/device-types/LANCOM/GS-1108.yaml
+++ b/device-types/LANCOM/GS-1108.yaml
@@ -5,7 +5,6 @@ slug: gs-1108
 part_number: '61457'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-1108P.yaml
+++ b/device-types/LANCOM/GS-1108P.yaml
@@ -5,7 +5,6 @@ slug: gs-1108p
 part_number: '61430'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-1326.yaml
+++ b/device-types/LANCOM/GS-1326.yaml
@@ -5,7 +5,6 @@ slug: gs-1326
 part_number: '61438'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2310.yaml
+++ b/device-types/LANCOM/GS-2310.yaml
@@ -5,7 +5,6 @@ slug: gs-2310
 part_number: '61492'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2310P-plus.yaml
+++ b/device-types/LANCOM/GS-2310P-plus.yaml
@@ -5,7 +5,6 @@ slug: gs-2310p-plus
 part_number: '61440'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2310P.yaml
+++ b/device-types/LANCOM/GS-2310P.yaml
@@ -5,7 +5,6 @@ slug: gs-2310p
 part_number: '61433'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2326-plus.yaml
+++ b/device-types/LANCOM/GS-2326-plus.yaml
@@ -5,7 +5,6 @@ slug: gs-2326-plus
 part_number: '61483'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2326.yaml
+++ b/device-types/LANCOM/GS-2326.yaml
@@ -5,7 +5,6 @@ slug: gs-2326
 part_number: '61470'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2326P-plus.yaml
+++ b/device-types/LANCOM/GS-2326P-plus.yaml
@@ -5,7 +5,6 @@ slug: gs-2326p-plus
 part_number: '61481'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2328.yaml
+++ b/device-types/LANCOM/GS-2328.yaml
@@ -5,7 +5,6 @@ slug: gs-2328
 part_number: '61444'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2328F.yaml
+++ b/device-types/LANCOM/GS-2328F.yaml
@@ -5,7 +5,6 @@ slug: gs-2328f
 part_number: '61446'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2328P.yaml
+++ b/device-types/LANCOM/GS-2328P.yaml
@@ -5,7 +5,6 @@ slug: gs-2328p
 part_number: '61442'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2352.yaml
+++ b/device-types/LANCOM/GS-2352.yaml
@@ -5,7 +5,6 @@ slug: gs-2352
 part_number: '61472'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-2352P.yaml
+++ b/device-types/LANCOM/GS-2352P.yaml
@@ -5,7 +5,6 @@ slug: gs-2352p
 part_number: '61436'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-3126X.yaml
+++ b/device-types/LANCOM/GS-3126X.yaml
@@ -5,7 +5,6 @@ slug: gs-3126x
 part_number: '61847'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-3126XP.yaml
+++ b/device-types/LANCOM/GS-3126XP.yaml
@@ -5,7 +5,6 @@ slug: gs-3126xp
 part_number: '61848'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-3152X.yaml
+++ b/device-types/LANCOM/GS-3152X.yaml
@@ -5,7 +5,6 @@ slug: gs-3152x
 part_number: '61488'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-3152XP.yaml
+++ b/device-types/LANCOM/GS-3152XP.yaml
@@ -5,7 +5,6 @@ slug: gs-3152xp
 part_number: '61487'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-3152XSP.yaml
+++ b/device-types/LANCOM/GS-3152XSP.yaml
@@ -5,7 +5,6 @@ slug: gs-3152xsp
 part_number: '61486'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-3510XP.yaml
+++ b/device-types/LANCOM/GS-3510XP.yaml
@@ -5,7 +5,6 @@ slug: gs-3510xp
 part_number: '61849'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-3528X.yaml
+++ b/device-types/LANCOM/GS-3528X.yaml
@@ -5,7 +5,6 @@ slug: gs-3528x
 part_number: '61496'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/GS-3528XP.yaml
+++ b/device-types/LANCOM/GS-3528XP.yaml
@@ -5,7 +5,6 @@ slug: gs-3528xp
 part_number: '61850'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/ISG-1000.yaml
+++ b/device-types/LANCOM/ISG-1000.yaml
@@ -5,7 +5,6 @@ slug: isg-1000
 part_number: '61073'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/ISG-4000.yaml
+++ b/device-types/LANCOM/ISG-4000.yaml
@@ -5,7 +5,6 @@ slug: isg-4000
 part_number: '61075'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/ISG-8000.yaml
+++ b/device-types/LANCOM/ISG-8000.yaml
@@ -5,7 +5,6 @@ slug: isg-8000
 part_number: '61077'
 u_height: 1
 is_full_depth: true
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/LN-1700.yaml
+++ b/device-types/LANCOM/LN-1700.yaml
@@ -5,7 +5,6 @@ slug: ln-1700
 part_number: '61767'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/LANCOM/LN-1700B.yaml
+++ b/device-types/LANCOM/LN-1700B.yaml
@@ -5,7 +5,6 @@ slug: ln-1700b
 part_number: '61792'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/LANCOM/LN-1700UE.yaml
+++ b/device-types/LANCOM/LN-1700UE.yaml
@@ -5,7 +5,6 @@ slug: ln-1700ue
 part_number: '61801'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/LANCOM/LN-1702.yaml
+++ b/device-types/LANCOM/LN-1702.yaml
@@ -5,7 +5,6 @@ slug: ln-1702
 part_number: '61764'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/LANCOM/LN-1702B.yaml
+++ b/device-types/LANCOM/LN-1702B.yaml
@@ -5,7 +5,6 @@ slug: ln-1702b
 part_number: '61794'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/LANCOM/WLC-1000.yaml
+++ b/device-types/LANCOM/WLC-1000.yaml
@@ -5,7 +5,6 @@ slug: wlc-1000
 part_number: '61783'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/WLC-30.yaml
+++ b/device-types/LANCOM/WLC-30.yaml
@@ -5,7 +5,6 @@ slug: wlc-30
 part_number: '61789'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/LANCOM/WLC-4006-plus.yaml
+++ b/device-types/LANCOM/WLC-4006-plus.yaml
@@ -5,7 +5,6 @@ slug: wlc-4006-plus
 part_number: '62035'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/LANCOM/WLC-4025-plus.yaml
+++ b/device-types/LANCOM/WLC-4025-plus.yaml
@@ -5,7 +5,6 @@ slug: wlc-4025-plus
 part_number: wlc-4025-plus
 u_height: 1
 is_full_depth: false
-comments: ''
 interfaces:
   - name: ETH-1
     type: 1000base-t

--- a/device-types/LANCOM/WLC-4025.yaml
+++ b/device-types/LANCOM/WLC-4025.yaml
@@ -5,7 +5,6 @@ slug: wlc-4025
 part_number: wlc-4025
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/LANCOM/WLC-4100.yaml
+++ b/device-types/LANCOM/WLC-4100.yaml
@@ -5,7 +5,6 @@ slug: wlc-4100
 part_number: '61369'
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/Nokia/7210-SAS-Sx.yaml
+++ b/device-types/Nokia/7210-SAS-Sx.yaml
@@ -5,7 +5,6 @@ slug: 7210-sas-sx-10-100GE
 part_number: 3HE11597AARB01
 u_height: 2
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Opengear/IM7216-2-DAC-US.yaml
+++ b/device-types/Opengear/IM7216-2-DAC-US.yaml
@@ -5,7 +5,6 @@ slug: im7216-2-dac-us
 part_number: IM7216-2-DAC-US
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Opengear/IM7232-2-DAC-US.yaml
+++ b/device-types/Opengear/IM7232-2-DAC-US.yaml
@@ -5,7 +5,6 @@ slug: im7232-2-dac-us
 part_number: IM7232-2-DAC-US
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Raritan/PX2-2493.yaml
+++ b/device-types/Raritan/PX2-2493.yaml
@@ -5,7 +5,6 @@ slug: px2-2493
 part_number: PX2-2493
 u_height: 0
 is_full_depth: false
-comments: ''
 power-ports:
   - name: Inlet
     type: iec-60309-p-n-e-6h

--- a/device-types/Rohde & Schwarz/SITLine-ETH-40G.yaml
+++ b/device-types/Rohde & Schwarz/SITLine-ETH-40G.yaml
@@ -5,7 +5,6 @@ slug: sitline-eth40g
 part_number: 5414.6130.02
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/Rohde & Schwarz/SITLine-ETH-4G.yaml
+++ b/device-types/Rohde & Schwarz/SITLine-ETH-4G.yaml
@@ -5,7 +5,6 @@ slug: sitline-eth4g
 part_number: 5414.7766.02
 u_height: 1
 is_full_depth: false
-comments: ''
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/Rohde & Schwarz/TrustedVPN-L.yaml
+++ b/device-types/Rohde & Schwarz/TrustedVPN-L.yaml
@@ -5,7 +5,6 @@ slug: trustedvpn-l
 part_number: 3630.1751.02
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Rohde & Schwarz/TrustedVPN-XL.yaml
+++ b/device-types/Rohde & Schwarz/TrustedVPN-XL.yaml
@@ -5,7 +5,6 @@ slug: trustedvpn-xl
 part_number: 3630.1768.02
 u_height: 1
 is_full_depth: false
-comments: ''
 console-ports:
   - name: VGA
     type: other

--- a/device-types/Solid Optics/SO-CHASSIS-MOD4.yml
+++ b/device-types/Solid Optics/SO-CHASSIS-MOD4.yml
@@ -2,7 +2,6 @@
 manufacturer: Solid Optics
 model: SO-CHASSIS-MOD4
 slug: so-chassis-mod4
-part_number: ''
 u_height: 1
 is_full_depth: false
 subdevice_role: parent

--- a/device-types/Synology/DS1817+.yaml
+++ b/device-types/Synology/DS1817+.yaml
@@ -8,26 +8,16 @@ is_full_depth: false
 power-ports:
   - name: PSU 1
     type: iec-60320-c14
-    label: ''
-    description: ''
 interfaces:
   - name: LAN 1
     type: 1000base-t
     mgmt_only: false
-    label: ''
-    description: ''
   - name: LAN 2
     type: 1000base-t
     mgmt_only: false
-    label: ''
-    description: ''
   - name: LAN 3
     type: 1000base-t
     mgmt_only: false
-    label: ''
-    description: ''
   - name: LAN 4
     type: 1000base-t
     mgmt_only: false
-    label: ''
-    description: ''

--- a/tests/definitions_test.py
+++ b/tests/definitions_test.py
@@ -101,3 +101,23 @@ def test_definitions(file_path, schema):
             if name in known_names:
                 pytest.fail(f'Duplicate entry "{name}" in {component_type} list', False)
             known_names.add(name)
+
+    # Check for empty quotes
+    def iterdict(var):
+        for dict_value in var.values():
+            if isinstance(dict_value, dict):
+                iterdict(dict_value)
+            if isinstance(dict_value, list):
+                iterlist(dict_value)
+            else:
+                if(isinstance(dict_value, str) and not dict_value):
+                    pytest.fail(f'{file_path} has empty quotes', False)
+
+    def iterlist(var):
+        for list_value in var:
+            if isinstance(list_value, dict):
+                iterdict(list_value)
+            elif isinstance(list_value, list):
+                iterlist(list_value)
+
+    iterdict(definition)

--- a/tests/yamllint.yaml
+++ b/tests/yamllint.yaml
@@ -14,7 +14,7 @@ rules:
   document-start:
     level: warning
   empty-lines: enable
-  empty-values: disable
+  empty-values: enable
   hyphens: enable
   indentation:
     spaces: 2


### PR DESCRIPTION
Fixes #686
- yamllint: enable empty-values
- definitions_test.py: add test for empty quotes
- clean up device-type files
