### PR TITLE
Update Allied Telesis modules to include their slot number 

### DIFF
--- a/module-types/Allied Telesis/FS201.yaml
+++ b/module-types/Allied Telesis/FS201.yaml
@@ -4,7 +4,7 @@ model: FS201
 part_number: AT-FS201
 comments: 10/100TX to 100FX (ST) media and rate converter
 interfaces:
-  - name: Port 1 ({module} - 100Base-FX)
+  - name: Port 1 (Slot {module} - 100Base-FX)
     type: other
   - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS201.yaml
+++ b/module-types/Allied Telesis/FS201.yaml
@@ -6,5 +6,5 @@ comments: 10/100TX to 100FX (ST) media and rate converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other
-  - name: Port 2 ({module})
+  - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS202.yaml
+++ b/module-types/Allied Telesis/FS202.yaml
@@ -6,5 +6,5 @@ comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other
-  - name: Port 2 ({module})
+  - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS202.yaml
+++ b/module-types/Allied Telesis/FS202.yaml
@@ -4,7 +4,7 @@ model: FS202
 part_number: AT-FS202
 comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
-  - name: Port 1 ({module} - 100Base-FX)
+  - name: Port 1 (Slot {module} - 100Base-FX)
     type: other
   - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS232-1.yaml
+++ b/module-types/Allied Telesis/FS232-1.yaml
@@ -6,5 +6,5 @@ comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other
-  - name: Port 2 ({module})
+  - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS232-1.yaml
+++ b/module-types/Allied Telesis/FS232-1.yaml
@@ -4,7 +4,7 @@ model: FS232/1
 part_number: AT-FS232/1
 comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
-  - name: Port 1 ({module} - 100Base-FX)
+  - name: Port 1 (Slot {module} - 100Base-FX)
     type: other
   - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS232-2.yaml
+++ b/module-types/Allied Telesis/FS232-2.yaml
@@ -6,5 +6,5 @@ comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other
-  - name: Port 2 ({module})
+  - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS232-2.yaml
+++ b/module-types/Allied Telesis/FS232-2.yaml
@@ -4,7 +4,7 @@ model: FS232/2
 part_number: AT-FS232/2
 comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
-  - name: Port 1 ({module} - 100Base-FX)
+  - name: Port 1 (Slot {module} - 100Base-FX)
     type: other
   - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS232.yaml
+++ b/module-types/Allied Telesis/FS232.yaml
@@ -4,7 +4,7 @@ model: FS232
 part_number: AT-FS232
 comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
-  - name: Port 1 ({module} - 100Base-FX)
+  - name: Port 1 (Slot {module} - 100Base-FX)
     type: other
   - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS232.yaml
+++ b/module-types/Allied Telesis/FS232.yaml
@@ -6,5 +6,5 @@ comments: Fast Ethernet to Fiber Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other
-  - name: Port 2 ({module})
+  - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS238A-1.yaml
+++ b/module-types/Allied Telesis/FS238A-1.yaml
@@ -4,7 +4,7 @@ model: FS238A/1
 part_number: AT-FS238A/1
 comments: 10/100TX to 100LX (SC) BiDi media and rate converter
 interfaces:
-  - name: Port 1 ({module} - 100Base-FX)
+  - name: Port 1 (Slot {module} - 100Base-FX)
     type: other
   - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS238A-1.yaml
+++ b/module-types/Allied Telesis/FS238A-1.yaml
@@ -6,5 +6,5 @@ comments: 10/100TX to 100LX (SC) BiDi media and rate converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other
-  - name: Port 2 ({module})
+  - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS238B-1.yaml
+++ b/module-types/Allied Telesis/FS238B-1.yaml
@@ -6,5 +6,5 @@ comments: Fast Ethernet to Fiber BiDi Media and Rate Converter
 interfaces:
   - name: Port 1 ({module} - 100Base-FX)
     type: other
-  - name: Port 2 ({module})
+  - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/FS238B-1.yaml
+++ b/module-types/Allied Telesis/FS238B-1.yaml
@@ -4,7 +4,7 @@ model: FS238B/1
 part_number: AT-FS238B/1
 comments: Fast Ethernet to Fiber BiDi Media and Rate Converter
 interfaces:
-  - name: Port 1 ({module} - 100Base-FX)
+  - name: Port 1 (Slot {module} - 100Base-FX)
     type: other
   - name: Port 2 (Slot {module})
     type: 100base-tx

--- a/module-types/Allied Telesis/SBx81CFC400.yaml
+++ b/module-types/Allied Telesis/SBx81CFC400.yaml
@@ -3,9 +3,9 @@ manufacturer: Allied Telesis
 model: SBx81CFC400
 part_number: AT-SBx81CFC400
 console-ports:
-  - name: Console ({module})
+  - name: Console (Slot {module})
     type: rj-45
 interfaces:
-  - name: eth0 ({module})
+  - name: eth0 (Slot {module})
     type: 1000base-t
     mgmt_only: true

--- a/module-types/Allied Telesis/SBx81CFC960.yaml
+++ b/module-types/Allied Telesis/SBx81CFC960.yaml
@@ -3,10 +3,10 @@ manufacturer: Allied Telesis
 model: SBx81CFC960
 part_number: AT-SBx81CFC960
 console-ports:
-  - name: Console ({module})
+  - name: Console (Slot {module})
     type: rj-45
 interfaces:
-  - name: eth0 ({module})
+  - name: eth0 (Slot {module})
     type: 1000base-t
     mgmt_only: true
   - name: port1.{module}.1


### PR DESCRIPTION
I updated the Allied Telesis modules to include their slot number in the name for easier identification 