### PR TITLE
Add Allied Telesis x8100 series

### DIFF
--- a/device-types/Allied Telesis/x8106.yaml
+++ b/device-types/Allied Telesis/x8106.yaml
@@ -1,0 +1,36 @@
+---
+manufacturer: Allied Telesis
+model: SwitchBlade x8106
+slug: sbx8106
+part_number: AT-SBx8106
+u_height: 4
+is_full_depth: true
+module-bays:
+  - name: PSU Slot A
+    position: 'A'
+    label: PoE PSU 1
+  - name: PSU Slot B
+    position: 'B'
+    label: PoE PSU 2
+  - name: PSU Slot C
+    position: 'C'
+    label: System PSU 1
+  - name: PSU Slot D
+    position: 'D'
+    label: System PSU 2
+  - name: Slot 1
+    position: '1'
+  - name: Slot 2
+    position: '2'
+  - name: Slot 3
+    position: '3'
+  - name: Slot 4
+    position: '4'
+  - name: Slot 5
+    position: '5'
+  - name: Slot 6
+    position: '6'
+inventory-items:
+  - name: Fan-Module
+    manufacturer: Allied Telesis
+    part_id: AT-SBxFAN06

--- a/device-types/Allied Telesis/x8112.yaml
+++ b/device-types/Allied Telesis/x8112.yaml
@@ -1,0 +1,48 @@
+---
+manufacturer: Allied Telesis
+model: SwitchBlade x8112
+slug: sbx8112
+part_number: AT-SBx8112
+u_height: 7
+is_full_depth: true
+module-bays:
+  - name: PSU Slot A
+    position: 'A'
+    label: PoE PSU 1
+  - name: PSU Slot B
+    position: 'B'
+    label: PoE PSU 2
+  - name: PSU Slot C
+    position: 'C'
+    label: System PSU 1
+  - name: PSU Slot D
+    position: 'D'
+    label: System PSU 2
+  - name: Slot 1
+    position: '1'
+  - name: Slot 2
+    position: '2'
+  - name: Slot 3
+    position: '3'
+  - name: Slot 4
+    position: '4'
+  - name: Slot 5
+    position: '5'
+  - name: Slot 6
+    position: '6'
+  - name: Slot 7
+    position: '7'
+  - name: Slot 8
+    position: '8'
+  - name: Slot 9
+    position: '9'
+  - name: Slot 10
+    position: '10'
+  - name: Slot 11
+    position: '11'
+  - name: Slot 12
+    position: '12'
+inventory-items:
+  - name: Fan-Module
+    manufacturer: Allied Telesis
+    part_id: AT-SBxFAN12

--- a/device-types/Allied Telesis/x908Gen2.yaml
+++ b/device-types/Allied Telesis/x908Gen2.yaml
@@ -35,3 +35,10 @@ module-bays:
     position: '7'
   - name: Slot 8
     position: '8'
+inventory-items:
+  - name: Fan-Module A
+    manufacturer: Allied Telesis
+    part_id: AT-FAN08
+  - name: Fan-Module B
+    manufacturer: Allied Telesis
+    part_id: AT-FAN08

--- a/device-types/Allied Telesis/x908Gen2.yaml
+++ b/device-types/Allied Telesis/x908Gen2.yaml
@@ -8,18 +8,17 @@ is_full_depth: true
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU A
-    type: iec-60320-c14
-    maximum_draw: 470
-  - name: PSU B
-    type: iec-60320-c14
-    maximum_draw: 470
 interfaces:
   - name: eth0
     type: 1000base-t
     mgmt_only: true
 module-bays:
+  - name: PSU Slot A
+    position: 'A'
+    label: PSU 1
+  - name: PSU Slot B
+    position: 'B'
+    label: PSU 2
   - name: Slot 1
     position: '1'
   - name: Slot 2

--- a/module-types/Allied Telesis/SBx81CFC400.yaml
+++ b/module-types/Allied Telesis/SBx81CFC400.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Allied Telesis
+model: SBx81CFC400
+part_number: AT-SBx81CFC400
+console-ports:
+  - name: Console ({module})
+    type: rj-45
+interfaces:
+  - name: eth0 ({module})
+    type: 1000base-t
+    mgmt_only: true

--- a/module-types/Allied Telesis/SBx81CFC960.yaml
+++ b/module-types/Allied Telesis/SBx81CFC960.yaml
@@ -1,0 +1,19 @@
+---
+manufacturer: Allied Telesis
+model: SBx81CFC960
+part_number: AT-SBx81CFC960
+console-ports:
+  - name: Console ({module})
+    type: rj-45
+interfaces:
+  - name: eth0 ({module})
+    type: 1000base-t
+    mgmt_only: true
+  - name: port1.{module}.1
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.2
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.3
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.4
+    type: 10gbase-x-sfpp

--- a/module-types/Allied Telesis/SBx81GC40.yaml
+++ b/module-types/Allied Telesis/SBx81GC40.yaml
@@ -1,0 +1,85 @@
+---
+manufacturer: Allied Telesis
+model: SBx81GC40
+part_number: AT-SBx81GC40
+interfaces:
+  - name: port1.{module}.1
+    type: 1000base-x-sfp
+  - name: port1.{module}.2
+    type: 1000base-x-sfp
+  - name: port1.{module}.3
+    type: 1000base-x-sfp
+  - name: port1.{module}.4
+    type: 1000base-x-sfp
+  - name: port1.{module}.5
+    type: 1000base-x-sfp
+  - name: port1.{module}.6
+    type: 1000base-x-sfp
+  - name: port1.{module}.7
+    type: 1000base-x-sfp
+  - name: port1.{module}.8
+    type: 1000base-x-sfp
+  - name: port1.{module}.9
+    type: 1000base-x-sfp
+  - name: port1.{module}.10
+    type: 1000base-x-sfp
+  - name: port1.{module}.11
+    type: 1000base-x-sfp
+  - name: port1.{module}.12
+    type: 1000base-x-sfp
+  - name: port1.{module}.13
+    type: 1000base-x-sfp
+  - name: port1.{module}.14
+    type: 1000base-x-sfp
+  - name: port1.{module}.15
+    type: 1000base-x-sfp
+  - name: port1.{module}.16
+    type: 1000base-x-sfp
+  - name: port1.{module}.17
+    type: 1000base-x-sfp
+  - name: port1.{module}.18
+    type: 1000base-x-sfp
+  - name: port1.{module}.19
+    type: 1000base-x-sfp
+  - name: port1.{module}.20
+    type: 1000base-x-sfp
+  - name: port1.{module}.21
+    type: 1000base-x-sfp
+  - name: port1.{module}.22
+    type: 1000base-x-sfp
+  - name: port1.{module}.23
+    type: 1000base-x-sfp
+  - name: port1.{module}.24
+    type: 1000base-x-sfp
+  - name: port1.{module}.25
+    type: 1000base-x-sfp
+  - name: port1.{module}.26
+    type: 1000base-x-sfp
+  - name: port1.{module}.27
+    type: 1000base-x-sfp
+  - name: port1.{module}.28
+    type: 1000base-x-sfp
+  - name: port1.{module}.29
+    type: 1000base-x-sfp
+  - name: port1.{module}.30
+    type: 1000base-x-sfp
+  - name: port1.{module}.31
+    type: 1000base-x-sfp
+  - name: port1.{module}.32
+    type: 1000base-x-sfp
+  - name: port1.{module}.33
+    type: 1000base-x-sfp
+  - name: port1.{module}.34
+    type: 1000base-x-sfp
+  - name: port1.{module}.35
+    type: 1000base-x-sfp
+  - name: port1.{module}.36
+    type: 1000base-x-sfp
+  - name: port1.{module}.37
+    type: 1000base-x-sfp
+  - name: port1.{module}.38
+    type: 1000base-x-sfp
+  - name: port1.{module}.39
+    type: 1000base-x-sfp
+  - name: port1.{module}.40
+    type: 1000base-x-sfp

--- a/module-types/Allied Telesis/SBx81GP24.yaml
+++ b/module-types/Allied Telesis/SBx81GP24.yaml
@@ -1,0 +1,53 @@
+---
+manufacturer: Allied Telesis
+model: SBx81GP24
+part_number: AT-SBx81GP24
+interfaces:
+  - name: port1.{module}.1
+    type: 1000base-t
+  - name: port1.{module}.2
+    type: 1000base-t
+  - name: port1.{module}.3
+    type: 1000base-t
+  - name: port1.{module}.4
+    type: 1000base-t
+  - name: port1.{module}.5
+    type: 1000base-t
+  - name: port1.{module}.6
+    type: 1000base-t
+  - name: port1.{module}.7
+    type: 1000base-t
+  - name: port1.{module}.8
+    type: 1000base-t
+  - name: port1.{module}.9
+    type: 1000base-t
+  - name: port1.{module}.10
+    type: 1000base-t
+  - name: port1.{module}.11
+    type: 1000base-t
+  - name: port1.{module}.12
+    type: 1000base-t
+  - name: port1.{module}.13
+    type: 1000base-t
+  - name: port1.{module}.14
+    type: 1000base-t
+  - name: port1.{module}.15
+    type: 1000base-t
+  - name: port1.{module}.16
+    type: 1000base-t
+  - name: port1.{module}.17
+    type: 1000base-t
+  - name: port1.{module}.18
+    type: 1000base-t
+  - name: port1.{module}.19
+    type: 1000base-t
+  - name: port1.{module}.20
+    type: 1000base-t
+  - name: port1.{module}.21
+    type: 1000base-t
+  - name: port1.{module}.22
+    type: 1000base-t
+  - name: port1.{module}.23
+    type: 1000base-t
+  - name: port1.{module}.24
+    type: 1000base-t

--- a/module-types/Allied Telesis/SBx81GS24a.yaml
+++ b/module-types/Allied Telesis/SBx81GS24a.yaml
@@ -1,0 +1,53 @@
+---
+manufacturer: Allied Telesis
+model: SBx81GS24a
+part_number: AT-SBx81GS24a
+interfaces:
+  - name: port1.{module}.1
+    type: 1000base-x-sfp
+  - name: port1.{module}.2
+    type: 1000base-x-sfp
+  - name: port1.{module}.3
+    type: 1000base-x-sfp
+  - name: port1.{module}.4
+    type: 1000base-x-sfp
+  - name: port1.{module}.5
+    type: 1000base-x-sfp
+  - name: port1.{module}.6
+    type: 1000base-x-sfp
+  - name: port1.{module}.7
+    type: 1000base-x-sfp
+  - name: port1.{module}.8
+    type: 1000base-x-sfp
+  - name: port1.{module}.9
+    type: 1000base-x-sfp
+  - name: port1.{module}.10
+    type: 1000base-x-sfp
+  - name: port1.{module}.11
+    type: 1000base-x-sfp
+  - name: port1.{module}.12
+    type: 1000base-x-sfp
+  - name: port1.{module}.13
+    type: 1000base-x-sfp
+  - name: port1.{module}.14
+    type: 1000base-x-sfp
+  - name: port1.{module}.15
+    type: 1000base-x-sfp
+  - name: port1.{module}.16
+    type: 1000base-x-sfp
+  - name: port1.{module}.17
+    type: 1000base-x-sfp
+  - name: port1.{module}.18
+    type: 1000base-x-sfp
+  - name: port1.{module}.19
+    type: 1000base-x-sfp
+  - name: port1.{module}.20
+    type: 1000base-x-sfp
+  - name: port1.{module}.21
+    type: 1000base-x-sfp
+  - name: port1.{module}.22
+    type: 1000base-x-sfp
+  - name: port1.{module}.23
+    type: 1000base-x-sfp
+  - name: port1.{module}.24
+    type: 1000base-x-sfp

--- a/module-types/Allied Telesis/SBx81GT24.yaml
+++ b/module-types/Allied Telesis/SBx81GT24.yaml
@@ -1,0 +1,53 @@
+---
+manufacturer: Allied Telesis
+model: SBx81GT24
+part_number: AT-SBx81GT24
+interfaces:
+  - name: port1.{module}.1
+    type: 1000base-t
+  - name: port1.{module}.2
+    type: 1000base-t
+  - name: port1.{module}.3
+    type: 1000base-t
+  - name: port1.{module}.4
+    type: 1000base-t
+  - name: port1.{module}.5
+    type: 1000base-t
+  - name: port1.{module}.6
+    type: 1000base-t
+  - name: port1.{module}.7
+    type: 1000base-t
+  - name: port1.{module}.8
+    type: 1000base-t
+  - name: port1.{module}.9
+    type: 1000base-t
+  - name: port1.{module}.10
+    type: 1000base-t
+  - name: port1.{module}.11
+    type: 1000base-t
+  - name: port1.{module}.12
+    type: 1000base-t
+  - name: port1.{module}.13
+    type: 1000base-t
+  - name: port1.{module}.14
+    type: 1000base-t
+  - name: port1.{module}.15
+    type: 1000base-t
+  - name: port1.{module}.16
+    type: 1000base-t
+  - name: port1.{module}.17
+    type: 1000base-t
+  - name: port1.{module}.18
+    type: 1000base-t
+  - name: port1.{module}.19
+    type: 1000base-t
+  - name: port1.{module}.20
+    type: 1000base-t
+  - name: port1.{module}.21
+    type: 1000base-t
+  - name: port1.{module}.22
+    type: 1000base-t
+  - name: port1.{module}.23
+    type: 1000base-t
+  - name: port1.{module}.24
+    type: 1000base-t

--- a/module-types/Allied Telesis/SBx81GT40.yaml
+++ b/module-types/Allied Telesis/SBx81GT40.yaml
@@ -1,0 +1,85 @@
+---
+manufacturer: Allied Telesis
+model: SBx81GT40
+part_number: AT-SBx81GT40
+interfaces:
+  - name: port1.{module}.1
+    type: 1000base-t
+  - name: port1.{module}.2
+    type: 1000base-t
+  - name: port1.{module}.3
+    type: 1000base-t
+  - name: port1.{module}.4
+    type: 1000base-t
+  - name: port1.{module}.5
+    type: 1000base-t
+  - name: port1.{module}.6
+    type: 1000base-t
+  - name: port1.{module}.7
+    type: 1000base-t
+  - name: port1.{module}.8
+    type: 1000base-t
+  - name: port1.{module}.9
+    type: 1000base-t
+  - name: port1.{module}.10
+    type: 1000base-t
+  - name: port1.{module}.11
+    type: 1000base-t
+  - name: port1.{module}.12
+    type: 1000base-t
+  - name: port1.{module}.13
+    type: 1000base-t
+  - name: port1.{module}.14
+    type: 1000base-t
+  - name: port1.{module}.15
+    type: 1000base-t
+  - name: port1.{module}.16
+    type: 1000base-t
+  - name: port1.{module}.17
+    type: 1000base-t
+  - name: port1.{module}.18
+    type: 1000base-t
+  - name: port1.{module}.19
+    type: 1000base-t
+  - name: port1.{module}.20
+    type: 1000base-t
+  - name: port1.{module}.21
+    type: 1000base-t
+  - name: port1.{module}.22
+    type: 1000base-t
+  - name: port1.{module}.23
+    type: 1000base-t
+  - name: port1.{module}.24
+    type: 1000base-t
+  - name: port1.{module}.25
+    type: 1000base-t
+  - name: port1.{module}.26
+    type: 1000base-t
+  - name: port1.{module}.27
+    type: 1000base-t
+  - name: port1.{module}.28
+    type: 1000base-t
+  - name: port1.{module}.29
+    type: 1000base-t
+  - name: port1.{module}.30
+    type: 1000base-t
+  - name: port1.{module}.31
+    type: 1000base-t
+  - name: port1.{module}.32
+    type: 1000base-t
+  - name: port1.{module}.33
+    type: 1000base-t
+  - name: port1.{module}.34
+    type: 1000base-t
+  - name: port1.{module}.35
+    type: 1000base-t
+  - name: port1.{module}.36
+    type: 1000base-t
+  - name: port1.{module}.37
+    type: 1000base-t
+  - name: port1.{module}.38
+    type: 1000base-t
+  - name: port1.{module}.39
+    type: 1000base-t
+  - name: port1.{module}.40
+    type: 1000base-t

--- a/module-types/Allied Telesis/SBx81XLEM.yaml
+++ b/module-types/Allied Telesis/SBx81XLEM.yaml
@@ -1,0 +1,29 @@
+---
+manufacturer: Allied Telesis
+model: SBx81GS24a
+part_number: AT-SBx81GS24a
+interfaces:
+  - name: port1.{module}.1
+    type: 1000base-x-sfp
+  - name: port1.{module}.2
+    type: 1000base-x-sfp
+  - name: port1.{module}.3
+    type: 1000base-x-sfp
+  - name: port1.{module}.4
+    type: 1000base-x-sfp
+  - name: port1.{module}.5
+    type: 1000base-x-sfp
+  - name: port1.{module}.6
+    type: 1000base-x-sfp
+  - name: port1.{module}.7
+    type: 1000base-x-sfp
+  - name: port1.{module}.8
+    type: 1000base-x-sfp
+  - name: port1.{module}.9
+    type: 1000base-x-sfp
+  - name: port1.{module}.10
+    type: 1000base-x-sfp
+  - name: port1.{module}.11
+    type: 1000base-x-sfp
+  - name: port1.{module}.12
+    type: 1000base-x-sfp

--- a/module-types/Allied Telesis/SBx81XS16.yaml
+++ b/module-types/Allied Telesis/SBx81XS16.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: Allied Telesis
+model: SBx81XS16
+part_number: AT-SBx81XS16
+interfaces:
+  - name: port1.{module}.1
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.2
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.3
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.4
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.5
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.6
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.7
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.8
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.9
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.10
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.11
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.12
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.13
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.14
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.15
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.16
+    type: 10gbase-x-sfpp

--- a/module-types/Allied Telesis/SBx81XS6.yaml
+++ b/module-types/Allied Telesis/SBx81XS6.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Allied Telesis
+model: SBx81XS6
+part_number: AT-SBx81XS6
+interfaces:
+  - name: port1.{module}.1
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.2
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.3
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.4
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.5
+    type: 10gbase-x-sfpp
+  - name: port1.{module}.6
+    type: 10gbase-x-sfpp

--- a/module-types/Allied Telesis/SBxPWRPOE1.yaml
+++ b/module-types/Allied Telesis/SBxPWRPOE1.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Allied Telesis
+model: SBxPWRPOE1
+part_number: AT-SBxPWRPOE1
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c20
+    maximum_draw: 1200
+    label: PoE PSU

--- a/module-types/Allied Telesis/SBxPWRSYS1-DC.yaml
+++ b/module-types/Allied Telesis/SBxPWRSYS1-DC.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Allied Telesis
+model: SBxPWRSYS1-DC
+part_number: AT-SBxPWRSYS1-DC
+power-ports:
+  - name: PSU {module}
+    type: dc-terminal
+    maximum_draw: 1200
+    label: System PSU

--- a/module-types/Allied Telesis/SBxPWRSYS1.yaml
+++ b/module-types/Allied Telesis/SBxPWRSYS1.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Allied Telesis
+model: SBxPWRSYS1
+part_number: AT-SBxPWRSYS1
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c20
+    maximum_draw: 1200
+    label: System PSU

--- a/module-types/Allied Telesis/SBxPWRSYS2.yaml
+++ b/module-types/Allied Telesis/SBxPWRSYS2.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Allied Telesis
+model: SBxPWRSYS2
+part_number: AT-SBxPWRSYS2
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c20
+    maximum_draw: 1200
+    label: System PSU


### PR DESCRIPTION
Add Allied Telesis modular switch platform x8100 with all corresponding products.
Also changed x908 Gen2 to use the PSUs of the x8100 platform.