### PR TITLE
PowerVault ME4024 Fix

### DIFF
--- a/device-types/Dell/PowerVault_ME4024.yml
+++ b/device-types/Dell/PowerVault_ME4024.yml
@@ -4,38 +4,16 @@ model: PowerVault ME4024
 slug: dell_powervault_me4024
 u_height: 2
 is_full_depth: true
-console-ports:
-  - name: Serial
-    type: other
-power-ports:
-  - name: Power 1
-    type: iec-60320-c14
-  - name: Power 2
-    type: iec-60320-c14
-interfaces:
-  - name: Controller A - Management
-    type: 1000base-t
-    mgmt_only: true
-  - name: iSCSi A1
-    type: infiniband-fdr10
-  - name: iSCSi A2
-    type: infiniband-fdr10
-  - name: iSCSi A3
-    type: infiniband-fdr10
-  - name: iSCSi A4
-    type: infiniband-fdr10
-  - name: SAS A1
-    type: other
-  - name: Controller B - Management
-    type: 1000base-t
-    mgmt_only: true
-  - name: iSCSi B1
-    type: infiniband-fdr10
-  - name: iSCSi B2
-    type: infiniband-fdr10
-  - name: iSCSi B3
-    type: infiniband-fdr10
-  - name: iSCSi B4
-    type: infiniband-fdr10
-  - name: SAS B1
-    type: other
+module-bays:
+  - name: '1'
+    label: PSU Slot 1
+    position: '1'
+  - name: '2'
+    label: PSU Slot 2
+    position: '2'
+  - name: A
+    label: Controller Slot A
+    position: '3'
+  - name: B
+    label: Controller Slot B
+    position: '4'

--- a/module-types/Dell/3PD98.yaml
+++ b/module-types/Dell/3PD98.yaml
@@ -1,0 +1,8 @@
+---
+manufacturer: Dell
+model: 3PD98
+part_number: 3PD98
+comments: Dell 3PD98 PV ME412 ME424 ME4012 ME4024 ME5012 ME5024 C13 580W AC Power Supply
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c14

--- a/module-types/Dell/49H29.yaml
+++ b/module-types/Dell/49H29.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Dell
+model: 49H29
+part_number: 49H29
+comments: SAS 4 Port Controller for use in the Dell ME4012 and Dell ME4024
+interfaces:
+  - name: mgmtport_{module}
+    type: 1000base-t
+    mgmt_only: true
+  - name: SAS {module}0
+    type: other #SFF-8644 - SAS-12Gb
+  - name: SAS {module}1
+    type: other #SFF-8644 - SAS-12Gb
+  - name: SAS {module}2
+    type: other #SFF-8644 - SAS-12Gb
+  - name: SAS {module}3
+    type: other #SFF-8644 - SAS-12Gb
+  - name: Expansion Port {module}0
+    type: other #SFF-8644 - SAS-12Gb
+console-ports:
+  - name: Serial
+    type: usb-mini-b


### PR DESCRIPTION
Fixed the ME4024 to have module bays for the swappable PSU and controllers