### PR TITLE
feat: add AVM Fritzbox 7530

### DIFF
--- a/device-types/AVM/7530.yaml
+++ b/device-types/AVM/7530.yaml
@@ -1,0 +1,41 @@
+---
+manufacturer: AVM
+model: FRITZ!Box 7530
+slug: fritzbox-7530
+part_number: '20002839'
+u_height: 0
+is_full_depth: false
+airflow: passive
+comments: '[AVM FRITZ!Box 7530 Datasheet](https://avm.de/produkte/fritzbox/fritzbox-7530/technische-daten/)'
+power-ports:
+  - name: Power
+    type: dc-terminal
+    maximum_draw: 30
+interfaces:
+  - name: DSL
+    label: DSL
+    type: xdsl
+    mgmt_only: false
+  - name: FON1
+    label: FON 1
+    type: other
+    mgmt_only: false
+  - name: LAN1
+    label: LAN 1 / WAN
+    type: 1000base-t
+    mgmt_only: false
+  - name: LAN2
+    label: LAN 2
+    type: 1000base-t
+    mgmt_only: false
+  - name: LAN3
+    label: LAN 3
+    type: 1000base-t
+    mgmt_only: false
+  - name: LAN4
+    label: LAN 4
+    type: 1000base-t
+    mgmt_only: false
+  - name: WiFi
+    type: ieee802.11ac
+    mgmt_only: false


### PR DESCRIPTION
Adds the [AVM Fritzbox 7530](https://avm.de/produkte/fritzbox/fritzbox-7530/technische-daten/), an extremely common home router in Germany. The sister product, 7590, is already in the device type library.