### PR TITLE
Fix ASR1002-HX interfaces numbering for TenGigabitEthernet interfaces from TenGigabitEthernet0/0/X to TenGigabitEthernet0/1/X

### DIFF
--- a/device-types/Cisco/ASR1002-HX.yaml
+++ b/device-types/Cisco/ASR1002-HX.yaml
@@ -30,21 +30,21 @@ interfaces:
     type: 1000base-x-sfp
   - name: GigabitEthernet0/0/7
     type: 1000base-x-sfp
-  - name: TenGigabitEthernet0/0/0
+  - name: TenGigabitEthernet0/1/0
     type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet0/0/1
+  - name: TenGigabitEthernet0/1/1
     type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet0/0/2
+  - name: TenGigabitEthernet0/1/2
     type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet0/0/3
+  - name: TenGigabitEthernet0/1/3
     type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet0/0/4
+  - name: TenGigabitEthernet0/1/4
     type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet0/0/5
+  - name: TenGigabitEthernet0/1/5
     type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet0/0/6
+  - name: TenGigabitEthernet0/1/6
     type: 10gbase-x-sfpp
-  - name: TenGigabitEthernet0/0/7
+  - name: TenGigabitEthernet0/1/7
     type: 10gbase-x-sfpp
   - name: GigabitEthernet0
     type: 1000base-t


### PR DESCRIPTION
The ASR1002-HX TenGigabitEthernet interfaces are numbered TenGigabitEthernet0/1/X but the current devicetype is using TenGigabitEthernet0/0/X.

This PR fixes those interfaces to match what is in the Cisco Hardware Installation Guide and in the box.

ASR1002-HX CLI output:
```
ASR1002-HX# show int descr
Interface                      Status         Protocol Description
Gi0/0/0                        admin down     down     
Gi0/0/1                        admin down     down     
Gi0/0/2                        admin down     down     
Gi0/0/3                        admin down     down     
Gi0/0/4                        admin down     down     
Gi0/0/5                        admin down     down     
Gi0/0/6                        admin down     down     
Gi0/0/7                        admin down     down     
Te0/1/0                        admin down     down     
Te0/1/1                        admin down     down     
Te0/1/2                        admin down     down     
Te0/1/3                        admin down     down     
Te0/1/4                        admin down     down     
Te0/1/5                        admin down     down     
Te0/1/6                        admin down     down     
Te0/1/7                        admin down     down     
Gi0                            admin down     down     
```

Cisco Hardware Installation Guide: https://www.cisco.com/c/en/us/td/docs/routers/asr1000/install/guide/1001HX_1002HX/b_ASR1001HX-1002HX_HIG/b_ASR1001HX-1002HX_HIG_chapter_01.html#concept_5FC6664E3BFA4DE784958CAFE7FB4EFF