### PR TITLE
Add Zyxel XGS1930 smart managed switch family

### DIFF
--- a/device-types/Zyxel/XGS1930-28.yaml
+++ b/device-types/Zyxel/XGS1930-28.yaml
@@ -1,0 +1,75 @@
+---
+manufacturer: Zyxel
+model: XGS1930-28
+slug: xgs1930-28
+part_number: XGS1930-28
+u_height: 1
+is_full_depth: false
+airflow: passive
+comments: '[XGS1930 series specs](https://www.zyxel.com/products_services/24-48-port-GbE-Smart-Managed-Switch-with-4-SFP--Uplink-XGS1930-Series/specifications)'
+power-ports:
+  - name: PS
+    type: iec-60320-c14
+    maximum_draw: 25
+    description: 100 to 240 V AC, 50/60 Hz
+interfaces:
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t
+  - name: '25'
+    type: 10gbase-x-sfpp
+  - name: '26'
+    type: 10gbase-x-sfpp
+  - name: '27'
+    type: 10gbase-x-sfpp
+  - name: '28'
+    type: 10gbase-x-sfpp
+  - name: mgmt
+    type: virtual
+    mgmt_only: true
+    description: Virtual Management Interface

--- a/device-types/Zyxel/XGS1930-28HP.yaml
+++ b/device-types/Zyxel/XGS1930-28HP.yaml
@@ -1,0 +1,75 @@
+---
+manufacturer: Zyxel
+model: XGS1930-28HP
+slug: xgs1930-28hp
+part_number: XGS1930-28HP
+u_height: 1
+is_full_depth: false
+airflow: left-to-right
+comments: '[XGS1930 series specs](https://www.zyxel.com/products_services/24-48-port-GbE-Smart-Managed-Switch-with-4-SFP--Uplink-XGS1930-Series/specifications)'
+power-ports:
+  - name: PS
+    type: iec-60320-c14
+    maximum_draw: 471
+    description: 100 to 240 V AC, 50/60 Hz
+interfaces:
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t
+  - name: '25'
+    type: 10gbase-x-sfpp
+  - name: '26'
+    type: 10gbase-x-sfpp
+  - name: '27'
+    type: 10gbase-x-sfpp
+  - name: '28'
+    type: 10gbase-x-sfpp
+  - name: mgmt
+    type: virtual
+    mgmt_only: true
+    description: Virtual Management Interface

--- a/device-types/Zyxel/XGS1930-52.yaml
+++ b/device-types/Zyxel/XGS1930-52.yaml
@@ -1,0 +1,123 @@
+---
+manufacturer: Zyxel
+model: XGS1930-52
+slug: xgs1930-52
+part_number: XGS1930-52
+u_height: 1
+is_full_depth: false
+airflow: left-to-right
+comments: '[XGS1930 series specs](https://www.zyxel.com/products_services/24-48-port-GbE-Smart-Managed-Switch-with-4-SFP--Uplink-XGS1930-Series/specifications)'
+power-ports:
+  - name: PS
+    type: iec-60320-c14
+    maximum_draw: 56
+    description: 100 to 240 V AC, 50/60 Hz
+interfaces:
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t
+  - name: '25'
+    type: 1000base-t
+  - name: '26'
+    type: 1000base-t
+  - name: '27'
+    type: 1000base-t
+  - name: '28'
+    type: 1000base-t
+  - name: '29'
+    type: 1000base-t
+  - name: '30'
+    type: 1000base-t
+  - name: '31'
+    type: 1000base-t
+  - name: '32'
+    type: 1000base-t
+  - name: '33'
+    type: 1000base-t
+  - name: '34'
+    type: 1000base-t
+  - name: '35'
+    type: 1000base-t
+  - name: '36'
+    type: 1000base-t
+  - name: '37'
+    type: 1000base-t
+  - name: '38'
+    type: 1000base-t
+  - name: '39'
+    type: 1000base-t
+  - name: '40'
+    type: 1000base-t
+  - name: '41'
+    type: 1000base-t
+  - name: '42'
+    type: 1000base-t
+  - name: '43'
+    type: 1000base-t
+  - name: '44'
+    type: 1000base-t
+  - name: '45'
+    type: 1000base-t
+  - name: '46'
+    type: 1000base-t
+  - name: '47'
+    type: 1000base-t
+  - name: '48'
+    type: 1000base-t
+  - name: '49'
+    type: 10gbase-x-sfpp
+  - name: '50'
+    type: 10gbase-x-sfpp
+  - name: '51'
+    type: 10gbase-x-sfpp
+  - name: '52'
+    type: 10gbase-x-sfpp
+  - name: mgmt
+    type: virtual
+    mgmt_only: true
+    description: Virtual Management Interface

--- a/device-types/Zyxel/XGS1930-52HP.yaml
+++ b/device-types/Zyxel/XGS1930-52HP.yaml
@@ -1,0 +1,123 @@
+---
+manufacturer: Zyxel
+model: XGS1930-52HP
+slug: xgs1930-52hp
+part_number: XGS1930-52HP
+u_height: 1
+is_full_depth: false
+airflow: left-to-right
+comments: '[XGS1930 series specs](https://www.zyxel.com/products_services/24-48-port-GbE-Smart-Managed-Switch-with-4-SFP--Uplink-XGS1930-Series/specifications)'
+power-ports:
+  - name: PS
+    type: iec-60320-c14
+    maximum_draw: 499
+    description: 100 to 240 V AC, 50/60 Hz
+interfaces:
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    type: 1000base-t
+  - name: '22'
+    type: 1000base-t
+  - name: '23'
+    type: 1000base-t
+  - name: '24'
+    type: 1000base-t
+  - name: '25'
+    type: 1000base-t
+  - name: '26'
+    type: 1000base-t
+  - name: '27'
+    type: 1000base-t
+  - name: '28'
+    type: 1000base-t
+  - name: '29'
+    type: 1000base-t
+  - name: '30'
+    type: 1000base-t
+  - name: '31'
+    type: 1000base-t
+  - name: '32'
+    type: 1000base-t
+  - name: '33'
+    type: 1000base-t
+  - name: '34'
+    type: 1000base-t
+  - name: '35'
+    type: 1000base-t
+  - name: '36'
+    type: 1000base-t
+  - name: '37'
+    type: 1000base-t
+  - name: '38'
+    type: 1000base-t
+  - name: '39'
+    type: 1000base-t
+  - name: '40'
+    type: 1000base-t
+  - name: '41'
+    type: 1000base-t
+  - name: '42'
+    type: 1000base-t
+  - name: '43'
+    type: 1000base-t
+  - name: '44'
+    type: 1000base-t
+  - name: '45'
+    type: 1000base-t
+  - name: '46'
+    type: 1000base-t
+  - name: '47'
+    type: 1000base-t
+  - name: '48'
+    type: 1000base-t
+  - name: '49'
+    type: 10gbase-x-sfpp
+  - name: '50'
+    type: 10gbase-x-sfpp
+  - name: '51'
+    type: 10gbase-x-sfpp
+  - name: '52'
+    type: 10gbase-x-sfpp
+  - name: mgmt
+    type: virtual
+    mgmt_only: true
+    description: Virtual Management Interface


### PR DESCRIPTION
add XGS1930-28, XGS1930-28HP, XGS1930-52, XGS1930-52HP switches

[XGS1930 series specs](https://www.zyxel.com/products_services/24-48-port-GbE-Smart-Managed-Switch-with-4-SFP--Uplink-XGS1930-Series/specifications)