### PR TITLE
Fix firepower 1120 console port

### DIFF
--- a/device-types/Cisco/FPR1120-NGFW-K9.yaml
+++ b/device-types/Cisco/FPR1120-NGFW-K9.yaml
@@ -11,7 +11,7 @@ console-ports:
   - name: Console
     type: rj-45
   - name: usb
-    type: usb-a
+    type: usb-mini-b
 power-ports:
   - name: PSU
     type: iec-60320-c14


### PR DESCRIPTION
The USB console port is mini B. (The USB A port on the device is a host port and NOT a console port).