### PR TITLE
Change Cisco WS-C2960CG-8TL to WS-C2960CG-8TC-L

### DIFF
--- a/device-types/Cisco/WS-C2960CG-8TC-L.yaml
+++ b/device-types/Cisco/WS-C2960CG-8TC-L.yaml
@@ -1,12 +1,12 @@
 ---
 manufacturer: Cisco
-model: Catalyst 2960CG-8TL
-part_number: WS-C2960CG-8TL
-slug: ws-c2960cg-8tl
+model: Catalyst 2960CG-8TC-L
+part_number: WS-C2960CG-8TC-L
+slug: ws-c2960cg-8tc-l
 u_height: 1
 is_full_depth: false
 console-ports:
-  - name: CON0
+  - name: con0
     type: rj-45
 power-ports:
   - name: PSU0


### PR DESCRIPTION
There is no record of the `WS-C2960CG-8TL` existing, it is probable that model is the `WS-C2960CG-8TC-L`

Ref: 
- https://www.cisco.com/c/en/us/support/switches/catalyst-2960-c-series-switches/series.html
- https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst2960c_3560c/hardware/installation/guide/2960c_3560c_hig/higoverview.html