### PR TITLE
PowerVault ME4024 and 42H29 Controller

### DIFF
--- a/device-types/Dell/49H29.yaml
+++ b/device-types/Dell/49H29.yaml
@@ -1,8 +1,13 @@
 ---
 manufacturer: Dell
 model: 49H29
+slug: dell_controller_49H29
 part_number: 49H29
-comments: PowerVault ME4012 ME4024 SAS 4 Port Controller
+comments: SAS 4 Port Controller for use in the Dell ME4012, ME4024, and ME4084
+u_height: 0
+is_full_depth: false
+airflow: front-to-rear
+subdevice_role: child
 interfaces:
   - name: mgmtport_{module}
     type: 1000base-t

--- a/device-types/Dell/PowerVault_MD3200.yaml
+++ b/device-types/Dell/PowerVault_MD3200.yaml
@@ -1,11 +1,11 @@
 ---
 manufacturer: Dell
-model: PowerVault MD3200
-slug: dell_powervault_md3200
-comments: '[Dell PowerVault MD3200 Datasheet](http://www1.la.dell.com/content/products/productdetails.aspx/powervault-md3200?c=vc&l=en&s=corp)'
+model: PowerVault ME4024
+slug: dell_powervault_me4024
 u_height: 2
 is_full_depth: true
 airflow: front-to-rear
+subdevice_role: parent
 module-bays:
   - name: '1'
     label: PSU Slot 1
@@ -13,9 +13,8 @@ module-bays:
   - name: '2'
     label: PSU Slot 2
     position: '2'
+device-bays:
   - name: A
     label: Controller Slot A
-    position: A
   - name: B
     label: Controller Slot B
-    position: B

--- a/device-types/Dell/PowerVault_MD3200.yaml
+++ b/device-types/Dell/PowerVault_MD3200.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Dell
-model: PowerVault ME4024
-slug: dell_powervault_me4024
+model: PowerVault MD3200
+slug: dell_powervault_md3200
 u_height: 2
 is_full_depth: true
 airflow: front-to-rear

--- a/device-types/Dell/PowerVault_ME4024.yml
+++ b/device-types/Dell/PowerVault_ME4024.yml
@@ -4,6 +4,8 @@ model: PowerVault ME4024
 slug: dell_powervault_me4024
 u_height: 2
 is_full_depth: true
+airflow: front-to-rear
+subdevice_role: parent
 module-bays:
   - name: '1'
     label: PSU Slot 1
@@ -11,9 +13,8 @@ module-bays:
   - name: '2'
     label: PSU Slot 2
     position: '2'
+device-bays:
   - name: A
     label: Controller Slot A
-    position: A
   - name: B
     label: Controller Slot B
-    position: B


### PR DESCRIPTION
The powervault me4024 is just a chassis that holds two controllers. as such it should be a parent child relationship with device bays