### PR TITLE
Addition of NEC UNIVERGE IX Series

### DIFF
--- a/device-types/NEC/UNIVERGE-IX2106.yaml
+++ b/device-types/NEC/UNIVERGE-IX2106.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: NEC
+model: UNIVERGE IX2106
+slug: univerge-ix2106
+part_number: BI000087
+comments: |
+  NEC UNIVERGE IX2106, VPN-Compatible High speed Access Router, 7W
+  (1) RJ-45 Console Port, (1) Ethernet 1000BASE-T, (4) Ethernet 1000BASE-T in Switching Hub
+
+  Dimentions(WxDxH in mm): 135x196x36
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+interfaces:
+  - name: GigaEthernet0
+    type: 1000base-t
+  - name: GigaEthernet1 port 1
+    type: 1000base-t
+  - name: GigaEthernet1 port 2
+    type: 1000base-t
+  - name: GigaEthernet1 port 3
+    type: 1000base-t
+  - name: GigaEthernet1 port 4
+    type: 1000base-t
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 7
+    allocated_draw: 7

--- a/device-types/NEC/UNIVERGE-IX2107.yaml
+++ b/device-types/NEC/UNIVERGE-IX2107.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: NEC
+model: UNIVERGE IX2107
+slug: univerge-ix2107
+part_number: BI000118
+comments: |
+  NEC UNIVERGE IX2107, VPN-Compatible High speed Access Router, 7W
+  (1) RJ-45 Console Port, (1) Ethernet 1000BASE-T, (4) Ethernet 1000BASE-T in Switching Hub
+
+  Dimentions(WxDxH in mm): 135x196x36
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+interfaces:
+  - name: GigaEthernet0
+    type: 1000base-t
+  - name: GigaEthernet1 port 1
+    type: 1000base-t
+  - name: GigaEthernet1 port 2
+    type: 1000base-t
+  - name: GigaEthernet1 port 3
+    type: 1000base-t
+  - name: GigaEthernet1 port 4
+    type: 1000base-t
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 7
+    allocated_draw: 7

--- a/device-types/NEC/UNIVERGE-IX2215.yaml
+++ b/device-types/NEC/UNIVERGE-IX2215.yaml
@@ -1,0 +1,47 @@
+---
+manufacturer: NEC
+model: UNIVERGE IX2215
+slug: univerge-ix2215
+part_number: BI000054
+comments: |
+  NEC UNIVERGE IX2215, VPN-Compatible High speed Access Router, 18W
+  (1) RJ-45 Console Port, (2) Ethernet 1000BASE-T, (8) Ethernet 1000BASE-T in Switching Hub, (1) ISDN LINE interface, (1) ISDN S/T interface, (1) USB2.0 Type-A
+
+  Dimentions(WxDxH in mm): 210x297x43
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+interfaces:
+  - name: GigaEthernet0
+    type: 1000base-t
+  - name: GigaEthernet1
+    type: 1000base-t
+  - name: GigaEthernet2 port 1
+    type: 1000base-t
+  - name: GigaEthernet2 port 2
+    type: 1000base-t
+  - name: GigaEthernet2 port 3
+    type: 1000base-t
+  - name: GigaEthernet2 port 4
+    type: 1000base-t
+  - name: GigaEthernet2 port 5
+    type: 1000base-t
+  - name: GigaEthernet2 port 6
+    type: 1000base-t
+  - name: GigaEthernet2 port 7
+    type: 1000base-t
+  - name: GigaEthernet2 port 8
+    type: 1000base-t
+  - name: USB0
+    type: other
+  - name: BRI0 port LINE
+    type: other
+  - name: BRI0 port S/T
+    type: other
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 18
+    allocated_draw: 14

--- a/device-types/NEC/UNIVERGE-IX2235.yaml
+++ b/device-types/NEC/UNIVERGE-IX2235.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: NEC
+model: UNIVERGE IX2235
+slug: univerge-ix2235
+part_number: BI000106
+comments: |
+  NEC UNIVERGE IX2235, VPN-Compatible High speed Access Router, 19W
+  (1) RJ-45 Console Port, (2) Ethernet 1000BASE-T, (8) Ethernet 1000BASE-T in Switching Hub, (1) USB2.0 Type-A
+
+  Dimentions(WxDxH in mm): 210x165x43
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+interfaces:
+  - name: GigaEthernet0
+    type: 1000base-t
+  - name: GigaEthernet1
+    type: 1000base-t
+  - name: GigaEthernet2 port 1
+    type: 1000base-t
+  - name: GigaEthernet2 port 2
+    type: 1000base-t
+  - name: GigaEthernet2 port 3
+    type: 1000base-t
+  - name: GigaEthernet2 port 4
+    type: 1000base-t
+  - name: GigaEthernet2 port 5
+    type: 1000base-t
+  - name: GigaEthernet2 port 6
+    type: 1000base-t
+  - name: GigaEthernet2 port 7
+    type: 1000base-t
+  - name: GigaEthernet2 port 8
+    type: 1000base-t
+  - name: USB0
+    type: other
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 19
+    allocated_draw: 12

--- a/device-types/NEC/UNIVERGE-IX2310.yaml
+++ b/device-types/NEC/UNIVERGE-IX2310.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: NEC
+model: UNIVERGE IX2310
+slug: univerge-ix2310
+part_number: BI000111
+comments: |
+  NEC UNIVERGE IX2310, VPN-Compatible High speed Access Router, 50W
+  (1) RJ-45 Console Port, (4) Ethernet 10/100/1000/2.5G/5G/10GBASE-T, (1) USB2.0 Type-A
+
+  Dimentions(WxDxH in mm): 210x297x44
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+interfaces:
+  - name: GigaEthernet0
+    type: 1000base-t
+  - name: GigaEthernet1
+    type: 1000base-t
+  - name: GigaEthernet2
+    type: 1000base-t
+  - name: GigaEthernet3
+    type: 1000base-t
+  - name: USB0
+    type: other
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 50
+    allocated_draw: 42


### PR DESCRIPTION
This PR introduces (current mainline) UNIVERGE IX Series manufactured by NEC.

The catalogue can be downloaded from following link (Please note that the documentation published there are all written in Japanese):
- https://jpn.nec.com/univerge/ix/download.html

-----
Signed-off-by: KOSHIKAWA Kenichi <reishoku.misc ~@~ pm.me>