### PR TITLE
Added Intel HNS2600TPR Blade

### DIFF
--- a/device-types/Intel/HNS2600TPR.yaml
+++ b/device-types/Intel/HNS2600TPR.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Intel
+model: HNS2600TPR
+slug: intel-hns2600tpr
+u_height: 0.5
+comments: |
+  [HNS2600TPR Specifications on intel.com](https://ark.intel.com/content/www/us/en/ark/products/88297/intel-compute-module-hns2600tpr.html)
+subdevice_role: child
+inventory-items:
+  - name: S2600TPR
+    label: Intel Server Board S2600TPR
+    manufacturer: Intel
+interfaces:
+  - name: GigabitEthernet1
+    type: 1000base-t
+  - name: GigabitEthernet2
+    type: 1000base-t
+  - name: IPMI
+    type: 1000base-t
+    mgmt_only: true
+console-ports:
+  - name: Rear VGA
+    type: other


### PR DESCRIPTION
I created the .yaml file for the Intel blade with the Specs from the [Intel Spec sheet](https://ark.intel.com/content/www/us/en/ark/products/88297/intel-compute-module-hns2600tpr.html). I thought about adding the PCIe slots as module bays but i was not sure if this is the intended way to model this kind of data inside NetBox. Please let me know how i can improve my contributions. 