### PR TITLE
Allied Telesis MCR12 and Modules

### DIFF
--- a/device-types/Allied Telesis/MCR12.yaml
+++ b/device-types/Allied Telesis/MCR12.yaml
@@ -1,0 +1,38 @@
+---
+manufacturer: Allied Telesis
+model: MCR12
+slug: at-mcr12
+part_number: MCR12
+u_height: 3
+is_full_depth: false
+module-bays:
+  - name: Power Supply A
+    position: A
+    label: PSU 1
+  - name: Power Supply B
+    position: B
+    label: PSU 2
+  - name: Slot 1
+    position: '1'
+  - name: Slot 2
+    position: '2'
+  - name: Slot 3
+    position: '3'
+  - name: Slot 4
+    position: '4'
+  - name: Slot 5
+    position: '5'
+  - name: Slot 6
+    position: '6'
+  - name: Slot 7
+    position: '7'
+  - name: Slot 8
+    position: '8'
+  - name: Slot 9
+    position: '9'
+  - name: Slot 10
+    position: '10'
+  - name: Slot 11
+    position: '11'
+  - name: Slot 12
+    position: '12'

--- a/module-types/Allied Telesis/FS201.yaml
+++ b/module-types/Allied Telesis/FS201.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Allied Telesis
-model: FS202
-part_number: AT-FS202
-comments: Fast Ethernet to Fiber Media and Rate Converter
+model: FS201
+part_number: AT-FS201
+comments: 10/100TX to 100FX (ST) media and rate converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other

--- a/module-types/Allied Telesis/FS202.yaml
+++ b/module-types/Allied Telesis/FS202.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Allied Telesis
+model: FS202
+part_number: AT-FS202
+interfaces:
+  - name: Port 1 ({module} - 100Base-FX)
+    type: other
+  - name: Port 2 ({module})
+    type: 100base-tx

--- a/module-types/Allied Telesis/FS232-1.yaml
+++ b/module-types/Allied Telesis/FS232-1.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Allied Telesis
-model: FS202
-part_number: AT-FS202
+model: FS232/1
+part_number: AT-FS232/1
 comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)

--- a/module-types/Allied Telesis/FS232-2.yaml
+++ b/module-types/Allied Telesis/FS232-2.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Allied Telesis
-model: FS202
-part_number: AT-FS202
+model: FS232/2
+part_number: AT-FS232/2
 comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)

--- a/module-types/Allied Telesis/FS232.yaml
+++ b/module-types/Allied Telesis/FS232.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Allied Telesis
-model: FS202
-part_number: AT-FS202
+model: FS232
+part_number: AT-FS232
 comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)

--- a/module-types/Allied Telesis/FS238A-1.yaml
+++ b/module-types/Allied Telesis/FS238A-1.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Allied Telesis
-model: FS202
-part_number: AT-FS202
-comments: Fast Ethernet to Fiber Media and Rate Converter
+model: FS238A/1
+part_number: AT-FS238A/1
+comments: 10/100TX to 100LX (SC) BiDi media and rate converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other

--- a/module-types/Allied Telesis/FS238B-1.yaml
+++ b/module-types/Allied Telesis/FS238B-1.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Allied Telesis
-model: FS202
-part_number: AT-FS202
-comments: Fast Ethernet to Fiber Media and Rate Converter
+model: FS238B/1
+part_number: AT-FS238B/1
+comments: Fast Ethernet to Fiber BiDi Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other

--- a/module-types/Allied Telesis/PWR4.yaml
+++ b/module-types/Allied Telesis/PWR4.yaml
@@ -1,0 +1,7 @@
+---
+manufacturer: Allied Telesis
+model: PWR4
+part_number: AT-PWR4
+power-ports:
+  - name: PSU {module}
+    type: iec-60320-c14


### PR DESCRIPTION
Added the following Allied Telesis device/modules:

- MCR12
- FS201
- FS202
- FS232/1
- FS232/2
- FS232
- FS238A/1
- FS238B/1
- PWR4 (power module for the MCR12)