### PR TITLE
Raspberrypi device fixes

### DIFF
--- a/device-types/Raspberry Pi/RPI3-MODB-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI3-MODB-1GB.yaml
@@ -7,7 +7,9 @@ u_height: 0
 is_full_depth: false
 interfaces:
   - name: eth0
-    type: 1000base-t
+    type: 100base-tx
+  - name: wlan0
+    type: ieee802.11n
 power-ports:
   - name: PSU
     type: usb-micro-b

--- a/device-types/Raspberry Pi/RPI3-MODB-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI3-MODB-1GB.yaml
@@ -10,4 +10,4 @@ interfaces:
     type: 1000base-t
 power-ports:
   - name: PSU
-    type: nema-1-15p
+    type: usb-micro-b

--- a/device-types/Raspberry Pi/RPI3-MODBP-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI3-MODBP-1GB.yaml
@@ -10,4 +10,4 @@ interfaces:
     type: 1000base-t
 power-ports:
   - name: PSU
-    type: nema-1-15p
+    type: usb-micro-b

--- a/device-types/Raspberry Pi/RPI3-MODBP-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI3-MODBP-1GB.yaml
@@ -8,6 +8,8 @@ is_full_depth: false
 interfaces:
   - name: eth0
     type: 1000base-t
+  - name: wlan0
+    type: ieee802.11ac
 power-ports:
   - name: PSU
     type: usb-micro-b

--- a/device-types/Raspberry Pi/RPI4-MODB-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODB-1GB.yaml
@@ -8,6 +8,8 @@ is_full_depth: false
 interfaces:
   - name: eth0
     type: 1000base-t
+  - name: wlan0
+    type: ieee802.11ac
 power-ports:
   - name: PSU
     type: usb-c

--- a/device-types/Raspberry Pi/RPI4-MODB-1GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODB-1GB.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Raspberry Pi
 model: Raspberry Pi 4 Model B 1GB
-slug: rpi4-modbp-1gb
-part_number: RPI4-MODBP-1GB
+slug: rpi4-modb-1gb
+part_number: RPI4-MODB-1GB
 u_height: 0
 is_full_depth: false
 interfaces:

--- a/device-types/Raspberry Pi/RPI4-MODB-2GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODB-2GB.yaml
@@ -8,6 +8,8 @@ is_full_depth: false
 interfaces:
   - name: eth0
     type: 1000base-t
+  - name: wlan0
+    type: ieee802.11ac
 power-ports:
   - name: PSU
     type: usb-c

--- a/device-types/Raspberry Pi/RPI4-MODB-2GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODB-2GB.yaml
@@ -10,4 +10,4 @@ interfaces:
     type: 1000base-t
 power-ports:
   - name: PSU
-    type: nema-1-15p
+    type: usb-c

--- a/device-types/Raspberry Pi/RPI4-MODB-4GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODB-4GB.yaml
@@ -8,6 +8,8 @@ is_full_depth: false
 interfaces:
   - name: eth0
     type: 1000base-t
+  - name: wlan0
+    type: ieee802.11ac
 power-ports:
   - name: PSU
     type: usb-c

--- a/device-types/Raspberry Pi/RPI4-MODB-4GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODB-4GB.yaml
@@ -10,4 +10,4 @@ interfaces:
     type: 1000base-t
 power-ports:
   - name: PSU
-    type: nema-1-15p
+    type: usb-c

--- a/device-types/Raspberry Pi/RPI4-MODB-8GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODB-8GB.yaml
@@ -8,6 +8,8 @@ is_full_depth: false
 interfaces:
   - name: eth0
     type: 1000base-t
+  - name: wlan0
+    type: ieee802.11ac
 power-ports:
   - name: PSU
     type: usb-c

--- a/device-types/Raspberry Pi/RPI4-MODB-8GB.yaml
+++ b/device-types/Raspberry Pi/RPI4-MODB-8GB.yaml
@@ -10,4 +10,4 @@ interfaces:
     type: 1000base-t
 power-ports:
   - name: PSU
-    type: nema-1-15p
+    type: usb-c


### PR DESCRIPTION
This PR fixes a few issues with the raspberry pi devices.

* 1GB pi 4 renamed to match the other devices (there is no B+ variant of the pi4)
* Swapped power inputs types to correct USB connector for each variant
* Added Pi's wifi interfaces
* Fixed interface type for pi3 to 10/100