### PR TITLE
Modify SonicWall modular products

### DIFF
--- a/device-types/SonicWall/NSa2650.yaml
+++ b/device-types/SonicWall/NSa2650.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 120
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 120
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa2650.yaml
+++ b/device-types/SonicWall/NSa2650.yaml
@@ -13,6 +13,7 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+  - name: Expansion Module
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa2650.yaml
+++ b/device-types/SonicWall/NSa2650.yaml
@@ -14,6 +14,9 @@ module-bays:
   - name: PSU Slot 2
     position: '2'
   - name: Expansion Module
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa2700.yaml
+++ b/device-types/SonicWall/NSa2700.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 60
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 60
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa2700.yaml
+++ b/device-types/SonicWall/NSa2700.yaml
@@ -13,6 +13,9 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa3650.yaml
+++ b/device-types/SonicWall/NSa3650.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 120
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 120
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa3650.yaml
+++ b/device-types/SonicWall/NSa3650.yaml
@@ -13,6 +13,7 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+  - name: Expansion Module
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa3650.yaml
+++ b/device-types/SonicWall/NSa3650.yaml
@@ -14,6 +14,9 @@ module-bays:
   - name: PSU Slot 2
     position: '2'
   - name: Expansion Module
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa3700.yaml
+++ b/device-types/SonicWall/NSa3700.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 90
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 90
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa3700.yaml
+++ b/device-types/SonicWall/NSa3700.yaml
@@ -13,6 +13,9 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa4650.yaml
+++ b/device-types/SonicWall/NSa4650.yaml
@@ -17,6 +17,10 @@ module-bays:
 inventory-items:
   - name: Storage-Module
     manufacturer: SonicWall
+  - name: Fan-Module 1
+    manufacturer: SonicWall
+  - name: Fan-Module 2
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa4650.yaml
+++ b/device-types/SonicWall/NSa4650.yaml
@@ -13,6 +13,7 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+  - name: Expansion Module
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa4650.yaml
+++ b/device-types/SonicWall/NSa4650.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 350
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 350
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa4650.yaml
+++ b/device-types/SonicWall/NSa4650.yaml
@@ -14,6 +14,9 @@ module-bays:
   - name: PSU Slot 2
     position: '2'
   - name: Expansion Module
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa4700.yaml
+++ b/device-types/SonicWall/NSa4700.yaml
@@ -17,6 +17,10 @@ module-bays:
 inventory-items:
   - name: Storage-Module
     manufacturer: SonicWall
+  - name: Fan-Module 1
+    manufacturer: SonicWall
+  - name: Fan-Module 2
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa4700.yaml
+++ b/device-types/SonicWall/NSa4700.yaml
@@ -13,6 +13,7 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+  - name: Expansion Module
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa4700.yaml
+++ b/device-types/SonicWall/NSa4700.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 350
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 350
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa4700.yaml
+++ b/device-types/SonicWall/NSa4700.yaml
@@ -14,6 +14,9 @@ module-bays:
   - name: PSU Slot 2
     position: '2'
   - name: Expansion Module
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa5650.yaml
+++ b/device-types/SonicWall/NSa5650.yaml
@@ -17,6 +17,10 @@ module-bays:
 inventory-items:
   - name: Storage-Module
     manufacturer: SonicWall
+  - name: Fan-Module 1
+    manufacturer: SonicWall
+  - name: Fan-Module 2
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa5650.yaml
+++ b/device-types/SonicWall/NSa5650.yaml
@@ -13,6 +13,7 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+  - name: Expansion Module
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa5650.yaml
+++ b/device-types/SonicWall/NSa5650.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 350
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 350
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa5650.yaml
+++ b/device-types/SonicWall/NSa5650.yaml
@@ -14,6 +14,9 @@ module-bays:
   - name: PSU Slot 2
     position: '2'
   - name: Expansion Module
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa6700.yaml
+++ b/device-types/SonicWall/NSa6700.yaml
@@ -13,6 +13,7 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+  - name: Expansion Module
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa6700.yaml
+++ b/device-types/SonicWall/NSa6700.yaml
@@ -17,6 +17,12 @@ module-bays:
 inventory-items:
   - name: Storage-Module
     manufacturer: SonicWall
+  - name: Fan-Module 1
+    manufacturer: SonicWall
+  - name: Fan-Module 2
+    manufacturer: SonicWall
+  - name: Fan-Module 3
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa6700.yaml
+++ b/device-types/SonicWall/NSa6700.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 350
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 350
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSa6700.yaml
+++ b/device-types/SonicWall/NSa6700.yaml
@@ -14,6 +14,9 @@ module-bays:
   - name: PSU Slot 2
     position: '2'
   - name: Expansion Module
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSsp13700.yaml
+++ b/device-types/SonicWall/NSsp13700.yaml
@@ -13,6 +13,7 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+  - name: Expansion Module
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSsp13700.yaml
+++ b/device-types/SonicWall/NSsp13700.yaml
@@ -17,6 +17,12 @@ module-bays:
 inventory-items:
   - name: Storage-Module
     manufacturer: SonicWall
+  - name: Fan-Module 1
+    manufacturer: SonicWall
+  - name: Fan-Module 2
+    manufacturer: SonicWall
+  - name: Fan-Module 3
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSsp13700.yaml
+++ b/device-types/SonicWall/NSsp13700.yaml
@@ -8,13 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 350
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 350
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSsp13700.yaml
+++ b/device-types/SonicWall/NSsp13700.yaml
@@ -14,6 +14,9 @@ module-bays:
   - name: PSU Slot 2
     position: '2'
   - name: Expansion Module
+inventory-items:
+  - name: Storage-Module
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSsp15700.yaml
+++ b/device-types/SonicWall/NSsp15700.yaml
@@ -23,6 +23,10 @@ inventory-items:
     manufacturer: SonicWall
   - name: Storage-Module 4
     manufacturer: SonicWall
+  - name: Fan-Module 1
+    manufacturer: SonicWall
+  - name: Fan-Module 2
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSsp15700.yaml
+++ b/device-types/SonicWall/NSsp15700.yaml
@@ -14,6 +14,15 @@ module-bays:
   - name: PSU Slot 2
     position: '2'
   - name: Expansion Module
+inventory-items:
+  - name: Storage-Module 1
+    manufacturer: SonicWall
+  - name: Storage-Module 2
+    manufacturer: SonicWall
+  - name: Storage-Module 3
+    manufacturer: SonicWall
+  - name: Storage-Module 4
+    manufacturer: SonicWall
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSsp15700.yaml
+++ b/device-types/SonicWall/NSsp15700.yaml
@@ -8,13 +8,11 @@ is_full_depth: true
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 1200
-  - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 1200
+module-bays:
+  - name: PSU Slot 1
+    position: '1'
+  - name: PSU Slot 2
+    position: '2'
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/device-types/SonicWall/NSsp15700.yaml
+++ b/device-types/SonicWall/NSsp15700.yaml
@@ -13,6 +13,7 @@ module-bays:
     position: '1'
   - name: PSU Slot 2
     position: '2'
+  - name: Expansion Module
 interfaces:
   - name: MGMT
     type: 1000base-t

--- a/module-types/SonicWall/01-SSC-0019.yaml
+++ b/module-types/SonicWall/01-SSC-0019.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: SonicWall
+model: 01-SSC-0019
+part_number: 01-SSC-0019
+comments: Power Supply for NSa 4650/5650/6650/9250/9450/9650
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c14
+    maximum_draw: 350

--- a/module-types/SonicWall/01-SSC-1215.yaml
+++ b/module-types/SonicWall/01-SSC-1215.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: SonicWall
+model: 01-SSC-1215
+part_number: 01-SSC-1215
+comments: Power Supply for SonicWall NSsp 12000 Series
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c14
+    maximum_draw: 350

--- a/module-types/SonicWall/02-SSC-3078.yaml
+++ b/module-types/SonicWall/02-SSC-3078.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-3078
+part_number: 02-SSC-3078
+comments: Power Supply for NSa 2700/TZ 670/TZ 570
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c14
+    maximum_draw: 60

--- a/module-types/SonicWall/02-SSC-3114.yaml
+++ b/module-types/SonicWall/02-SSC-3114.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-3114
+part_number: 02-SSC-3114
+comments: M.2 Storage Module 32GB

--- a/module-types/SonicWall/02-SSC-3115.yaml
+++ b/module-types/SonicWall/02-SSC-3115.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-3115
+part_number: 02-SSC-3115
+comments: M.2 Storage Module 64GB

--- a/module-types/SonicWall/02-SSC-3116.yaml
+++ b/module-types/SonicWall/02-SSC-3116.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-3116
+part_number: 02-SSC-3116
+comments: M.2 Storage Module 128GB

--- a/module-types/SonicWall/02-SSC-3117.yaml
+++ b/module-types/SonicWall/02-SSC-3117.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-3117
+part_number: 02-SSC-3117
+comments: M.2 Storage Module 256GB

--- a/module-types/SonicWall/02-SSC-8060.yaml
+++ b/module-types/SonicWall/02-SSC-8060.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-8060
+part_number: 02-SSC-8060
+comments: Power Supply for NSa 3700 Series
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c14
+    maximum_draw: 90

--- a/module-types/SonicWall/02-SSC-8061.yaml
+++ b/module-types/SonicWall/02-SSC-8061.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-8061
+part_number: 02-SSC-8061
+comments: Power Supply for NSa 2650/3650
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c14
+    maximum_draw: 120

--- a/module-types/SonicWall/02-SSC-8893.yaml
+++ b/module-types/SonicWall/02-SSC-8893.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-8893
+part_number: 02-SSC-8893
+comments: M.2 Storage Module 512GB

--- a/module-types/SonicWall/02-SSC-8894.yaml
+++ b/module-types/SonicWall/02-SSC-8894.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: SonicWall
+model: 02-SSC-8894
+part_number: 02-SSC-8894
+comments: SSD Storage Module 1TB


### PR DESCRIPTION
Modify all existing SonicWall products which can hold modules or inventory items of any type.
Additionally, add PSU/Storage modules which can be placed in modules.