### PR TITLE
Add/update Cisco Meraki MS250 switches and associated PSUs

### DIFF
--- a/device-types/Cisco/Meraki-MS250-24.yaml
+++ b/device-types/Cisco/Meraki-MS250-24.yaml
@@ -1,15 +1,15 @@
 ---
 manufacturer: Cisco
-model: MS250-48FP
-slug: ms250-48fp
-part_number: MS250-48FP-HW
+model: MS250-24
+slug: ms250-24
+part_number: MS250-24-HW
 u_height: 1
 is_full_depth: false
 comments: |
   [MS250 Overview and Specifications](https://documentation.meraki.com/MS/MS_Overview_and_Specifications/MS250_Overview_and_Specifications)
   [MS250 Datasheet](https://meraki.cisco.com/lib/pdf/meraki_datasheet_ms250.pdf)
 
-  Uses MA-PWR-1025WAC modular PSU.
+  Uses MA-PWR-250WAC modular PSU.
 interfaces:
   - name: Port 1
     type: 1000base-t
@@ -60,60 +60,12 @@ interfaces:
   - name: Port 24
     type: 1000base-t
   - name: Port 25
-    type: 1000base-t
+    type: 10gbase-x-sfpp
   - name: Port 26
-    type: 1000base-t
+    type: 10gbase-x-sfpp
   - name: Port 27
-    type: 1000base-t
+    type: 10gbase-x-sfpp
   - name: Port 28
-    type: 1000base-t
-  - name: Port 29
-    type: 1000base-t
-  - name: Port 30
-    type: 1000base-t
-  - name: Port 31
-    type: 1000base-t
-  - name: Port 32
-    type: 1000base-t
-  - name: Port 33
-    type: 1000base-t
-  - name: Port 34
-    type: 1000base-t
-  - name: Port 35
-    type: 1000base-t
-  - name: Port 36
-    type: 1000base-t
-  - name: Port 37
-    type: 1000base-t
-  - name: Port 38
-    type: 1000base-t
-  - name: Port 39
-    type: 1000base-t
-  - name: Port 40
-    type: 1000base-t
-  - name: Port 41
-    type: 1000base-t
-  - name: Port 42
-    type: 1000base-t
-  - name: Port 43
-    type: 1000base-t
-  - name: Port 44
-    type: 1000base-t
-  - name: Port 45
-    type: 1000base-t
-  - name: Port 46
-    type: 1000base-t
-  - name: Port 47
-    type: 1000base-t
-  - name: Port 48
-    type: 1000base-t
-  - name: Port 49
-    type: 10gbase-x-sfpp
-  - name: Port 50
-    type: 10gbase-x-sfpp
-  - name: Port 51
-    type: 10gbase-x-sfpp
-  - name: Port 52
     type: 10gbase-x-sfpp
   - name: Dedicated Stack Port 1
     type: 40gbase-x-qsfpp

--- a/device-types/Cisco/Meraki-MS250-24P.yaml
+++ b/device-types/Cisco/Meraki-MS250-24P.yaml
@@ -1,15 +1,15 @@
 ---
 manufacturer: Cisco
-model: MS250-48FP
-slug: ms250-48fp
-part_number: MS250-48FP-HW
+model: MS250-24P
+slug: ms250-24p
+part_number: MS250-24P-HW
 u_height: 1
 is_full_depth: false
 comments: |
   [MS250 Overview and Specifications](https://documentation.meraki.com/MS/MS_Overview_and_Specifications/MS250_Overview_and_Specifications)
   [MS250 Datasheet](https://meraki.cisco.com/lib/pdf/meraki_datasheet_ms250.pdf)
 
-  Uses MA-PWR-1025WAC modular PSU.
+  Uses MA-PWR-640WAC modular PSU.
 interfaces:
   - name: Port 1
     type: 1000base-t
@@ -60,60 +60,12 @@ interfaces:
   - name: Port 24
     type: 1000base-t
   - name: Port 25
-    type: 1000base-t
+    type: 10gbase-x-sfpp
   - name: Port 26
-    type: 1000base-t
+    type: 10gbase-x-sfpp
   - name: Port 27
-    type: 1000base-t
+    type: 10gbase-x-sfpp
   - name: Port 28
-    type: 1000base-t
-  - name: Port 29
-    type: 1000base-t
-  - name: Port 30
-    type: 1000base-t
-  - name: Port 31
-    type: 1000base-t
-  - name: Port 32
-    type: 1000base-t
-  - name: Port 33
-    type: 1000base-t
-  - name: Port 34
-    type: 1000base-t
-  - name: Port 35
-    type: 1000base-t
-  - name: Port 36
-    type: 1000base-t
-  - name: Port 37
-    type: 1000base-t
-  - name: Port 38
-    type: 1000base-t
-  - name: Port 39
-    type: 1000base-t
-  - name: Port 40
-    type: 1000base-t
-  - name: Port 41
-    type: 1000base-t
-  - name: Port 42
-    type: 1000base-t
-  - name: Port 43
-    type: 1000base-t
-  - name: Port 44
-    type: 1000base-t
-  - name: Port 45
-    type: 1000base-t
-  - name: Port 46
-    type: 1000base-t
-  - name: Port 47
-    type: 1000base-t
-  - name: Port 48
-    type: 1000base-t
-  - name: Port 49
-    type: 10gbase-x-sfpp
-  - name: Port 50
-    type: 10gbase-x-sfpp
-  - name: Port 51
-    type: 10gbase-x-sfpp
-  - name: Port 52
     type: 10gbase-x-sfpp
   - name: Dedicated Stack Port 1
     type: 40gbase-x-qsfpp

--- a/device-types/Cisco/Meraki-MS250-48.yaml
+++ b/device-types/Cisco/Meraki-MS250-48.yaml
@@ -1,15 +1,15 @@
 ---
 manufacturer: Cisco
-model: MS250-48FP
-slug: ms250-48fp
-part_number: MS250-48FP-HW
+model: MS250-48
+slug: ms250-48
+part_number: MS250-48-HW
 u_height: 1
 is_full_depth: false
 comments: |
   [MS250 Overview and Specifications](https://documentation.meraki.com/MS/MS_Overview_and_Specifications/MS250_Overview_and_Specifications)
   [MS250 Datasheet](https://meraki.cisco.com/lib/pdf/meraki_datasheet_ms250.pdf)
 
-  Uses MA-PWR-1025WAC modular PSU.
+  Uses MA-PWR-250WAC modular PSU.
 interfaces:
   - name: Port 1
     type: 1000base-t

--- a/device-types/Cisco/Meraki-MS250-48LP.yaml
+++ b/device-types/Cisco/Meraki-MS250-48LP.yaml
@@ -1,15 +1,15 @@
 ---
 manufacturer: Cisco
-model: MS250-48FP
-slug: ms250-48fp
-part_number: MS250-48FP-HW
+model: MS250-48LP
+slug: ms250-48lp
+part_number: MS250-48LP-HW
 u_height: 1
 is_full_depth: false
 comments: |
   [MS250 Overview and Specifications](https://documentation.meraki.com/MS/MS_Overview_and_Specifications/MS250_Overview_and_Specifications)
   [MS250 Datasheet](https://meraki.cisco.com/lib/pdf/meraki_datasheet_ms250.pdf)
 
-  Uses MA-PWR-1025WAC modular PSU.
+  Uses MA-PWR-640WAC modular PSU.
 interfaces:
   - name: Port 1
     type: 1000base-t

--- a/module-types/Cisco/Meraki-MA-PWR-1025WAC.yaml
+++ b/module-types/Cisco/Meraki-MA-PWR-1025WAC.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Cisco
+model: MA-PWR-1025WAC
+part_number: MA-PWR-1025WAC
+comments: '[1025W power supply unit product information](https://meraki.cisco.com/product/switches/switches-accessories/switches-accessories-power/1025-watt-power-supply/)'
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c14
+    maximum_draw: 1025

--- a/module-types/Cisco/Meraki-MA-PWR-250WAC.yaml
+++ b/module-types/Cisco/Meraki-MA-PWR-250WAC.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Cisco
+model: MA-PWR-250WAC
+part_number: MA-PWR-250WAC
+comments: '[250W power supply unit product information](https://meraki.cisco.com/product/security-sd-wan/appliances-accessories/ma-pwr-250wac/)'
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c14
+    maximum_draw: 250

--- a/module-types/Cisco/Meraki-MA-PWR-640WAC.yaml
+++ b/module-types/Cisco/Meraki-MA-PWR-640WAC.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Cisco
+model: MA-PWR-640WAC
+part_number: MA-PWR-640WAC
+comments: '[640W power supply unit product information](https://meraki.cisco.com/product/switches/switches-accessories/switches-accessories-power/640-watt-power-supply/)'
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c16
+    maximum_draw: 640


### PR DESCRIPTION
I'm not entirely sure about the PSU config, but it seems that this is also being done this way for some other devices already.
One PSU is bundled with the switch and a second one can be installed for redundancy.
There's no requirement to always have a specific one, as long as at least one is present.
Both of them are modular.