### PR TITLE
Add Eaton UPS 9PX and related devices/modules

### DIFF
--- a/device-types/Eaton/9PX3000iRT2U.yaml
+++ b/device-types/Eaton/9PX3000iRT2U.yaml
@@ -1,0 +1,74 @@
+---
+manufacturer: Eaton
+model: 9PX 3000i RT 2U
+slug: 9px3000irt2u
+part_number: 9PX3000iRT2U
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+comments: 9PX 1-3kVA Series [Manual](https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/backup-power-ups/eaton-9px-ups/eaton-9px-1-3kva-ups-manual.pdf)
+console-ports:
+  - name: Serial
+    type: de-9
+    label: RS232
+  - name: USB Console
+    type: usb-b
+    label: USB
+power-ports:
+  - name: Mains Utility
+    type: iec-60320-c20
+    maximum_draw: 3000
+    allocated_draw: null
+    label: Input 16A
+power-outlets:
+  - name: Group 1 - Output 1
+    type: iec-60320-c19
+    power_port: Mains Utility
+    label: Output
+  - name: Group 1 - Output 2
+    type: iec-60320-c13
+    power_port: Mains Utility
+    label: Output 10A
+  - name: Group 1 - Output 3
+    type: iec-60320-c13
+    power_port: Mains Utility
+    label: Output 10A
+  - name: Group 2 - Output 1
+    type: iec-60320-c13
+    power_port: Mains Utility
+    label: Output 10A
+  - name: Group 2 - Output 2
+    type: iec-60320-c13
+    power_port: Mains Utility
+    label: Output 10A
+  - name: Primary Group - Output 1
+    type: iec-60320-c19
+    power_port: Mains Utility
+    label: Output
+  - name: Primary Group - Output 2
+    type: iec-60320-c13
+    power_port: Mains Utility
+    label: Output 10A
+  - name: Primary Group - Output 3
+    type: iec-60320-c13
+    power_port: Mains Utility
+    label: Output 10A
+  - name: Primary Group - Output 4
+    type: iec-60320-c13
+    power_port: Mains Utility
+    label: Output 10A
+  - name: Primary Group - Output 5
+    type: iec-60320-c13
+    power_port: Mains Utility
+    label: Output 10A
+interfaces:
+  - name: Battery connector
+    type: other
+    mgmt_only: false
+    label: 72V DC 40A
+  - name: Battery detection
+    type: other
+    mgmt_only: false
+    label: Batt detection
+module-bays:
+  - name: Communication card slot

--- a/device-types/Eaton/9PX3000iRT2U.yaml
+++ b/device-types/Eaton/9PX3000iRT2U.yaml
@@ -71,3 +71,6 @@ interfaces:
     label: Batt detection
 module-bays:
   - name: Communication card slot
+  - name: Environmental Sensor 1
+  - name: Environmental Sensor 2
+  - name: Environmental Sensor 3

--- a/device-types/Eaton/9PX3000iRT2U.yaml
+++ b/device-types/Eaton/9PX3000iRT2U.yaml
@@ -18,7 +18,6 @@ power-ports:
   - name: Mains Utility
     type: iec-60320-c20
     maximum_draw: 3000
-    allocated_draw: null
     label: Input 16A
 power-outlets:
   - name: Group 1 - Output 1

--- a/device-types/Eaton/9PXEBM72RT2U.yaml
+++ b/device-types/Eaton/9PXEBM72RT2U.yaml
@@ -1,0 +1,26 @@
+---
+manufacturer: Eaton
+model: 9PX Extended Battery Module, 72V
+slug: 9pxebm72rt2u
+part_number: 9PXEBM72RT2U
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+comments: 9PX 1-3kVA Series [Manual](https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/backup-power-ups/eaton-9px-ups/eaton-9px-1-3kva-ups-manual.pdf)
+interfaces:
+  - name: Battery connector, left
+    type: other
+    mgmt_only: false
+    label: 72V DC 40A
+  - name: Battery detection, left
+    type: other
+    mgmt_only: false
+    label: Batt detection
+  - name: Battery connector, right
+    type: other
+    mgmt_only: false
+    label: 72V DC 40A
+  - name: Battery detection, right
+    type: other
+    mgmt_only: false
+    label: Batt detection

--- a/device-types/Eaton/EMPDT1H1C2.yaml
+++ b/device-types/Eaton/EMPDT1H1C2.yaml
@@ -1,0 +1,20 @@
+---
+manufacturer: Eaton
+model: Environmental Monitoring Probe Gen 2
+slug: environmental-monitoring-probe-gen-2
+part_number: EMPDT1H1C2
+u_height: 0
+is_full_depth: false
+airflow: passive
+comments: Environmental Monitoring Probe Gen 2 [Manual](https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/power-management-software-connectivity/eaton-environmental-monitoring-probe-gen-2/eaton-emp-gen-2-manual.pdf)
+interfaces:
+  - name: Device
+    type: other
+    mgmt_only: false
+    label: from device
+    description: RJ45 connector for RS485/Modbus connection
+  - name: Sensors
+    type: other
+    mgmt_only: false
+    label: to sensors
+    description: RJ45 connector for RS485/Modbus connection

--- a/module-types/Eaton/EMPDT1H1C2.yaml
+++ b/module-types/Eaton/EMPDT1H1C2.yaml
@@ -1,11 +1,7 @@
 ---
 manufacturer: Eaton
 model: Environmental Monitoring Probe Gen 2
-slug: environmental-monitoring-probe-gen-2
 part_number: EMPDT1H1C2
-u_height: 0
-is_full_depth: false
-airflow: passive
 comments: Environmental Monitoring Probe Gen 2 [Manual](https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/power-management-software-connectivity/eaton-environmental-monitoring-probe-gen-2/eaton-emp-gen-2-manual.pdf)
 interfaces:
   - name: EMP{module}/Device

--- a/module-types/Eaton/EMPDT1H1C2.yaml
+++ b/module-types/Eaton/EMPDT1H1C2.yaml
@@ -8,12 +8,12 @@ is_full_depth: false
 airflow: passive
 comments: Environmental Monitoring Probe Gen 2 [Manual](https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/power-management-software-connectivity/eaton-environmental-monitoring-probe-gen-2/eaton-emp-gen-2-manual.pdf)
 interfaces:
-  - name: Device
+  - name: EMP{module}/Device
     type: other
     mgmt_only: false
     label: from device
     description: RJ45 connector for RS485/Modbus connection
-  - name: Sensors
+  - name: EMP{module}/Sensors
     type: other
     mgmt_only: false
     label: to sensors

--- a/module-types/Eaton/Network-M2.yaml
+++ b/module-types/Eaton/Network-M2.yaml
@@ -1,0 +1,20 @@
+---
+manufacturer: Eaton
+model: Network-M2
+part_number: 744-A3983-02
+comments: Gigabit Network Card [Manual](https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/power-management-software-connectivity/eaton-gigabit-network-card/eaton-network-m2-user-guide.pdf)
+interfaces:
+  - name: RNDIS
+    type: other
+    mgmt_only: true
+    label: Settings
+    description: RNDIS (Ethernet over USB) connection with USB Micro-B connector
+  - name: Sensors
+    type: other
+    mgmt_only: false
+    label: AUX
+    description: USB-A connection for USB to RS485/Modbus connection to environmental
+      sensors
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true


### PR DESCRIPTION
Adds device modules for:

- UPS: 9PX 3000i RT 2U (9PX3000iRT2U)
- Network module: Network-M2 (744-A3983-02)
- Environment sensor: Environmental Monitoring Probe Gen 2 (EMPDT1H1C2)
- Battery extension module: 9PX Extended Battery Module, 72V (9PXEBM72RT2U)