### PR TITLE
Add ubnt rps ac 100w

### DIFF
--- a/module-types/Ubiquiti/RPS-AC-100W.yaml
+++ b/module-types/Ubiquiti/RPS-AC-100W.yaml
@@ -1,0 +1,8 @@
+---
+manufacturer: Ubiquiti
+model: RPS-AC-100W
+part_number: RPS-AC-100W
+power-ports:
+  - name: {module}
+    type: iec-60320-c14
+    maximum_draw: 100

--- a/module-types/Ubiquiti/RPS-AC-100W.yaml
+++ b/module-types/Ubiquiti/RPS-AC-100W.yaml
@@ -5,6 +5,6 @@ part_number: RPS-AC-100W
 comments: |
   [Ubiquiti RPS-AC-100W](https://dl.ui.com/ds/uf_gpon) Page 5
 power-ports:
-  - name: {module}
+  - name: PSU {module}
     type: iec-60320-c14
     maximum_draw: 100

--- a/module-types/Ubiquiti/RPS-AC-100W.yaml
+++ b/module-types/Ubiquiti/RPS-AC-100W.yaml
@@ -2,6 +2,8 @@
 manufacturer: Ubiquiti
 model: RPS-AC-100W
 part_number: RPS-AC-100W
+comments: |
+  [Ubiquiti RPS-AC-100W](https://dl.ui.com/ds/uf_gpon) Page 5
 power-ports:
   - name: {module}
     type: iec-60320-c14


### PR DESCRIPTION
AC Power supply used in Ubnt OLTs and routers.