### PR TITLE
Add power type other

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -172,7 +172,8 @@
                         "dc-terminal",
                         "saf-d-grid",
                         "ubiquiti-smartpower",
-                        "hardwired"
+                        "hardwired",
+                        "other"
                     ]
                 },
                 "maximum_draw": {
@@ -281,7 +282,8 @@
                         "hdot-cx",
                         "saf-d-grid",
                         "ubiquiti-smartpower",
-                        "hardwired"
+                        "hardwired",
+                        "other"
                     ]
                 },
                 "power_port": {


### PR DESCRIPTION
Add the type `other` for power ports and power outlets to validation.