### PR TITLE
Cisco 2821 and 2800 modules

### DIFF
--- a/device-types/Cisco/ISR2821.yaml
+++ b/device-types/Cisco/ISR2821.yaml
@@ -1,0 +1,64 @@
+---
+manufacturer: Cisco
+model: ISR2821
+slug: isr2821
+part_number: CISCO2821
+u_height: 2
+is_full_depth: false
+comments: 'Datasheet: [Link](https://www.cisco.com/c/dam/global/de_at/assets/unified_partners/smb/vertriebliche-positionierung/routing/downloads/isr_2800_datenblatt_e.pdf)'
+console-ports:
+  - name: aux 0
+    type: rj-45
+    label: AUX
+  - name: con 0
+    type: rj-45
+    label: CONSOLE
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: false
+    label: GE 0/0
+  - name: GigabitEthernet0/1
+    type: 1000base-t
+    mgmt_only: false
+    label: GE 0/1
+module-bays:
+  - name: AIM slot 0
+    label: AIM 0
+    description: Advanced Integration Module Slot
+  - name: AIM slot 1
+    label: AIM 1
+    description: Advanced Integration Module Slot
+  - name: Slot 0 SubSlot 4
+    label: PVDM0
+    description: Packet Voice Digital Signal Processor Module Slot
+  - name: Slot 0 SubSlot 5
+    label: PVDM1
+    description: Packet Voice Digital Signal Processor Module Slot
+  - name: Slot 0/0
+    label: HWIC0
+    position: 0/0
+    description: High-Speed WAN Interface Card Slot
+  - name: Slot 0/1
+    label: HWIC1
+    position: 0/1
+    description: High-Speed WAN Interface Card Slot
+  - name: Slot 0/2
+    label: HWIC2
+    position: 0/2
+    description: High-Speed WAN Interface Card Slot
+  - name: Slot 0/3
+    label: HWIC3
+    position: 0/3
+    description: High-Speed WAN Interface Card Slot
+  - name: Slot 1/0
+    label: '1'
+    position: 1/0
+    description: Single-wide / Extended single-wide Network Module Slot
+  - name: Slot 2/0
+    label: '2'
+    position: 2/0
+    description: Network Module Slot

--- a/module-types/Cisco/AIM-VPN_EPII-PLUS.yaml
+++ b/module-types/Cisco/AIM-VPN_EPII-PLUS.yaml
@@ -1,0 +1,4 @@
+---
+manufacturer: Cisco
+model: AIM-VPN/EPII-PLUS
+comments: Enhanced-performance DES/3DES/AES VPN encryption/compression AIM

--- a/module-types/Cisco/PVDM2-64.yaml
+++ b/module-types/Cisco/PVDM2-64.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: Cisco
+model: PVDM2-64
+part_number: PVDM2-64
+comments: PVDMII DSP SIMM with four DSPs

--- a/module-types/Cisco/VIC2-4FXO.yaml
+++ b/module-types/Cisco/VIC2-4FXO.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Cisco
+model: VIC2-4FXO
+part_number: VIC2-4FXO
+comments: 'Description: 2nd generation four port FXO voice interface daughtercard'
+interfaces:
+  - name: voice-port {module}/0
+    type: other
+    mgmt_only: false
+    label: '0'
+  - name: voice-port {module}/1
+    type: other
+    mgmt_only: false
+    label: '1'
+  - name: voice-port {module}/2
+    type: other
+    mgmt_only: false
+    label: '2'
+  - name: voice-port {module}/3
+    type: other
+    mgmt_only: false
+    label: '3'


### PR DESCRIPTION
- Add Cisco ISR 2821 
- Add Cisco VIC2-4FXO card for 2800 family
- Add Cisco AIM-VPN/EPII-Plus module for 2800 family
- Add Cisco PVDM2-64 DSP module for 2800 family