### PR TITLE
Remove spaces from Supermicro device names

### DIFF
--- a/device-types/Supermicro/AS-1114S-WN10RT.yml
+++ b/device-types/Supermicro/AS-1114S-WN10RT.yml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Supermicro
-model: AS -1114S-WN10RT
-slug: as--1114s-wn10rt
+model: AS-1114S-WN10RT
+slug: as-1114s-wn10rt
 u_height: 1
 is_full_depth: true
 console-ports:

--- a/device-types/Supermicro/AS-1123US-TR4.yml
+++ b/device-types/Supermicro/AS-1123US-TR4.yml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Supermicro
-model: AS -1123US-TR4
-slug: as--1123us-tr4
+model: AS-1123US-TR4
+slug: as-1123us-tr4
 u_height: 1
 is_full_depth: true
 console-ports:


### PR DESCRIPTION
I presume they were added by accident.