### PR TITLE
Create FS FMU-MC042733 CWDM Module

### DIFF
--- a/device-types/FS/FMU-MC042733.yaml
+++ b/device-types/FS/FMU-MC042733.yaml
@@ -1,0 +1,30 @@
+---
+manufacturer: FS
+model: FMU-MC042733
+slug: fmu-mc042733
+comments: '[4 Channels 1270-1330nm, LC/UPC, Dual Fiber, Low Insertion Loss CWDM Mux Demux, FMU Plug-in Module](https://www.fs.com/products/42972.html)'
+part_number: '42972'
+u_height: 0
+is_full_depth: false
+subdevice_role: child
+front-ports:
+  - name: '1270'
+    type: lc
+    rear_port: Line
+    rear_port_position: 1
+  - name: '1290'
+    type: lc
+    rear_port: Line
+    rear_port_position: 2
+  - name: '1310'
+    type: lc
+    rear_port: Line
+    rear_port_position: 3
+  - name: '1330'
+    type: lc
+    rear_port: Line
+    rear_port_position: 4
+rear-ports:
+  - name: Line
+    type: lc
+    positions: 5


### PR DESCRIPTION
Create FS FMU-MC042733 CWDM Module as child object

Parent is: https://github.com/netbox-community/devicetype-library/blob/master/device-types/FS/FMU-1UFMX-N.yaml

Reference:
https://www.fs.com/products/42972.html