### PR TITLE
Dell 49H29 Serial Name Fix

### DIFF
--- a/module-types/Dell/49H29.yaml
+++ b/module-types/Dell/49H29.yaml
@@ -18,5 +18,5 @@ interfaces:
   - name: Expansion Port {module}0
     type: other #SFF-8644 - SAS-12Gb
 console-ports:
-  - name: Serial
+  - name: Serial{module}
     type: usb-mini-b


### PR DESCRIPTION
Fixed serial name for Dell 49H29 SAS 4 port controller