### PR TITLE
Add peplink 1350

### DIFF
--- a/device-types/Peplink/Balance-1350.yaml
+++ b/device-types/Peplink/Balance-1350.yaml
@@ -3,7 +3,7 @@ manufacturer: PepLink
 model: Balance 1350
 slug: balance-1350
 is_full_depth: false
-u_height: 2
+u_height: 1
 comments: |
   [Peplink Balance 1350 Data Sheet](https://www.peplink.com/products/balance-1350/#datasheet--resources)
 console-ports:
@@ -66,4 +66,3 @@ interfaces:
     type: other
     mgmt_only: false
     description: usb wan port
-

--- a/device-types/Peplink/Balance-1350.yaml
+++ b/device-types/Peplink/Balance-1350.yaml
@@ -1,7 +1,8 @@
 ---
-manufacturer: PepLink
+manufacturer: Peplink
 model: Balance 1350
 slug: balance-1350
+part_number: BPL-135
 is_full_depth: false
 u_height: 1
 comments: |

--- a/device-types/Peplink/Balance-1350.yaml
+++ b/device-types/Peplink/Balance-1350.yaml
@@ -1,0 +1,69 @@
+---
+manufacturer: PepLink
+model: Balance 1350
+slug: balance-1350
+is_full_depth: false
+u_height: 2
+comments: |
+  [Peplink Balance 1350 Data Sheet](https://www.peplink.com/products/balance-1350/#datasheet--resources)
+console-ports:
+  - name: con0
+    type: rj-45
+power-ports:
+  - name: psu0
+    type: iec-60320-c14
+    maximum_draw: 70
+interfaces:
+  - name: lan1
+    type: 1000base-t
+    mgmt_only: false
+  - name: lan2
+    type: 1000base-t
+    mgmt_only: false
+  - name: lan3
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan1
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan2
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan3
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan4
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan5
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan6
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan7
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan8
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan9
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan10
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan11
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan12
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan13
+    type: 1000base-t
+    mgmt_only: false
+  - name: wan14
+    type: other
+    mgmt_only: false
+    description: usb wan port
+

--- a/device-types/Peplink/Balance-305.yaml
+++ b/device-types/Peplink/Balance-305.yaml
@@ -1,5 +1,5 @@
 ---
-manufacturer: PepLink
+manufacturer: Peplink
 model: Balance 305
 slug: balance-305
 part_number: BPL-305


### PR DESCRIPTION
Addition of Peplink 1350.

[Netbox-Device-Type-Library-Import](https://github.com/dmcken/Netbox-Device-Type-Library-Import) doesn't work with manufacturer name of PepLink vs Peplink so lower-cased the only other model under this manufacturer.