### PR TITLE
Create 8x_Combo_PON_OLT_AM

### DIFF
--- a/module-types/8x_Combo_PON_OLT_AM
+++ b/module-types/8x_Combo_PON_OLT_AM
@@ -1,0 +1,46 @@
+---
+manufacturer: Adtran
+model: 8-Port Combo PON Access Module
+part_number: '4187518F32'
+comments: ''
+interfaces:
+- name: GPON 1/{module}/1
+  type: 10gbase-x-sfpp
+  mgmt_only: false
+  label: '1'
+  description: ''
+- name: GPON 1/{module}/2
+  type: 10gbase-x-sfpp
+  mgmt_only: false
+  label: '2'
+  description: ''
+- name: GPON 1/{module}/3
+  type: 10gbase-x-sfpp
+  mgmt_only: false
+  label: '3'
+  description: ''
+- name: GPON 1/{module}/4
+  type: 10gbase-x-sfpp
+  mgmt_only: false
+  label: '4'
+  description: ''
+- name: GPON 1/{module}/5
+  type: 10gbase-x-sfpp
+  mgmt_only: false
+  label: '5'
+  description: ''
+- name: GPON 1/{module}/6
+  type: 10gbase-x-sfpp
+  mgmt_only: false
+  label: '6'
+  description: ''
+- name: GPON 1/{module}/7
+  type: 10gbase-x-sfpp
+  mgmt_only: false
+  label: '7'
+  description: ''
+- name: GPON 1/{module}/8
+  type: 10gbase-x-sfpp
+  mgmt_only: false
+  label: '8'
+  description: ''


### PR DESCRIPTION
Adtran 4187518F32

The 10G Combo PON OLT module supports a flexible optics approach that allows for each of the eight ports to independently utilize multiple types of transceivers. This allows service providers the flexibility to determine the right technology (GPON or XGS-PON) for residential FTTH while also providing capacity for high-bandwidth business and mobile backhaul services. The module is compatible with the Total Access 5000 Series.