### PR TITLE
add NEC UNIVERGE IX2105 IX2207 IX3110

### DIFF
--- a/device-types/NEC/UNIVERGE-IX2105.yaml
+++ b/device-types/NEC/UNIVERGE-IX2105.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: NEC
+model: UNIVERGE IX2105
+slug: univerge-ix2105
+part_number: BE108821
+comments: |
+  NEC UNIVERGE IX2105, VPN-Compatible High speed Access Router, 7W
+  (1) RJ-45 Console Port, (1) Ethernet 1000BASE-T, (4) Ethernet 1000BASE-T in Switching Hub
+
+  Dimentions(WxDxH in mm): 135x196x36
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+interfaces:
+  - name: GigaEthernet0
+    type: 1000base-t
+  - name: GigaEthernet1 port 1
+    type: 1000base-t
+  - name: GigaEthernet1 port 2
+    type: 1000base-t
+  - name: GigaEthernet1 port 3
+    type: 1000base-t
+  - name: GigaEthernet1 port 4
+    type: 1000base-t
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 7
+    allocated_draw: 7

--- a/device-types/NEC/UNIVERGE-IX2207.yaml
+++ b/device-types/NEC/UNIVERGE-IX2207.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: NEC
+model: UNIVERGE IX2207
+slug: univerge-ix2207
+part_number: BI000059
+comments: |
+  NEC UNIVERGE IX2207, VPN-Compatible High speed Access Router, 24W
+  (1) RJ-45 Console Port, (2) Ethernet 1000BASE-T, (4) Ethernet 1000BASE-T in Switching Hub, (2) USB2.0 Type-A
+
+  Dimentions(WxDxH in mm): 210x148x43
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+interfaces:
+  - name: GigaEthernet0
+    type: 1000base-t
+  - name: GigaEthernet1
+    type: 1000base-t
+  - name: GigaEthernet2 port 1
+    type: 1000base-t
+  - name: GigaEthernet2 port 2
+    type: 1000base-t
+  - name: GigaEthernet2 port 3
+    type: 1000base-t
+  - name: GigaEthernet2 port 4
+    type: 1000base-t
+  - name: USB0
+    type: other
+  - name: USB1
+    type: other
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 24
+    allocated_draw: 11

--- a/device-types/NEC/UNIVERGE-IX3110.yaml
+++ b/device-types/NEC/UNIVERGE-IX3110.yaml
@@ -1,0 +1,34 @@
+---
+manufacturer: NEC
+model: UNIVERGE IX3110
+slug: univerge-ix3110
+part_number: BE105556
+comments: |
+  NEC UNIVERGE IX3110, VPN-Compatible High speed Access Router, 40W
+  (1) RJ-45 Console Port, (4) Ethernet 1000BASE-T, (4) Ethernet 1000BASE-X-SFP
+  Every Ethernet port is a 1000BASE-T/SFP combo port
+
+  Dimentions(WxDxH in mm): 430x315x43
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: CONSOLE
+    type: rj-45
+interfaces:
+  - name: GigaEthernet0
+    type: 1000base-t
+  - name: GigaEthernet1
+    type: 1000base-t
+  - name: GigaEthernet2
+    type: 1000base-t
+  - name: GigaEthernet3
+    type: 1000base-t
+power-ports:
+  - name: Module 0
+    type: iec-60320-c14
+    maximum_draw: 40
+    allocated_draw: 40
+  - name: Module 1
+    type: iec-60320-c14
+    maximum_draw: 40
+    allocated_draw: 40


### PR DESCRIPTION
This pull request adds more NEC UNIVERGE IX series routers (IX2105 IX2207 IX3110).

The product datasheet can be found below.
I couldn't find an English datasheet, so it's only a Japanese datasheet.
https://jpn.nec.com/univerge/ix/Info/ix2105.html
https://jpn.nec.com/univerge/ix/Spec/hw-spec.html#ix2207
https://jpn.nec.com/univerge/ix/Spec/hw-spec-ix3000.html#ix3110