### PR TITLE
Weight Validation Fix

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -605,7 +605,7 @@
                 "value": {
                     "type": "number",
                     "minimum": 0,
-                    "multipleOf": 0.01
+                    "multipleOfPrecision": 0.01
                 },
                 "unit": {
                     "type": "string",


### PR DESCRIPTION
In JSON Schema, multipleOf has issues with precision and specifically has a rounding issue. As mentioned in this [jsonschema issue](https://github.com/python-jsonschema/jsonschema/issues/679) this can be fixed by using `multipleOfPrecision`. This PR implements that change, and closes issue #1068