### PR TITLE
Add PoE (mode/type) to component definition

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -394,6 +394,26 @@
                         "other"
                     ]
                 },
+                "poe_mode": {
+                    "type": "string",
+                    "enum": [
+                        "pd",
+                        "pse"
+                    ]
+                },
+                "poe_type": {
+                    "type": "string",
+                    "enum": [
+                        "type1-ieee802.3af",
+                        "type2-ieee802.3at",
+                        "type3-ieee802.3bt",
+                        "type4-ieee802.3bt",
+                        "passive-24v-2pair",
+                        "passive-24v-4pair",
+                        "passive-48v-2pair",
+                        "passive-48v-4pair"
+                    ]
+                },
                 "mgmt_only": {
                     "type": "boolean"
                 }


### PR DESCRIPTION
Adding Power-over-Ethernet attributes to component definition.  
This enables contributors to enrich devices and modules with information about PoE-capable ports.