### PR TITLE
Cisco Stackport Name Changes

### DIFF
--- a/device-types/Cisco/C9200-24P.yaml
+++ b/device-types/Cisco/C9200-24P.yaml
@@ -91,10 +91,10 @@ interfaces:
   - name: GigabitEthernet1/0/24
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200-24T.yaml
+++ b/device-types/Cisco/C9200-24T.yaml
@@ -91,10 +91,10 @@ interfaces:
   - name: GigabitEthernet1/0/24
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200-48P.yaml
+++ b/device-types/Cisco/C9200-48P.yaml
@@ -163,10 +163,10 @@ interfaces:
   - name: GigabitEthernet1/0/48
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200-48T.yaml
+++ b/device-types/Cisco/C9200-48T.yaml
@@ -163,10 +163,10 @@ interfaces:
   - name: GigabitEthernet1/0/48
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-24P-4G-E.yaml
+++ b/device-types/Cisco/C9200L-24P-4G-E.yaml
@@ -103,10 +103,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-x-sfp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0/0

--- a/device-types/Cisco/C9200L-24P-4G.yaml
+++ b/device-types/Cisco/C9200L-24P-4G.yaml
@@ -103,10 +103,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-24P-4X.yaml
+++ b/device-types/Cisco/C9200L-24P-4X.yaml
@@ -103,10 +103,10 @@ interfaces:
   - name: TenGigabitEthernet1/1/4
     type: 10gbase-x-sfpp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-24T-4G.yaml
+++ b/device-types/Cisco/C9200L-24T-4G.yaml
@@ -103,10 +103,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-24T-4X.yaml
+++ b/device-types/Cisco/C9200L-24T-4X.yaml
@@ -103,10 +103,10 @@ interfaces:
   - name: TenGigabitEthernet1/1/4
     type: 10gbase-x-sfpp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-48P-4G-E.yaml
+++ b/device-types/Cisco/C9200L-48P-4G-E.yaml
@@ -175,10 +175,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-x-sfp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0/0

--- a/device-types/Cisco/C9200L-48P-4G.yaml
+++ b/device-types/Cisco/C9200L-48P-4G.yaml
@@ -175,10 +175,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-48P-4X.yaml
+++ b/device-types/Cisco/C9200L-48P-4X.yaml
@@ -175,10 +175,10 @@ interfaces:
   - name: TenGigabitEthernet1/1/4
     type: 10gbase-x-sfpp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-48PL-4G.yaml
+++ b/device-types/Cisco/C9200L-48PL-4G.yaml
@@ -175,10 +175,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-48T-4G.yaml
+++ b/device-types/Cisco/C9200L-48T-4G.yaml
@@ -175,10 +175,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-t
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9200L-48T-4X.yaml
+++ b/device-types/Cisco/C9200L-48T-4X.yaml
@@ -175,10 +175,10 @@ interfaces:
   - name: TenGigabitEthernet1/1/4
     type: 10gbase-x-sfpp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0

--- a/device-types/Cisco/C9300L-24P-4G.yaml
+++ b/device-types/Cisco/C9300L-24P-4G.yaml
@@ -78,10 +78,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-x-sfp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0/0

--- a/device-types/Cisco/C9300L-48P-4G.yaml
+++ b/device-types/Cisco/C9300L-48P-4G.yaml
@@ -126,10 +126,10 @@ interfaces:
   - name: GigabitEthernet1/1/4
     type: 1000base-x-sfp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0/0

--- a/device-types/Cisco/C9300L-48P-4X.yaml
+++ b/device-types/Cisco/C9300L-48P-4X.yaml
@@ -126,10 +126,10 @@ interfaces:
   - name: TenGigabitEthernet1/1/4
     type: 10gbase-x-sfpp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0/0

--- a/device-types/Cisco/C9300L-48UXG-4X.yaml
+++ b/device-types/Cisco/C9300L-48UXG-4X.yaml
@@ -126,10 +126,10 @@ interfaces:
   - name: TenGigabitEthernet1/1/4
     type: 10gbase-x-sfpp
     mgmt_only: false
-  - name: STACK0
+  - name: StackPort1/1
     type: cisco-stackwise
     mgmt_only: false
-  - name: STACK1
+  - name: StackPort1/2
     type: cisco-stackwise
     mgmt_only: false
   - name: GigabitEthernet0/0

--- a/device-types/Cisco/WS-C3750E-24TD.yaml
+++ b/device-types/Cisco/WS-C3750E-24TD.yaml
@@ -58,10 +58,10 @@ interfaces:
     type: 10gbase-x-x2
   - name: TenGigabitEthernet1/0/2
     type: 10gbase-x-x2
-  - name: StackPort1
+  - name: StackPort1/1
     type: cisco-stackwise-plus
     mgmt_only: false
-  - name: StackPort2
+  - name: StackPort1/2
     type: cisco-stackwise-plus
     mgmt_only: false
 console-ports:


### PR DESCRIPTION
Fix all instances of STACK# to Stackport1/(#+1)