### PR TITLE
Remove questionable use of USB ports in console

### DIFF
--- a/device-types/Dell/PowerEdge_R330.yaml
+++ b/device-types/Dell/PowerEdge_R330.yaml
@@ -7,19 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R610.yaml
+++ b/device-types/Dell/PowerEdge_R610.yaml
@@ -13,19 +13,6 @@ console-ports:
     type: other
   - name: Rear VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
-  - name: Rear USB3
-    type: usb-a
-  - name: Rear USB4
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R620.yaml
+++ b/device-types/Dell/PowerEdge_R620.yaml
@@ -7,19 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R630.yaml
+++ b/device-types/Dell/PowerEdge_R630.yaml
@@ -7,19 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R640.yaml
+++ b/device-types/Dell/PowerEdge_R640.yaml
@@ -7,21 +7,10 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: Optional USB Port
-    type: usb-a
   - name: Front VGA
     type: other
   - name: Rear VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front iDRAC Direct micro port
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R650.yaml
+++ b/device-types/Dell/PowerEdge_R650.yaml
@@ -12,17 +12,6 @@ console-ports:
     type: other
   - name: Rear VGA
     type: other
-  - name: Internal USB1
-    type: usb-a
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front Dedicated iDRAC direct USB
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R6515.yaml
+++ b/device-types/Dell/PowerEdge_R6515.yaml
@@ -7,17 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R6525.yaml
+++ b/device-types/Dell/PowerEdge_R6525.yaml
@@ -7,17 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R720.yaml
+++ b/device-types/Dell/PowerEdge_R720.yaml
@@ -7,19 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R720xd.yaml
+++ b/device-types/Dell/PowerEdge_R720xd.yaml
@@ -13,13 +13,6 @@ console-ports:
     type: other
   - name: Rear VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R730.yaml
+++ b/device-types/Dell/PowerEdge_R730.yaml
@@ -7,19 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R740.yaml
+++ b/device-types/Dell/PowerEdge_R740.yaml
@@ -12,19 +12,6 @@ console-ports:
     type: other
   - name: Rear VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Front Dedicated iDRAC direct USB
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
-  - name: Rear Dedicated iDRAC direct USB
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R740xd.yaml
+++ b/device-types/Dell/PowerEdge_R740xd.yaml
@@ -13,15 +13,6 @@ console-ports:
     type: other
   - name: Rear VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R7515.yaml
+++ b/device-types/Dell/PowerEdge_R7515.yaml
@@ -7,19 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R7525.yaml
+++ b/device-types/Dell/PowerEdge_R7525.yaml
@@ -7,19 +7,8 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-  - name: USB
-    type: usb-a
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R815.yaml
+++ b/device-types/Dell/PowerEdge_R815.yaml
@@ -11,15 +11,6 @@ console-ports:
     type: de-9
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Dell/PowerEdge_R940.yaml
+++ b/device-types/Dell/PowerEdge_R940.yaml
@@ -9,15 +9,6 @@ console-ports:
     type: de-9
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: Power 1
     type: iec-60320-c14

--- a/device-types/Extreme Networks/5520-24T.yaml
+++ b/device-types/Extreme Networks/5520-24T.yaml
@@ -11,13 +11,6 @@ console-ports:
     type: rj-45
   - name: Console_USB
     type: usb-micro-b
-console-server-ports:
-  - name: USB-Storage1
-    type: usb-a
-    description: 'for management or external USB flash'
-  - name: USB-Storage2
-    type: usb-a
-    description: 'for management or external USB flash'
 interfaces:
   - name: '1'
     type: 1000base-t

--- a/device-types/Extreme Networks/VSP-7400-48Y-8C.yaml
+++ b/device-types/Extreme Networks/VSP-7400-48Y-8C.yaml
@@ -8,9 +8,6 @@ is_full_depth: true
 console-ports:
   - name: Console
     type: rj-45
-console-server-ports:
-  - name: USB-Storage
-    type: usb-micro-a
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/ProLiant_DL360_Gen9.yaml
+++ b/device-types/HPE/ProLiant_DL360_Gen9.yaml
@@ -9,12 +9,6 @@ console-ports:
     type: de-9
   - name: VGA
     type: other
-  - name: Front USB1
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/HPE/ProLiant_DL380_Gen9.yaml
+++ b/device-types/HPE/ProLiant_DL380_Gen9.yaml
@@ -9,12 +9,6 @@ console-ports:
     type: de-9
   - name: VGA
     type: other
-  - name: Front USB1
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/HPE/ProLiant_DL380p_Gen8.yaml
+++ b/device-types/HPE/ProLiant_DL380p_Gen8.yaml
@@ -10,16 +10,6 @@ console-ports:
     type: de-9
   - name: VGA
     type: other
-  - name: Front USB1
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
-  - name: Rear USB3
-    type: usb-a
-  - name: Rear USB4
-    type: usb-a
 power-ports:
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Huawei/Huawei_2288H_V5.yaml
+++ b/device-types/Huawei/Huawei_2288H_V5.yaml
@@ -10,15 +10,6 @@ console-ports:
     type: rj-45
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/LANCOM/ISG-1000.yaml
+++ b/device-types/LANCOM/ISG-1000.yaml
@@ -31,6 +31,5 @@ interfaces:
 console-ports:
   - name: com
     type: rj-45
-console-server-ports:
   - name: usb
     type: usb-a

--- a/device-types/LANCOM/ISG-4000.yaml
+++ b/device-types/LANCOM/ISG-4000.yaml
@@ -35,6 +35,3 @@ interfaces:
 console-ports:
   - name: com
     type: rj-45
-console-server-ports:
-  - name: usb
-    type: usb-a

--- a/device-types/LANCOM/ISG-8000.yaml
+++ b/device-types/LANCOM/ISG-8000.yaml
@@ -36,8 +36,3 @@ interfaces:
 console-ports:
   - name: com
     type: rj-45
-console-server-ports:
-  - name: usb0
-    type: usb-a
-  - name: usb1
-    type: usb-a

--- a/device-types/LANCOM/LN-1700UE.yaml
+++ b/device-types/LANCOM/LN-1700UE.yaml
@@ -21,6 +21,3 @@ interfaces:
 console-ports:
   - name: com
     type: mini-din-8
-console-server-ports:
-  - name: usb
-    type: usb-a

--- a/device-types/LANCOM/WLC-1000.yaml
+++ b/device-types/LANCOM/WLC-1000.yaml
@@ -31,6 +31,3 @@ interfaces:
 console-ports:
   - name: com
     type: rj-45
-console-server-ports:
-  - name: usb
-    type: usb-a

--- a/device-types/LANCOM/WLC-30.yaml
+++ b/device-types/LANCOM/WLC-30.yaml
@@ -23,6 +23,3 @@ interfaces:
 console-ports:
   - name: com
     type: mini-din-8
-console-server-ports:
-  - name: usb
-    type: usb-a

--- a/device-types/LANCOM/WLC-4006-plus.yaml
+++ b/device-types/LANCOM/WLC-4006-plus.yaml
@@ -23,6 +23,3 @@ interfaces:
 console-ports:
   - name: com
     type: mini-din-8
-console-server-ports:
-  - name: usb
-    type: usb-a

--- a/device-types/LANCOM/WLC-4025-plus.yaml
+++ b/device-types/LANCOM/WLC-4025-plus.yaml
@@ -17,6 +17,3 @@ interfaces:
 console-ports:
   - name: com
     type: mini-din-8
-console-server-ports:
-  - name: usb
-    type: usb-a

--- a/device-types/LANCOM/WLC-4100.yaml
+++ b/device-types/LANCOM/WLC-4100.yaml
@@ -21,6 +21,3 @@ interfaces:
 console-ports:
   - name: com
     type: mini-din-8
-console-server-ports:
-  - name: usb
-    type: usb-a

--- a/device-types/Lenovo/system_x3550_M5.yaml
+++ b/device-types/Lenovo/system_x3550_M5.yaml
@@ -28,11 +28,3 @@ console-ports:
     type: other
   - name: Rear VGA
     type: other
-  - name: Front usb 3.0
-    type: usb-a
-  - name: Front usb 2.0
-    type: usb-a
-  - name: Rear usb 3.0 (Left)
-    type: usb-a
-  - name: Rear usb 3.0 (Rigth)
-    type: usb-a

--- a/device-types/Lenovo/system_x3750_M4.yaml
+++ b/device-types/Lenovo/system_x3750_M4.yaml
@@ -22,11 +22,3 @@ interfaces:
 console-ports:
   - name: Rear VGA
     type: other
-  - name: Front usb 2.0 (Left)
-    type: usb-a
-  - name: Front usb 2.0 (Right)
-    type: usb-a
-  - name: Rear usb 2.0 (Top)
-    type: usb-a
-  - name: Rear usb 2.0 (Bottom)
-    type: usb-a

--- a/device-types/MikroTik/RB951G-2HnD.yaml
+++ b/device-types/MikroTik/RB951G-2HnD.yaml
@@ -2,9 +2,6 @@
 manufacturer: MikroTik
 model: RB951G-2HnD
 slug: rb951g-2hnd
-console-server-ports:
-  - name: usb
-    type: usb-a
 power-ports:
   - name: power8-30V
     type: iec-60320-c14

--- a/device-types/Nvidia/jetson-xavier-nx-developer-kit.yaml
+++ b/device-types/Nvidia/jetson-xavier-nx-developer-kit.yaml
@@ -11,18 +11,8 @@ interfaces:
 power-ports:
   - name: PSU
     type: dc-terminal
-console-server-ports:
+console-ports:
   - name: HDMI
     type: other
   - name: Display Port
     type: other
-  - name: USB 1
-    type: usb-a
-  - name: USB 2
-    type: usb-a
-  - name: USB 3
-    type: usb-a
-  - name: USB 4
-    type: usb-a
-  - name: micro USB type B
-    type: usb-micro-b

--- a/device-types/Rockwell Automation/5069-L4100ERW.yaml
+++ b/device-types/Rockwell Automation/5069-L4100ERW.yaml
@@ -15,11 +15,6 @@ interfaces:
 console-ports:
   - name: usb
     type: usb-b
-console-server-ports:
-  - name: usb-1
-    type: usb-a
-  - name: usb-2
-    type: usb-a
 power-ports:
   - name: MOD
     type: dc-terminal

--- a/device-types/Rockwell Automation/5069-L4200ERW.yaml
+++ b/device-types/Rockwell Automation/5069-L4200ERW.yaml
@@ -15,11 +15,6 @@ interfaces:
 console-ports:
   - name: usb
     type: usb-b
-console-server-ports:
-  - name: usb-1
-    type: usb-a
-  - name: usb-2
-    type: usb-a
 power-ports:
   - name: MOD
     type: dc-terminal

--- a/device-types/Rockwell Automation/5069-L430ERW.yaml
+++ b/device-types/Rockwell Automation/5069-L430ERW.yaml
@@ -15,11 +15,6 @@ interfaces:
 console-ports:
   - name: usb
     type: usb-b
-console-server-ports:
-  - name: usb-1
-    type: usb-a
-  - name: usb-2
-    type: usb-a
 power-ports:
   - name: MOD
     type: dc-terminal

--- a/device-types/Rockwell Automation/5069-L450ERW.yaml
+++ b/device-types/Rockwell Automation/5069-L450ERW.yaml
@@ -15,11 +15,6 @@ interfaces:
 console-ports:
   - name: usb
     type: usb-b
-console-server-ports:
-  - name: usb-1
-    type: usb-a
-  - name: usb-2
-    type: usb-a
 power-ports:
   - name: MOD
     type: dc-terminal

--- a/device-types/Rohde & Schwarz/TrustedVPN-XL.yaml
+++ b/device-types/Rohde & Schwarz/TrustedVPN-XL.yaml
@@ -8,13 +8,6 @@ is_full_depth: false
 console-ports:
   - name: VGA
     type: other
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
 power-ports:
   - name: PSU1
     type: iec-60320-c14

--- a/device-types/Synology/DS220+.yaml
+++ b/device-types/Synology/DS220+.yaml
@@ -11,8 +11,3 @@ interfaces:
     type: 1000base-t
   - name: LAN 2
     type: 1000base-t
-console-server-ports:
-  - name: Front USB
-    type: usb-a
-  - name: Rear USB
-    type: usb-a

--- a/device-types/Synology/RS1219plus.yaml
+++ b/device-types/Synology/RS1219plus.yaml
@@ -8,13 +8,6 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-console-server-ports:
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
-  - name: eSata
-    type: other
 power-ports:
   - name: PSU 1
     type: iec-60320-c14

--- a/device-types/Synology/RS1221plus.yaml
+++ b/device-types/Synology/RS1221plus.yaml
@@ -8,13 +8,6 @@ is_full_depth: true
 console-ports:
   - name: Serial
     type: de-9
-console-server-ports:
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
-  - name: eSata
-    type: other
 power-ports:
   - name: PSU 1
     type: iec-60320-c14

--- a/device-types/Synology/RS3617RPxs.yaml
+++ b/device-types/Synology/RS3617RPxs.yaml
@@ -19,19 +19,7 @@ interfaces:
     type: 1000base-t
   - name: Ethernet 4
     type: 1000base-t
-console-server-ports:
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
-  - name: Rear USB3
-    type: usb-a
-  - name: Rear USB4
-    type: usb-a
+console-ports:
   - name: Console
     type: de-9
     mgmt_only: true
-  - name: Expansion 1
-    type: other
-  - name: Expansion 2
-    type: other

--- a/device-types/Synology/RS820+.yaml
+++ b/device-types/Synology/RS820+.yaml
@@ -18,13 +18,7 @@ interfaces:
     type: 1000base-t
   - name: Ethernet 4
     type: 1000base-t
-console-server-ports:
-  - name: Rear USB1
-    type: usb-a
-  - name: Rear USB2
-    type: usb-a
+console-ports:
   - name: Console
     type: de-9
     mgmt_only: true
-  - name: eSATA
-    type: other

--- a/device-types/neousys/Nuvo-824DGC.yaml
+++ b/device-types/neousys/Nuvo-824DGC.yaml
@@ -10,25 +10,6 @@ console-ports:
     type: de-9
   - name: COM 2
     type: de-9
-console-server-ports:
-  - name: Front USB1
-    type: usb-a
-  - name: Front USB2
-    type: usb-a
-  - name: Front USB3
-    type: usb-a
-  - name: Front USB4
-    type: usb-a
-  - name: Front USB5
-    type: usb-a
-  - name: Front USB6
-    type: usb-a
-  - name: Front USB7
-    type: usb-a
-  - name: Front USB8
-    type: usb-a
-  - name: Internal USB1
-    type: usb-a
   - name: VGA
     type: other
   - name: DVI-D


### PR DESCRIPTION
Currently, there are a number of USB ports being modelled in the console port/console server port section of devices where they are clearly not being used for console access (external USB storage, USB HID, USB Peripherals, etc).

This PR removes all of those as that is not the intended usage of the console port/console server port section.  Modelling for these "special" cases can be done via other methods (interfaces, inventory items, etc) by the end user.

If there is a need to model these specific use cases,  in more detail then what is allowed via those methods, then a FR should be opened against the NetBox project to propose a implementation.