### PR TITLE
add some APC UPS, XLBP, XFMR device models, convert NMC from device to module models

### DIFF
--- a/device-types/APC/APTF10KT01.yaml
+++ b/device-types/APC/APTF10KT01.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: APC
+model: APTF10KT01
+slug: aptf10kt01
+part_number: APTF10KT01
+comments: APC 208V/120V 10KVA Step down Transformer
+u_height: 4
+is_full_depth: true
+power-ports:
+  - name: Source
+    type: hardwired
+power-outlets:
+  - name: Hard Wire Output
+    type: hardwired
+  - name: Outlet 1
+    type: nema-l14-30r
+  - name: Outlet 2
+    type: nema-l14-30r
+  - name: Outlet 3
+    type: nema-l5-20r
+  - name: Outlet 4
+    type: nema-l5-20r

--- a/device-types/APC/SMT1000.yaml
+++ b/device-types/APC/SMT1000.yaml
@@ -1,0 +1,36 @@
+---
+manufacturer: APC
+model: SMT1000
+slug: smt1000
+part_number: SMT1000
+comments: "APC Smart-UPS, Line Interactive, 1000VA, Tower, 120V, 8x NEMA 5-15R outlets, SmartSlot, AVR, LCD\n
+\n
+| RBC Information |      |\n
+| --------------- | ---- |\n
+| RBC Replacement | RBC6 |\n
+| RBC Quantity    | 1    |"
+u_height: 0
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: rj-45
+  - name: USB
+    type: usb-b
+power-ports:
+  - name: Source
+    type: nema-5-15p
+power-outlets:
+  - name: Group 1 Outlet 1
+    type: nema-5-15r
+  - name: Group 1 Outlet 2
+    type: nema-5-15r
+  - name: Group 1 Outlet 3
+    type: nema-5-15r
+  - name: Group 2 Outlet 1
+    type: nema-5-15r
+  - name: Group 2 Outlet 2
+    type: nema-5-15r
+  - name: Group 2 Outlet 3
+    type: nema-5-15r
+module-bays:
+  - name: SmartSlot

--- a/device-types/APC/SMT1500.yaml
+++ b/device-types/APC/SMT1500.yaml
@@ -1,0 +1,36 @@
+---
+manufacturer: APC
+model: SMT1500
+slug: smt1500
+part_number: SMT1500
+comments: "APC Smart-UPS, Line Interactive, 1500VA, Tower, 120V, 8x NEMA 5-15R outlets, SmartSlot, AVR, LCD\n
+\n
+| RBC Information |      |\n
+| --------------- | ---- |\n
+| RBC Replacement | RBC7 |\n
+| RBC Quantity    | 1    |"
+u_height: 0
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: rj-45
+  - name: USB
+    type: usb-b
+power-ports:
+  - name: Source
+    type: nema-5-15p
+power-outlets:
+  - name: Group 1 Outlet 1
+    type: nema-5-15r
+  - name: Group 1 Outlet 2
+    type: nema-5-15r
+  - name: Group 1 Outlet 3
+    type: nema-5-15r
+  - name: Group 2 Outlet 1
+    type: nema-5-15r
+  - name: Group 2 Outlet 2
+    type: nema-5-15r
+  - name: Group 2 Outlet 3
+    type: nema-5-15r
+module-bays:
+  - name: SmartSlot

--- a/device-types/APC/SMT1500RM2U.yaml
+++ b/device-types/APC/SMT1500RM2U.yaml
@@ -1,0 +1,36 @@
+---
+manufacturer: APC
+model: SMT1500RM2U
+slug: smt1500rm2u
+part_number: SMT1500RM2U
+comments: "APC Smart-UPS, Line Interactive, 1500VA, Rackmount 2U, 120V, 6x NEMA 5-15R outlets, SmartSlot, AVR, LCD\n
+\n
+| RBC Information |           |\n
+| --------------- | --------- |\n
+| RBC Replacement | APCRBC133 |\n
+| RBC Quantity    | 1         |"
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: rj-45
+  - name: USB
+    type: usb-b
+power-ports:
+  - name: Source
+    type: nema-5-15p
+power-outlets:
+  - name: Group 1 Outlet 1
+    type: nema-5-15r
+  - name: Group 1 Outlet 2
+    type: nema-5-15r
+  - name: Group 1 Outlet 3
+    type: nema-5-15r
+  - name: Group 2 Outlet 1
+    type: nema-5-15r
+  - name: Group 2 Outlet 2
+    type: nema-5-15r
+  - name: Group 2 Outlet 3
+    type: nema-5-15r
+module-bays:
+  - name: SmartSlot

--- a/device-types/APC/SMX2200HV.yaml
+++ b/device-types/APC/SMX2200HV.yaml
@@ -1,0 +1,45 @@
+---
+manufacturer: APC
+model: SMX2200HV
+slug: smx2200hv
+part_number: SMX2200HV
+comments: "APC Smart-UPS X, Line Interactive, 2200VA, Rack/tower convertible 4U, 208V-230V, 8x C13+1x C19 IEC, SmartSlot, Extended runtime\n
+\n
+| RBC Information |             |\n
+| --------------- | ----------- |\n
+| RBC Replacement | APCRBC143US |\n
+| RBC Quantity    | 1           |"
+u_height: 4
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: rj-45
+  - name: USB
+    type: usb-b
+power-ports:
+  - name: Source
+    type: iec-60320-c20
+  - name: XLBP Source
+power-outlets:
+  - name: Group 1 Outlet 1
+    type: iec-60320-c13
+  - name: Group 1 Outlet 2
+    type: iec-60320-c13
+  - name: Group 1 Outlet 3
+    type: iec-60320-c13
+  - name: Group 1 Outlet 4
+    type: iec-60320-c13
+  - name: Group 2 Outlet 1
+    type: iec-60320-c13
+  - name: Group 2 Outlet 2
+    type: iec-60320-c13
+  - name: Group 2 Outlet 3
+    type: iec-60320-c19
+  - name: Group 3 Outlet 1
+    type: iec-60320-c13
+  - name: Group 3 Outlet 2
+    type: iec-60320-c13
+  - name: Group 3 Outlet 3
+    type: iec-60320-c19
+module-bays:
+  - name: SmartSlot

--- a/device-types/APC/SMX2200HV.yaml
+++ b/device-types/APC/SMX2200HV.yaml
@@ -20,6 +20,7 @@ power-ports:
   - name: Source
     type: iec-60320-c20
   - name: XLBP Source
+    type: dc-terminal
 power-outlets:
   - name: Group 1 Outlet 1
     type: iec-60320-c13

--- a/device-types/APC/SRT3000RMXLT.yaml
+++ b/device-types/APC/SRT3000RMXLT.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: APC
+model: SRT3000RMXLT
+slug: srt3000rmxlt
+part_number: SRT3000RMXLT
+comments: "APC Smart-UPS On-Line, 3kVA, Rackmount 2U, 208V, 2x L6-20R+1x L6-30R NEMA outlets, SmartSlot, Extended runtime, W/ rail kit\n
+\n
+| RBC Information |           |\n
+| --------------- | --------- |\n
+| RBC Replacement | APCRBC152 |\n
+| RBC Quantity    | 1         |"
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: rj-45
+  - name: USB
+    type: usb-b
+power-ports:
+  - name: Source
+    type: nema-l6-20p
+  - name: XLBP Source
+power-outlets:
+  - name: Group 1 Outlet 1
+    type: nema-l6-30r
+  - name: Group 2 Outlet 1
+    type: nema-l6-20r
+  - name: Group 2 Outlet 2
+    type: nema-l6-20r
+module-bays:
+  - name: SmartSlot

--- a/device-types/APC/SRT3000RMXLT.yaml
+++ b/device-types/APC/SRT3000RMXLT.yaml
@@ -20,6 +20,7 @@ power-ports:
   - name: Source
     type: nema-l6-20p
   - name: XLBP Source
+    type: dc-terminal
 power-outlets:
   - name: Group 1 Outlet 1
     type: nema-l6-30r

--- a/device-types/APC/SURT192RMXLBP2.yaml
+++ b/device-types/APC/SURT192RMXLBP2.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: APC
+model: SURT192RMXLBP2
+slug: surt192rmxlbp2
+part_number: SURT192RMXLBP2
+comments: "APC Smart-UPS RT192V RM Battery Pack 2 Rows\n
+\n
+| RBC Information |           |\n
+| --------------- | --------- |\n
+| RBC Replacement | APCRBC140 |\n
+| RBC Quantity    | 4         |"
+u_height: 6
+is_full_depth: true
+power-ports:
+  - name: XLBP Source
+power-outlets:
+  - name: XLBP Output

--- a/device-types/APC/SURT192RMXLBP2.yaml
+++ b/device-types/APC/SURT192RMXLBP2.yaml
@@ -13,5 +13,7 @@ u_height: 6
 is_full_depth: true
 power-ports:
   - name: XLBP Source
+    type: dc-terminal
 power-outlets:
   - name: XLBP Output
+    type: dc-terminal

--- a/device-types/APC/SURT20KRMXLT.yaml
+++ b/device-types/APC/SURT20KRMXLT.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: APC
+model: SURT20KRMXLT
+slug: surt20krmxlt
+part_number: SURT20KRMXLT
+comments: "APC Smart-UPS RT 20kVA, 208V, LCD, rackmount, 12U, 4x NEMA L6-20R & 2x NEMA L6-30R outlets\n
+\n
+| RBC Information |           |\n
+| --------------- | --------- |\n
+| RBC Replacement | APCRBC140 |\n
+| RBC Quantity    | 4         |"
+u_height: 12
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: rj-45
+power-ports:
+  - name: Source
+    type: hardwired
+  - name: XLBP Source
+power-outlets:
+  - name: Hard Wire Output
+    type: hardwired
+  - name: PDU Panel 1 Group 1 Outlet 1
+    type: nema-l6-30r
+  - name: PDU Panel 1 Group 2 Outlet 1
+    type: nema-l6-20r
+  - name: PDU Panel 1 Group 2 Outlet 2
+    type: nema-l6-20r
+  - name: PDU Panel 2 Group 1 Outlet 1
+    type: nema-l6-30r
+  - name: PDU Panel 2 Group 2 Outlet 1
+    type: nema-l6-20r
+  - name: PDU Panel 2 Group 2 Outlet 2
+    type: nema-l6-20r
+module-bays:
+  - name: SmartSlot

--- a/device-types/APC/SURT20KRMXLT.yaml
+++ b/device-types/APC/SURT20KRMXLT.yaml
@@ -18,6 +18,7 @@ power-ports:
   - name: Source
     type: hardwired
   - name: XLBP Source
+    type: dc-terminal
 power-outlets:
   - name: Hard Wire Output
     type: hardwired

--- a/module-types/APC/AP9617.yaml
+++ b/module-types/APC/AP9617.yaml
@@ -1,12 +1,8 @@
 ---
 manufacturer: APC
 model: AP9617
-slug: ap9617
 part_number: AP9617
-u_height: 0
-is_full_depth: false
 comments: UPS Network Management Card
-subdevice_role: child
 interfaces:
   - name: Network
     type: 100base-tx

--- a/module-types/APC/AP9618.yaml
+++ b/module-types/APC/AP9618.yaml
@@ -1,12 +1,8 @@
 ---
 manufacturer: APC
 model: AP9618
-slug: ap9618
 part_number: AP9618
-u_height: 0
-is_full_depth: false
 comments: UPS Network Management Card w/ Environmental Monitoring & Out of Band Management
-subdevice_role: child
 interfaces:
   - name: Network
     type: 100base-tx

--- a/module-types/APC/AP9619.yaml
+++ b/module-types/APC/AP9619.yaml
@@ -1,12 +1,8 @@
 ---
 manufacturer: APC
 model: AP9619
-slug: ap9619
 part_number: AP9619
-u_height: 0
-is_full_depth: false
 comments: UPS Network Management Card w/ Environmental Monitoring
-subdevice_role: child
 interfaces:
   - name: Network
     type: 100base-tx

--- a/module-types/APC/AP9630.yaml
+++ b/module-types/APC/AP9630.yaml
@@ -1,12 +1,8 @@
 ---
 manufacturer: APC
 model: AP9630
-slug: ap9630
 part_number: AP9630
-u_height: 0
-is_full_depth: false
 comments: UPS Network Management Card 2
-subdevice_role: child
 interfaces:
   - name: Network
     type: 100base-tx

--- a/module-types/APC/AP9631.yaml
+++ b/module-types/APC/AP9631.yaml
@@ -1,12 +1,8 @@
 ---
 manufacturer: APC
 model: AP9631
-slug: ap9631
 part_number: AP9631
-u_height: 0
-is_full_depth: false
 comments: UPS Network Management Card 2 with Environmental Monitoring
-subdevice_role: child
 interfaces:
   - name: Network
     type: 100base-tx

--- a/module-types/APC/AP9640.yaml
+++ b/module-types/APC/AP9640.yaml
@@ -1,13 +1,9 @@
 ---
 manufacturer: APC
 model: AP9640
-slug: ap9640
 part_number: AP9640
-u_height: 0
-is_full_depth: false
 comments: UPS Network Management Card 3
-subdevice_role: child
 interfaces:
   - name: Network
-    type: 100base-tx
+    type: 1000base-t
     mgmt_only: true

--- a/module-types/APC/AP9641.yaml
+++ b/module-types/APC/AP9641.yaml
@@ -1,13 +1,9 @@
 ---
 manufacturer: APC
 model: AP9641
-slug: ap9641
 part_number: AP9641
-u_height: 0
-is_full_depth: false
 comments: UPS Network Management Card 3 with Environmental Monitoring
-subdevice_role: child
 interfaces:
   - name: Network
-    type: 100base-tx
+    type: 1000base-t
     mgmt_only: true


### PR DESCRIPTION
I opened Issue #821 because I think APC NMC modules are better modeled as modules than devices now that NetBox supports them. This pull request includes that conversion, as well as some new APC device models that support these modules.