### PR TITLE
Add power type other

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -172,7 +172,8 @@
                         "dc-terminal",
                         "saf-d-grid",
                         "ubiquiti-smartpower",
-                        "hardwired"
+                        "hardwired",
+                        "other"
                     ]
                 },
                 "maximum_draw": {
@@ -281,7 +282,8 @@
                         "hdot-cx",
                         "saf-d-grid",
                         "ubiquiti-smartpower",
-                        "hardwired"
+                        "hardwired",
+                        "other"
                     ]
                 },
                 "power_port": {
@@ -473,7 +475,8 @@
                         "sma-906",
                         "urm-p2",
                         "urm-p4",
-                        "urm-p8"
+                        "urm-p8",
+                        "other"
                     ]
                 },
                 "color": {


### PR DESCRIPTION
Add type `other` for power ports, power outlets and interfaces to validation schema.
(Ref #1120)