### PR TITLE
Allied Telesis Power Module Updates

### DIFF
--- a/module-types/Allied Telesis/PWR1200.yaml
+++ b/module-types/Allied Telesis/PWR1200.yaml
@@ -2,6 +2,7 @@
 manufacturer: Allied Telesis
 model: PWR1200
 part_number: AT-PWR1200
+comments: 1200W PoE+ power supply
 power-ports:
   - name: PSU {module}
     type: iec-60320-c14

--- a/module-types/Allied Telesis/PWR250.yaml
+++ b/module-types/Allied Telesis/PWR250.yaml
@@ -2,6 +2,7 @@
 manufacturer: Allied Telesis
 model: PWR250
 part_number: AT-PWR250
+comments: 250W AC system power supply
 power-ports:
   - name: PSU {module}
     type: dc-terminal

--- a/module-types/Allied Telesis/PWR4.yaml
+++ b/module-types/Allied Telesis/PWR4.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Allied Telesis
-model: PWR4
+model: CentreCOM PWR4
 part_number: AT-PWR4
 power-ports:
   - name: PSU {module}

--- a/module-types/Allied Telesis/PWR4.yaml
+++ b/module-types/Allied Telesis/PWR4.yaml
@@ -2,6 +2,7 @@
 manufacturer: Allied Telesis
 model: CentreCOM PWR4
 part_number: AT-PWR4
+comments: Hot Swappable, AC Redundant power supply module for the MCR12, unmanaged 12 slot, media converter power distribution chassis
 power-ports:
   - name: PSU {module}
     type: iec-60320-c14

--- a/module-types/Allied Telesis/PWR4.yaml
+++ b/module-types/Allied Telesis/PWR4.yaml
@@ -6,3 +6,4 @@ comments: Hot Swappable, AC Redundant power supply module for the MCR12, unmanag
 power-ports:
   - name: PSU {module}
     type: iec-60320-c14
+    maximum_draw: 80

--- a/module-types/Allied Telesis/PWR600-80.yaml
+++ b/module-types/Allied Telesis/PWR600-80.yaml
@@ -1,7 +1,8 @@
 ---
 manufacturer: Allied Telesis
-model: PWR600
-part_number: AT-PWR600
+model: PWR600-80
+part_number: AT-PWR600-80
+comments: 600W DC system power supply.
 power-ports:
   - name: PSU {module}
     type: dc-terminal

--- a/module-types/Allied Telesis/PWR600.yaml
+++ b/module-types/Allied Telesis/PWR600.yaml
@@ -2,6 +2,7 @@
 manufacturer: Allied Telesis
 model: PWR600
 part_number: AT-PWR600
+comments: 600W AC system power supply.
 power-ports:
   - name: PSU {module}
     type: iec-60320-c14

--- a/module-types/Allied Telesis/PWR800.yaml
+++ b/module-types/Allied Telesis/PWR800.yaml
@@ -2,6 +2,7 @@
 manufacturer: Allied Telesis
 model: PWR800
 part_number: AT-PWR800
+comments: 800W AC system and PoE+ power supply
 power-ports:
   - name: PSU {module}
     type: iec-60320-c14


### PR DESCRIPTION
Updated the power modules to include their use/details from Allied Telesis. Updated PWR4 to more closely match the name printed on the unit, also added the max draw. 