### PR TITLE
Update Aruba 2530-24G

### DIFF
--- a/device-types/HPE/Aruba-2530-24G.yaml
+++ b/device-types/HPE/Aruba-2530-24G.yaml
@@ -1,5 +1,5 @@
 ---
-manufacturer: Aruba
+manufacturer: HPE
 model: Aruba 2530-24G
 slug: hpe-aruba-2530-24g
 part_number: J9776A

--- a/device-types/HPE/Aruba-2530-24G.yaml
+++ b/device-types/HPE/Aruba-2530-24G.yaml
@@ -1,71 +1,100 @@
 ---
-manufacturer: HPE
+manufacturer: Aruba
 model: Aruba 2530-24G
 slug: hpe-aruba-2530-24g
-part_number: J9782A
-u_height: 1
-is_full_depth: false
-power-ports:
-  - name: PS1
-    type: iec-60320-c14
-    maximum_draw: 15
+part_number: J9776A
+u_height: 1.0
+is_full_depth: true
+comments: 'https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N11007'
 console-ports:
-  - name: Console
-    type: rj-45
+- name: Console
+  type: rj-45
+power-ports:
+- name: PS1
+  type: dc-terminal
+  maximum_draw: 50
 interfaces:
-  - name: '1'
-    type: 1000base-t
-  - name: '2'
-    type: 1000base-t
-  - name: '3'
-    type: 1000base-t
-  - name: '4'
-    type: 1000base-t
-  - name: '5'
-    type: 1000base-t
-  - name: '6'
-    type: 1000base-t
-  - name: '7'
-    type: 1000base-t
-  - name: '8'
-    type: 1000base-t
-  - name: '9'
-    type: 1000base-t
-  - name: '10'
-    type: 1000base-t
-  - name: '11'
-    type: 1000base-t
-  - name: '12'
-    type: 1000base-t
-  - name: '13'
-    type: 1000base-t
-  - name: '14'
-    type: 1000base-t
-  - name: '15'
-    type: 1000base-t
-  - name: '16'
-    type: 1000base-t
-  - name: '17'
-    type: 1000base-t
-  - name: '18'
-    type: 1000base-t
-  - name: '19'
-    type: 1000base-t
-  - name: '20'
-    type: 1000base-t
-  - name: '21'
-    type: 1000base-t
-  - name: '22'
-    type: 1000base-t
-  - name: '23'
-    type: 1000base-t
-  - name: '24'
-    type: 1000base-t
-  - name: '25'
-    type: 1000base-x-sfp
-  - name: '26'
-    type: 1000base-x-sfp
-  - name: '27'
-    type: 1000base-x-sfp
-  - name: '28'
-    type: 1000base-x-sfp
+- name: '1'
+  type: 1000base-t
+  mgmt_only: false
+- name: '2'
+  type: 1000base-t
+  mgmt_only: false
+- name: '3'
+  type: 1000base-t
+  mgmt_only: false
+- name: '4'
+  type: 1000base-t
+  mgmt_only: false
+- name: '5'
+  type: 1000base-t
+  mgmt_only: false
+- name: '6'
+  type: 1000base-t
+  mgmt_only: false
+- name: '7'
+  type: 1000base-t
+  mgmt_only: false
+- name: '8'
+  type: 1000base-t
+  mgmt_only: false
+- name: '9'
+  type: 1000base-t
+  mgmt_only: false
+- name: '10'
+  type: 1000base-t
+  mgmt_only: false
+- name: '11'
+  type: 1000base-t
+  mgmt_only: false
+- name: '12'
+  type: 1000base-t
+  mgmt_only: false
+- name: '13'
+  type: 1000base-t
+  mgmt_only: false
+- name: '14'
+  type: 1000base-t
+  mgmt_only: false
+- name: '15'
+  type: 1000base-t
+  mgmt_only: false
+- name: '16'
+  type: 1000base-t
+  mgmt_only: false
+- name: '17'
+  type: 1000base-t
+  mgmt_only: false
+- name: '18'
+  type: 1000base-t
+  mgmt_only: false
+- name: '19'
+  type: 1000base-t
+  mgmt_only: false
+- name: '20'
+  type: 1000base-t
+  mgmt_only: false
+- name: '21'
+  type: 1000base-t
+  mgmt_only: false
+- name: '22'
+  type: 1000base-t
+  mgmt_only: false
+- name: '23'
+  type: 1000base-t
+  mgmt_only: false
+- name: '24'
+  type: 1000base-t
+  mgmt_only: false
+- name: '25'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '26'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '27'
+  type: 1000base-x-sfp
+  mgmt_only: false
+- name: '28'
+  type: 1000base-x-sfp
+  mgmt_only: false

--- a/device-types/HPE/Aruba-2530-24G.yaml
+++ b/device-types/HPE/Aruba-2530-24G.yaml
@@ -6,6 +6,9 @@ part_number: J9776A
 u_height: 1.0
 is_full_depth: true
 comments: 'Quickspecs : https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N11007'
+weight:
+  - value: 6.1
+    unit: lb
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/HPE/Aruba-2530-24G.yaml
+++ b/device-types/HPE/Aruba-2530-24G.yaml
@@ -16,85 +16,57 @@ power-ports:
 interfaces:
   - name: '1'
     type: 1000base-t
-    mgmt_only: false
   - name: '2'
     type: 1000base-t
-    mgmt_only: false
   - name: '3'
     type: 1000base-t
-    mgmt_only: false
   - name: '4'
     type: 1000base-t
-    mgmt_only: false
   - name: '5'
     type: 1000base-t
-    mgmt_only: false
   - name: '6'
     type: 1000base-t
-    mgmt_only: false
   - name: '7'
     type: 1000base-t
-    mgmt_only: false
   - name: '8'
     type: 1000base-t
-    mgmt_only: false
   - name: '9'
     type: 1000base-t
-    mgmt_only: false
   - name: '10'
     type: 1000base-t
-    mgmt_only: false
   - name: '11'
     type: 1000base-t
-    mgmt_only: false
   - name: '12'
     type: 1000base-t
-    mgmt_only: false
   - name: '13'
     type: 1000base-t
-    mgmt_only: false
   - name: '14'
     type: 1000base-t
-    mgmt_only: false
   - name: '15'
     type: 1000base-t
-    mgmt_only: false
   - name: '16'
     type: 1000base-t
-    mgmt_only: false
   - name: '17'
     type: 1000base-t
-    mgmt_only: false
   - name: '18'
     type: 1000base-t
-    mgmt_only: false
   - name: '19'
     type: 1000base-t
-    mgmt_only: false
   - name: '20'
     type: 1000base-t
-    mgmt_only: false
   - name: '21'
     type: 1000base-t
-    mgmt_only: false
   - name: '22'
     type: 1000base-t
-    mgmt_only: false
   - name: '23'
     type: 1000base-t
-    mgmt_only: false
   - name: '24'
     type: 1000base-t
-    mgmt_only: false
   - name: '25'
     type: 1000base-x-sfp
-    mgmt_only: false
   - name: '26'
     type: 1000base-x-sfp
-    mgmt_only: false
   - name: '27'
     type: 1000base-x-sfp
-    mgmt_only: false
   - name: '28'
     type: 1000base-x-sfp
-    mgmt_only: false

--- a/device-types/HPE/Aruba-2530-24G.yaml
+++ b/device-types/HPE/Aruba-2530-24G.yaml
@@ -5,96 +5,96 @@ slug: hpe-aruba-2530-24g
 part_number: J9776A
 u_height: 1.0
 is_full_depth: true
-comments: 'https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N11007'
+comments: 'Quickspecs : https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N11007'
 console-ports:
-- name: Console
-  type: rj-45
+  - name: Console
+    type: rj-45
 power-ports:
-- name: PS1
-  type: dc-terminal
-  maximum_draw: 50
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 50
 interfaces:
-- name: '1'
-  type: 1000base-t
-  mgmt_only: false
-- name: '2'
-  type: 1000base-t
-  mgmt_only: false
-- name: '3'
-  type: 1000base-t
-  mgmt_only: false
-- name: '4'
-  type: 1000base-t
-  mgmt_only: false
-- name: '5'
-  type: 1000base-t
-  mgmt_only: false
-- name: '6'
-  type: 1000base-t
-  mgmt_only: false
-- name: '7'
-  type: 1000base-t
-  mgmt_only: false
-- name: '8'
-  type: 1000base-t
-  mgmt_only: false
-- name: '9'
-  type: 1000base-t
-  mgmt_only: false
-- name: '10'
-  type: 1000base-t
-  mgmt_only: false
-- name: '11'
-  type: 1000base-t
-  mgmt_only: false
-- name: '12'
-  type: 1000base-t
-  mgmt_only: false
-- name: '13'
-  type: 1000base-t
-  mgmt_only: false
-- name: '14'
-  type: 1000base-t
-  mgmt_only: false
-- name: '15'
-  type: 1000base-t
-  mgmt_only: false
-- name: '16'
-  type: 1000base-t
-  mgmt_only: false
-- name: '17'
-  type: 1000base-t
-  mgmt_only: false
-- name: '18'
-  type: 1000base-t
-  mgmt_only: false
-- name: '19'
-  type: 1000base-t
-  mgmt_only: false
-- name: '20'
-  type: 1000base-t
-  mgmt_only: false
-- name: '21'
-  type: 1000base-t
-  mgmt_only: false
-- name: '22'
-  type: 1000base-t
-  mgmt_only: false
-- name: '23'
-  type: 1000base-t
-  mgmt_only: false
-- name: '24'
-  type: 1000base-t
-  mgmt_only: false
-- name: '25'
-  type: 1000base-x-sfp
-  mgmt_only: false
-- name: '26'
-  type: 1000base-x-sfp
-  mgmt_only: false
-- name: '27'
-  type: 1000base-x-sfp
-  mgmt_only: false
-- name: '28'
-  type: 1000base-x-sfp
-  mgmt_only: false
+  - name: '1'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '2'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '3'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '4'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '5'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '6'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '7'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '8'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '9'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '10'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '11'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '12'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '13'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '14'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '15'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '16'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '17'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '18'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '19'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '20'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '21'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '22'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '23'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '24'
+    type: 1000base-t
+    mgmt_only: false
+  - name: '25'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '26'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '27'
+    type: 1000base-x-sfp
+    mgmt_only: false
+  - name: '28'
+    type: 1000base-x-sfp
+    mgmt_only: false


### PR DESCRIPTION
J9782A (2530-24) and J9776A(2530-24**G**) is different devices.

Modified values with referring to Quickspecs (https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N1040D)