### PR TITLE
Addition of Ubiquiti Switch Pro Aggregation

### DIFF
--- a/device-types/Ubiquiti/USW-Pro-Aggregation.yaml
+++ b/device-types/Ubiquiti/USW-Pro-Aggregation.yaml
@@ -1,0 +1,82 @@
+---
+manufacturer: Ubiquiti
+model: UniFi Switch Pro Aggregation
+slug: unifi-switch-pro-aggregation
+part_number: USW-Pro-Aggregation
+comments: |
+  UniFi Switch Pro Aggregation, 10G 28-Port and 25G 4-Port Managed Aggregation Switch, 100W, (28) SFP+ (4) SFP28
+
+  Dimensions: 442 x 325 x 44 mm (17.4 x 12.8 x 1.7")
+u_height: 1
+is_full_depth: false
+interfaces:
+  - name: SFP+ 1
+    type: 10gbase-x-sfpp
+  - name: SFP+ 2
+    type: 10gbase-x-sfpp
+  - name: SFP+ 3
+    type: 10gbase-x-sfpp
+  - name: SFP+ 4
+    type: 10gbase-x-sfpp
+  - name: SFP+ 5
+    type: 10gbase-x-sfpp
+  - name: SFP+ 6
+    type: 10gbase-x-sfpp
+  - name: SFP+ 7
+    type: 10gbase-x-sfpp
+  - name: SFP+ 8
+    type: 10gbase-x-sfpp
+  - name: SFP+ 9
+    type: 10gbase-x-sfpp
+  - name: SFP+ 10
+    type: 10gbase-x-sfpp
+  - name: SFP+ 11
+    type: 10gbase-x-sfpp
+  - name: SFP+ 12
+    type: 10gbase-x-sfpp
+  - name: SFP+ 13
+    type: 10gbase-x-sfpp
+  - name: SFP+ 14
+    type: 10gbase-x-sfpp
+  - name: SFP+ 15
+    type: 10gbase-x-sfpp
+  - name: SFP+ 16
+    type: 10gbase-x-sfpp
+  - name: SFP+ 17
+    type: 10gbase-x-sfpp
+  - name: SFP+ 18
+    type: 10gbase-x-sfpp
+  - name: SFP+ 19
+    type: 10gbase-x-sfpp
+  - name: SFP+ 20
+    type: 10gbase-x-sfpp
+  - name: SFP+ 21
+    type: 10gbase-x-sfpp
+  - name: SFP+ 22
+    type: 10gbase-x-sfpp
+  - name: SFP+ 23
+    type: 10gbase-x-sfpp
+  - name: SFP+ 24
+    type: 10gbase-x-sfpp
+  - name: SFP+ 25
+    type: 10gbase-x-sfpp
+  - name: SFP+ 26
+    type: 10gbase-x-sfpp
+  - name: SFP+ 27
+    type: 10gbase-x-sfpp
+  - name: SFP+ 28
+    type: 10gbase-x-sfpp
+  - name: SFP28 29
+    type: 25gbase-x-sfp28
+  - name: SFP28 30
+    type: 25gbase-x-sfp28
+  - name: SFP28 31
+    type: 25gbase-x-sfp28
+  - name: SFP28 32
+    type: 25gbase-x-sfp28
+power-ports:
+  - name: Universal AC input
+    type: iec-60320-c14
+    maximum_draw: 100
+  - name: USP-RPS DC input
+    type: ubiquiti-smartpower

--- a/schema/components.json
+++ b/schema/components.json
@@ -171,6 +171,7 @@
                         "usb-3-micro-b",
                         "dc-terminal",
                         "saf-d-grid",
+                        "ubiquiti-smartpower",
                         "hardwired"
                     ]
                 },
@@ -279,6 +280,7 @@
                         "dc-terminal",
                         "hdot-cx",
                         "saf-d-grid",
+                        "ubiquiti-smartpower",
                         "hardwired"
                     ]
                 },


### PR DESCRIPTION
This PR introduces Ubiquiti Switch Pro Aggregation and `ubiquiti-smartpower` Power Connector.

Datasheet (Direct Link, PDF): https://dl.ui.com/ds/usw-pro-aggregation_ds.pdf

Related Issue in netbox-community/netbox:
- https://github.com/netbox-community/netbox/issues/9192
- https://github.com/netbox-community/netbox/issues/9343

-----
Signed-off-by: KOSHIKAWA Kenichi <reishoku.misc ~@~ pm.me>