### PR TITLE
Add PC Engines manufacturer with APU models

### DIFF
--- a/device-types/PC Engines/APU.yaml
+++ b/device-types/PC Engines/APU.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: PC Engines
+model: APU
+slug: apu1
+part_number: apu1
+comments: |
+  Dimensions: 168 x 157 x 30 mm (6.61 x 6.18 x 1.18")
+interfaces:
+  - name: re0
+    type: 1000base-t
+  - name: re1
+    type: 1000base-t
+  - name: re2
+    type: 1000base-t
+console-ports:
+  - name: ttyS0
+    type: de-9
+
+power-ports:
+  - name: Input
+    type: dc-terminal
+    maximum_draw: 12
+    allocated_draw: 6

--- a/device-types/PC Engines/APU2.yaml
+++ b/device-types/PC Engines/APU2.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: PC Engines
+model: APU2
+slug: apu2
+part_number: apu2
+comments: |
+  Dimensions: 168 x 157 x 30 mm (6.61 x 6.18 x 1.18")
+interfaces:
+  - name: igb0
+    type: 1000base-t
+  - name: igb1
+    type: 1000base-t
+  - name: igb2
+    type: 1000base-t
+console-ports:
+  - name: ttyS0
+    type: de-9
+
+power-ports:
+  - name: Input
+    type: dc-terminal
+    maximum_draw: 12
+    allocated_draw: 6

--- a/device-types/PC Engines/APU4.yaml
+++ b/device-types/PC Engines/APU4.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: PC Engines
+model: APU4
+slug: apu4
+part_number: apu4
+comments: |
+  Dimensions: 168 x 157 x 30 mm (6.61 x 6.18 x 1.18")
+interfaces:
+  - name: igb0
+    type: 1000base-t
+  - name: igb1
+    type: 1000base-t
+  - name: igb2
+    type: 1000base-t
+  - name: igb3
+    type: 1000base-t
+console-ports:
+  - name: ttyS0
+    type: de-9
+
+power-ports:
+  - name: Input
+    type: dc-terminal
+    maximum_draw: 12
+    allocated_draw: 6


### PR DESCRIPTION
Add manufacturer: PC Engines.
Add models:
- APU
- APU2
- APU4