### PR TITLE
Dell R940 is 3U, not 4U

### DIFF
--- a/device-types/Dell/PowerEdge_R940.yaml
+++ b/device-types/Dell/PowerEdge_R940.yaml
@@ -2,8 +2,10 @@
 manufacturer: Dell
 model: PowerEdge R940
 slug: dell_poweredge_r940
-u_height: 4
+u_height: 3
 is_full_depth: true
+comments: |
+  [Dell R940 Data Sheet](https://i.dell.com/sites/doccontent/shared-content/data-sheets/en/Documents/poweredge-r940-spec-sheet.pdf)
 console-ports:
   - name: Serial
     type: de-9


### PR DESCRIPTION
Dell R940 is 3U, not 4U. Can't find any examples of a 4U PowerEdge R940.

References:
- https://i.dell.com/sites/doccontent/shared-content/data-sheets/en/Documents/poweredge-r940-spec-sheet.pdf
- https://www.dell.com/en-us/shop/dell-poweredge-servers/poweredge-r940-rack-server/spd/poweredge-r940/pe_r940_12229_vi_vp