### PR TITLE
Dell R740xd is 2U, not 1U

### DIFF
--- a/device-types/Dell/PowerEdge_R740xd.yaml
+++ b/device-types/Dell/PowerEdge_R740xd.yaml
@@ -2,7 +2,7 @@
 manufacturer: Dell
 model: PowerEdge R740xd
 slug: dell_poweredge_r740xd
-u_height: 1
+u_height: 2
 is_full_depth: true
 comments: |
   [Dell R740xd Data Sheet](https://www.dell.com/learn/yu/en/yupad1/shared-content~data-sheets~en/documents~poweredge-r740xd-spec-sheet.pdf)


### PR DESCRIPTION
Dell R740xd is 2U, not 1U. Couldn't find any reference to a 1U 740xd on Dell's website, and I haven't run across a 1U 740xd in the wild.

References:
- https://i.dell.com/sites/csdocuments/Shared-Content_data-Sheets_Documents/en/poweredge-r740xd-spec-sheet.pdf
- https://www.dell.com/en-us/shop/cty/pdp/spd/poweredge-r740xd/pe_r740xd_tm_vi_vp_sb