### PR TITLE
Update PowerEdge_R640.yaml

### DIFF
--- a/device-types/Dell/PowerEdge_R640.yaml
+++ b/device-types/Dell/PowerEdge_R640.yaml
@@ -31,7 +31,10 @@ interfaces:
   - name: iDRAC9
     type: 1000base-t
     mgmt_only: true
-device-bays:
+module-bays:
   - name: PCIe-Gen3 1
+    position: PCIE1
   - name: PCIe-Gen3 2
+    position: PCIE2
   - name: PCIe-Gen3 3
+    position: PCIE3

--- a/device-types/Dell/PowerEdge_R640.yaml
+++ b/device-types/Dell/PowerEdge_R640.yaml
@@ -4,6 +4,7 @@ model: PowerEdge R640
 slug: dell_poweredge_r640
 u_height: 1
 is_full_depth: true
+subdevice_role: parent
 console-ports:
   - name: Serial
     type: de-9


### PR DESCRIPTION
Fix error with import:
[{"__all__":["Subdevice role of device type (PowerEdge R640) must be set to \"parent\" to allow device bays."]},{"__all__":["Subdevice role of device type (PowerEdge R640) must be set to \"parent\" to allow device bays."]},{"__all__":["Subdevice role of device type (PowerEdge R640) must be set to \"parent\" to allow device bays."]}] 