### PR TITLE
Weight Import Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following fields may **optionally** be declared:
 >```
 >weight:
 >  - value: 12.21
->    unit: lb
+>weight_unit: lb
 >```
 
 For further detail on these attributes and those listed below, please reference the

--- a/README.md
+++ b/README.md
@@ -64,19 +64,19 @@ The following fields may **optionally** be declared:
 - `comments`: A string field which allows for comments to be added to the device. (**Default: None**)
   - Type: String
 > :test_tube: **Example**: `comments: This is a comment that will appear on all NetBox devices of this type`
-- `weight`: An array with a **single** item that allow for a value and unit of measurement to be defined. (**Default: None**)
-  - Type: Array
-  - Value: Number - must be multiple of 0.01
-  - Unit: String
-    - Options:
-        - kg
-        - g
-        - lb
-        - oz
+- `weight`: A number representing the numeric weight value. Must be a multiple of 0.01 (2 decimal places). (**Default: None**)
+    - Type: Number
+    - Value: must be a multiple of 0.01
+- `weight_unit`: A string defining the unit of measurement. It must be one of the supported values. (**Default: None**)
+  - Type: String
+  - Value: Enumerated Options
+    - kg
+    - g
+    - lb
+    - oz
 >:test_tube: **Example**:
 >```
->weight:
->  - value: 12.21
+>weight: 12.21
 >weight_unit: lb
 >```
 

--- a/device-types/Adtran/NV4660.yaml
+++ b/device-types/Adtran/NV4660.yaml
@@ -3,9 +3,8 @@ manufacturer: Adtran
 model: NetVanta 4660
 slug: nv4660
 part_number: 17004660F1
-weight:
-  - value: 3.2
-    unit: kg
+weight: 3.2
+weight_unit: kg
 u_height: 1
 is_full_depth: false
 console-ports:

--- a/device-types/Cisco/DPC3939B.yaml
+++ b/device-types/Cisco/DPC3939B.yaml
@@ -6,9 +6,8 @@ part_number: DPC3939B-AMC11-K9
 u_height: 0
 is_full_depth: false
 comments: Comcast Business Gateway Model DPC3939B
-weight:
-  - value: 2.65
-    unit: lb
+weight: 2.65
+weight_unit: lb
 power-ports:
   - name: PS1
     type: iec-60320-c8

--- a/device-types/Cisco/SPA112.yaml
+++ b/device-types/Cisco/SPA112.yaml
@@ -7,9 +7,8 @@ u_height: 0
 is_full_depth: false
 airflow: passive
 comments: 'There are models with 1 WAN, 1 LAN under a different hardware revision #. [Cisco SPA122 ATA with Router Data Sheet](https://www.cisco.com/c/en/us/products/collateral/unified-communications/small-business-voice-gateways-ata/datasheet_C78-691107.html)'
-weight:
-  - value: 5.4
-    unit: oz
+weight: 5.4
+weight_unit: oz
 power-ports:
   - name: POWER
     type: dc-terminal

--- a/device-types/Cisco/WS-C2960XR-24TD-I.yaml
+++ b/device-types/Cisco/WS-C2960XR-24TD-I.yaml
@@ -5,9 +5,8 @@ slug: cisco-ws-c2960xr-24td-i
 part_number: WS-C2960XR-24TD-I
 is_full_depth: false
 u_height: 1
-weight:
-  - value: 13.0
-    unit: lb
+weight: 13.0
+weight_unit: lb
 comments: IP Lite feature set (https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-2960-x-series-switches/datasheet_c78-728232.pdf)
 airflow: side-to-rear
 interfaces:

--- a/device-types/Datto/AP440.yaml
+++ b/device-types/Datto/AP440.yaml
@@ -6,9 +6,8 @@ part_number: AP440
 u_height: 0
 is_full_depth: false
 comments: '[Datto Access Points](https://www.datto.com/product-assets/wifi/AP840_840E_Datasheet_US.pdf)'
-weight:
-  - value: 1.19
-    unit: lb
+weight: 1.19
+weight_unit: lb
 power-ports:
   - name: DC
     type: dc-terminal

--- a/device-types/Datto/AP840.yaml
+++ b/device-types/Datto/AP840.yaml
@@ -6,9 +6,8 @@ part_number: AP840
 u_height: 0
 is_full_depth: false
 comments: '[Datto Access Points](https://www.datto.com/product-assets/wifi/AP840_840E_Datasheet_US.pdf)'
-weight:
-  - value: 2.03
-    unit: lb
+weight: 2.03
+weight_unit: lb
 power-ports:
   - name: DC
     type: dc-terminal

--- a/device-types/Datto/AP840E.yaml
+++ b/device-types/Datto/AP840E.yaml
@@ -6,9 +6,8 @@ part_number: AP840E
 u_height: 0
 is_full_depth: false
 comments: '[Datto Access Points](https://www.datto.com/product-assets/wifi/AP840_840E_Datasheet_US.pdf)'
-weight:
-  - value: 3.55
-    unit: lb
+weight: 3.55
+weight_unit: lb
 power-ports:
   - name: DC
     type: dc-terminal

--- a/device-types/EnGenius/EWS1200-28TFP.yaml
+++ b/device-types/EnGenius/EWS1200-28TFP.yaml
@@ -6,9 +6,8 @@ part_number: EWS1200-28TFP
 u_height: 1
 is_full_depth: false
 comments: "24-Port Managed Gigabit 410W PoE+ Network Switch\r\n\r\nSpecifications: [EWS1200-28TFP](https://www.engeniusnetworks.eu/products/network-switches/ews1200-28tfp/#specification)"
-weight:
-  - value: 3.85
-    unit: kg
+weight: 3.85
+weight_unit: kg
 power-ports:
   - name: Power
     type: iec-60320-c14

--- a/device-types/EnGenius/EWS360AP.yaml
+++ b/device-types/EnGenius/EWS360AP.yaml
@@ -7,9 +7,8 @@ u_height: 0
 is_full_depth: false
 airflow: passive
 comments: "EWS 11ac Managed Indoor Access Point\r\n\r\nSpecifications: [EWS360AP](https://www.engeniusnetworks.eu/products/wireless/indoor-access-points/ews360ap/#specification)"
-weight:
-  - value: 363
-    unit: g
+weight: 363
+weight_unit: g
 power-ports:
   - name: Power
     type: dc-terminal

--- a/device-types/EnGenius/EWS5912FP.yaml
+++ b/device-types/EnGenius/EWS5912FP.yaml
@@ -6,9 +6,8 @@ part_number: EWS5912FP
 u_height: 1
 is_full_depth: false
 comments: "8-Port Managed Gigabit 130W PoE+ Network Switch\r\n\r\nSpecifications: [EWS5912FP](https://www.engeniusnetworks.eu/products/network-switches/ews5912fp/#specification)"
-weight:
-  - value: 1.9
-    unit: kg
+weight: 1.9
+weight_unit: kg
 power-ports:
   - name: Power
     type: iec-60320-c14

--- a/device-types/FS/S3150-8T2FP.yaml
+++ b/device-types/FS/S3150-8T2FP.yaml
@@ -7,9 +7,8 @@ is_full_depth: false
 u_height: 1
 airflow: passive
 comments: '[FS S3150 Series Switches Data Sheet](https://www.fs.com/products_support/preview.html?categories_id=3256&files_id=4543&model_name=S3150-8T2FP&is_datasheet=1)'
-weight:
-  - value: 3.7
-    unit: lb
+weight: 3.7
+weight_unit: lb
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Fortinet/FEX-40D.yaml
+++ b/device-types/Fortinet/FEX-40D.yaml
@@ -4,9 +4,8 @@ model: FortiExtender 40D
 slug: fortinet-fex-40d
 part_number: FEX-40D
 u_height: 0
-weight:
-  - value: 0.83
-    unit: lb
+weight: 0.83
+weight_unit: lb
 is_full_depth: false
 comments: Built in LTE modem (2 antenna), PoE-capable, Wall-mount.
 console-ports:

--- a/device-types/Fortinet/FS-1048E.yaml
+++ b/device-types/Fortinet/FS-1048E.yaml
@@ -4,9 +4,8 @@ model: FortiSwitch 1048E
 slug: fortinet-fs-1048e
 part_number: FS-1048E
 u_height: 1
-weight:
-  - value: 18.96
-    unit: lb
+weight: 18.96
+weight_unit: lb
 is_full_depth: false
 comments: '[Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Data_Center_Series.pdf)'
 airflow: front-to-rear

--- a/device-types/Fortinet/FS-424E-FPOE.yaml
+++ b/device-types/Fortinet/FS-424E-FPOE.yaml
@@ -4,9 +4,8 @@ model: FortiSwitch 424E-FPOE
 slug: fortinet-fs-424e-fpoe
 part_number: FS-424E-FPOE
 u_height: 1
-weight:
-  - value: 12.72
-    unit: lb
+weight: 12.72
+weight_unit: lb
 is_full_depth: false
 comments: '[Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf)'
 airflow: side-to-rear

--- a/device-types/Fortinet/FS-448D-FPOE.yaml
+++ b/device-types/Fortinet/FS-448D-FPOE.yaml
@@ -4,9 +4,8 @@ model: FortiSwitch 448D-FPOE
 slug: fortinet-fs-448d-fpoe
 part_number: FS-448D-FPOE
 u_height: 1
-weight:
-  - value: 15.45
-    unit: lb
+weight: 15.45
+weight_unit: lb
 is_full_depth: false
 airflow: side-to-rear
 console-ports:

--- a/device-types/Fortinet/FS-448D-POE.yaml
+++ b/device-types/Fortinet/FS-448D-POE.yaml
@@ -4,9 +4,8 @@ model: FortiSwitch 448D-POE
 slug: fortinet-fs-448d-poe
 part_number: FS-448D-POE
 u_height: 1
-weight:
-  - value: 13.44
-    unit: lb
+weight: 13.44
+weight_unit: lb
 is_full_depth: false
 airflow: side-to-rear
 console-ports:

--- a/device-types/HPE/Aruba-2530-24-PoEP.yml
+++ b/device-types/HPE/Aruba-2530-24-PoEP.yml
@@ -6,9 +6,8 @@ part_number: J9779A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N11BE7)'
-weight:
-  - value: 3.8
-    unit: kg
+weight: 3.8
+weight_unit: kg
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/Aruba-2530-24.yaml
+++ b/device-types/HPE/Aruba-2530-24.yaml
@@ -6,9 +6,8 @@ part_number: J9782A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N1040D)'
-weight:
-  - value: 2.6
-    unit: kg
+weight: 2.6
+weight_unit: kg
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2530-24G-PoEP.yaml
+++ b/device-types/HPE/Aruba-2530-24G-PoEP.yaml
@@ -6,9 +6,8 @@ part_number: J9773A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N127FD)'
-weight:
-  - value: 4
-    unit: kg
+weight: 4
+weight_unit: kg
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2530-24G.yaml
+++ b/device-types/HPE/Aruba-2530-24G.yaml
@@ -6,9 +6,8 @@ part_number: J9776A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N11007)'
-weight:
-  - value: 6.1
-    unit: lb
+weight: 6.1
+weight_unit: lb
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2530-48-PoEP.yml
+++ b/device-types/HPE/Aruba-2530-48-PoEP.yml
@@ -6,9 +6,8 @@ part_number: J9778A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N11FF3)'
-weight:
-  - value: 10
-    unit: lb
+weight: 10
+weight_unit: lb
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/Aruba-2530-48.yaml
+++ b/device-types/HPE/Aruba-2530-48.yaml
@@ -6,9 +6,8 @@ part_number: J9781A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N10805)'
-weight:
-  - value: 2.6
-    unit: kg
+weight: 2.6
+weight_unit: kg
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2530-48G-PoEP.yaml
+++ b/device-types/HPE/Aruba-2530-48G-PoEP.yaml
@@ -6,9 +6,8 @@ part_number: J9772A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N12C00)'
-weight:
-  - value: 2.6
-    unit: kg
+weight: 2.6
+weight_unit: kg
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2530-48G.yaml
+++ b/device-types/HPE/Aruba-2530-48G.yaml
@@ -6,9 +6,8 @@ part_number: J9775A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N113F7)'
-weight:
-  - value: 3
-    unit: kg
+weight: 3
+weight_unit: kg
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2530-8-PoEP.yml
+++ b/device-types/HPE/Aruba-2530-8-PoEP.yml
@@ -6,9 +6,8 @@ part_number: J9780A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N117E5)'
-weight:
-  - value: 2
-    unit: lb
+weight: 2
+weight_unit: lb
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/Aruba-2530-8.yaml
+++ b/device-types/HPE/Aruba-2530-8.yaml
@@ -6,9 +6,8 @@ part_number: J9783A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915)'
-weight:
-  - value: 0.82
-    unit: kg
+weight: 0.82
+weight_unit: kg
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/HPE/Aruba-2530-8G-PoEP.yaml
+++ b/device-types/HPE/Aruba-2530-8G-PoEP.yaml
@@ -6,9 +6,8 @@ part_number: J9774A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915#N123F6)'
-weight:
-  - value: 1
-    unit: kg
+weight: 1
+weight_unit: kg
 power-ports:
   - name: PS1
     type: dc-terminal

--- a/device-types/HPE/Aruba-2530-8G.yaml
+++ b/device-types/HPE/Aruba-2530-8G.yaml
@@ -6,9 +6,8 @@ part_number: J9777A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2530 Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03624915)'
-weight:
-  - value: 0.91
-    unit: kg
+weight: 0.91
+weight_unit: kg
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2930F-24G-4SFP.yaml
+++ b/device-types/HPE/Aruba-2930F-24G-4SFP.yaml
@@ -6,9 +6,8 @@ part_number: JL259A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2930F 24G 4SFP Switch Data sheet](https://www.hpe.com/psnow/doc/PSN1008995548USEN.pdf)'
-weight:
-  - value: 5.31
-    unit: lb
+weight: 5.31
+weight_unit: lb
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2930F-24G-PoEP-4SFP.yaml
+++ b/device-types/HPE/Aruba-2930F-24G-PoEP-4SFP.yaml
@@ -6,9 +6,8 @@ part_number: JL261A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2930F 24G PoE+ 4SFP Switch Data sheet](https://www.hpe.com/psnow/doc/PSN1008995334USEN.pdf)'
-weight:
-  - value: 8.6
-    unit: lb
+weight: 8.6
+weight_unit: lb
 power-ports:
   - name: PS1
     type: iec-60320-c14

--- a/device-types/HPE/Aruba-2930M-48G-PoEP.yaml
+++ b/device-types/HPE/Aruba-2930M-48G-PoEP.yaml
@@ -6,9 +6,8 @@ part_number: JL322A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2930M Switch Series Datasheet](https://www.arubanetworks.com/assets/ds/DS_2930MSwitchSeries.pdf)'
-weight:
-  - value: 10.25
-    unit: lb
+weight: 10.25
+weight_unit: lb
 module-bays:
   - name: PS1
     position: '1'

--- a/device-types/HPE/Aruba-2930M-48G.yaml
+++ b/device-types/HPE/Aruba-2930M-48G.yaml
@@ -6,9 +6,8 @@ part_number: JL321A
 u_height: 1
 is_full_depth: false
 comments: '[Aruba 2930M 48G 1-slot Switch Data sheet](https://www.hpe.com/psnow/doc/PSN1009875168USEN.pdf)'
-weight:
-  - value: 10.14
-    unit: lb
+weight: 10.14
+weight_unit: lb
 module-bays:
   - name: PS1
     position: '1'

--- a/device-types/HPE/FlexFabric-5700-40XG-2QSFPP.yaml
+++ b/device-types/HPE/FlexFabric-5700-40XG-2QSFPP.yaml
@@ -6,9 +6,8 @@ part_number: JG896A
 u_height: 1
 is_full_depth: false
 comments: '[HPE FlexFabric 5700 Switch Series - Specification](https://support.hpe.com/hpesc/public/docDisplay?docId=c04400247)'
-weight:
-  - value: 10
-    unit: kg
+weight: 10
+weight_unit: kg
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/FlexFabric-5945-2-slot.yaml
+++ b/device-types/HPE/FlexFabric-5945-2-slot.yaml
@@ -6,9 +6,8 @@ part_number: JQ075A
 u_height: 1
 is_full_depth: false
 comments: '[HPE FlexFabric 5945 2-slot Switch Data sheet](https://www.hpe.com/psnow/doc/PSN1011424706USEN.pdf)'
-weight:
-  - value: 10.4
-    unit: kg
+weight: 10.4
+weight_unit: kg
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/FlexNetwork-5130-24G-4SFP+-EI.yml
+++ b/device-types/HPE/FlexNetwork-5130-24G-4SFP+-EI.yml
@@ -6,9 +6,8 @@ part_number: JG932A
 u_height: 1
 is_full_depth: false
 comments: '[HPE FlexNetwork 5130 EI Switch Series QuickSpecs](https://www.hpe.com/psnow/doc/c04394228.pdf)'
-weight:
-  - value: 5
-    unit: kg
+weight: 5
+weight_unit: kg
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/FlexNetwork-5130-48G-4SFP+-EI.yml
+++ b/device-types/HPE/FlexNetwork-5130-48G-4SFP+-EI.yml
@@ -6,9 +6,8 @@ part_number: JG934A
 u_height: 1
 is_full_depth: false
 comments: '[HPE FlexNetwork 5130 EI Switch Series QuickSpecs](https://www.hpe.com/psnow/doc/c04394228.pdf)'
-weight:
-  - value: 5
-    unit: kg
+weight: 5
+weight_unit: kg
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/FlexNetwork-5130-48G-4SFPP-HI.yml
+++ b/device-types/HPE/FlexNetwork-5130-48G-4SFPP-HI.yml
@@ -7,9 +7,8 @@ u_height: 1
 is_full_depth: false
 comments: '[HPE FlexNetwork 5130 HI Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c04924428)'
 airflow: front-to-rear
-weight:
-  - value: 7.5
-    unit: kg
+weight: 7.5
+weight_unit: kg
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/FlexNetwork-5130-48G-PoEP-4SFPP-HI.yml
+++ b/device-types/HPE/FlexNetwork-5130-48G-PoEP-4SFPP-HI.yml
@@ -7,9 +7,8 @@ u_height: 1
 is_full_depth: false
 comments: '[HPE FlexNetwork 5130 HI Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c04924428)'
 airflow: front-to-rear
-weight:
-  - value: 12.5
-    unit: kg
+weight: 12.5
+weight_unit: kg
 console-ports:
   - name: console
     type: rj-45

--- a/device-types/HPE/HP-5500-24G-4SFP-HI.yaml
+++ b/device-types/HPE/HP-5500-24G-4SFP-HI.yaml
@@ -6,9 +6,8 @@ part_number: JG311A
 u_height: 1
 is_full_depth: false
 comments: '[HPE 5500 HI Switch Series - Specifications](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c03237481)'
-weight:
-  - value: 7.5
-    unit: kg
+weight: 7.5
+weight_unit: kg
 module-bays:
   - name: PSU1
     position: PSU1

--- a/device-types/HPE/ProLiant-DL180-Gen6.yaml
+++ b/device-types/HPE/ProLiant-DL180-Gen6.yaml
@@ -6,9 +6,8 @@ u_height: 2.0
 is_full_depth: true
 part_number: 590638-371
 comments: '[HP ProLiant DL180 G6 QuickSpecs](https://www.hpe.com/psnow/doc/c04284378)'
-weight:
-  - value: 16.80
-    unit: kg
+weight: 16.80
+weight_unit: kg
 console-ports:
   - name: Serial
     type: de-9

--- a/device-types/HPE/ProLiant-DL360e-Gen8.yaml
+++ b/device-types/HPE/ProLiant-DL360e-Gen8.yaml
@@ -6,9 +6,8 @@ u_height: 1.0
 is_full_depth: true
 part_number: 661189-B21
 comments: '[HP ProLiant DL360e Gen8 QuickSpecs](https://www.hpe.com/psnow/doc/c04284501)'
-weight:
-  - value: 17.92
-    unit: kg
+weight: 17.92
+weight_unit: kg
 console-ports:
   - name: Serial
     type: de-9

--- a/device-types/HPE/ProLiant-DL365-Gen11.yaml
+++ b/device-types/HPE/ProLiant-DL365-Gen11.yaml
@@ -6,9 +6,8 @@ u_height: 1
 is_full_depth: true
 part_number: P53933-B21
 comments: '[HPE ProLiant DL365 Gen11 QuickSpecs](https://www.hpe.com/psnow/doc/a50004299enw)'
-weight:
-  - value: 18.39
-    unit: kg
+weight: 18.39
+weight_unit: kg
 console-ports:
   - name: Serial
     type: de-9

--- a/device-types/Huawei/CE8850-64CQ-EI.yaml
+++ b/device-types/Huawei/CE8850-64CQ-EI.yaml
@@ -6,9 +6,8 @@ part_number: CE8850-64CQ-EI
 u_height: 2
 is_full_depth: true
 comments: '[Huawei CE8850-64CQ-EI](https://support.huawei.com/enterprise/en/doc/EDOC1000019246/56d573f4/ce8850-64cq-ei)'
-weight:
-  - value: 22.2
-    unit: kg
+weight: 22.2
+weight_unit: kg
 module-bays:
   - name: FAN1
   - name: FAN2

--- a/device-types/Huawei/CE8861-4C-EI.yaml
+++ b/device-types/Huawei/CE8861-4C-EI.yaml
@@ -6,9 +6,8 @@ part_number: CE8861-4C-EI
 u_height: 2
 is_full_depth: true
 comments: '[Huawei CE8861-4C-EI](https://support.huawei.com/enterprise/en/doc/EDOC1000019246/56e787dc/ce8861-4c-ei)'
-weight:
-  - value: 21.3
-    unit: kg
+weight: 21.3
+weight_unit: kg
 module-bays:
   - name: FAN1
   - name: FAN2

--- a/device-types/Huawei/S5700-28P-LI-AC.yaml
+++ b/device-types/Huawei/S5700-28P-LI-AC.yaml
@@ -3,9 +3,8 @@ manufacturer: Huawei
 model: S5700-28P-LI-AC
 slug: huawei-S5700-28P-LI-AC
 u_height: 1.0
-weight:
-  - value: 2.8
-    unit: kg
+weight: 2.8
+weight_unit: kg
 is_full_depth: false
 airflow: passive
 comments: "S5700-28P-LI-AC (24*10/100/1000BASE-T ports, 4*1000BASE-X SFP ports, with integrated power module)\r\n\r\n [Datasheet:](https://support.huawei.com/enterprise/it/doc/EDOC1000013597/22fa8fb3/s5700-28p-li-ac)"

--- a/device-types/Huawei/S5700-28X-LI-AC.yaml
+++ b/device-types/Huawei/S5700-28X-LI-AC.yaml
@@ -3,9 +3,8 @@ manufacturer: Huawei
 model: S5700-28X-LI-AC
 slug: huawei-s5700-28x-li-ac
 u_height: 1.0
-weight:
-  - value: 3.4
-    unit: kg
+weight: 3.4
+weight_unit: kg
 is_full_depth: true
 airflow: left-to-right
 comments: "S5700-28X-LI-AC (24*10/100/1000BASE-T ports,4*10GE SFP+ ports, with integrated power module)\r\n\r\nDatasheet: [Link](https://support.huawei.com/enterprise/it/doc/EDOC1000013597/1115c1d4/s5700-28x-li-ac)"

--- a/device-types/Inspur/NF5180M6.yaml
+++ b/device-types/Inspur/NF5180M6.yaml
@@ -7,9 +7,8 @@ u_height: 1
 is_full_depth: true
 airflow: front-to-rear
 comments: '[Inspur NF5180M6 Technical Specifications](https://en.inspur.com/en/servers/rack_servers/2552517/index.html)'
-weight:
-  - value: 31
-    unit: kg
+weight: 31
+weight_unit: kg
 console-ports:
   - name: BMC/System Serial
     type: other

--- a/device-types/QNAP/TS-453D.yml
+++ b/device-types/QNAP/TS-453D.yml
@@ -6,9 +6,8 @@ u_height: 0
 part_number: TS-453d
 airflow: side-to-rear
 is_full_depth: false
-weight:
-  - value: 3.6
-    unit: kg
+weight: 3.6
+weight_unit: kg
 comments: '[TS-453B | Hardware Specs | QNAP](https://www.qnap.com/en/product/ts-453d/specs/hardware)'
 power-ports:
   - name: Power

--- a/device-types/QTECH/QSW-6900-56F.yaml
+++ b/device-types/QTECH/QSW-6900-56F.yaml
@@ -6,9 +6,8 @@ slug: qtech-qsw-6900-56f
 u_height: 1
 is_full_depth: false
 airflow: front-to-rear
-weight:
-  - value: 8
-    unit: kg
+weight: 8
+weight_unit: kg
 comments: '[QTECH QSW-6900-56F](https://ftp.qtech.ru/Switch/Data%20Center/QSW-6900/Manual/Installation%20Guide%20%5bEng%5d/QSW-6900-56F%20Installation%20Manual_Eng.pdf)'
 console-ports:
   - name: console

--- a/device-types/QTECH/QSW-6900-56LF.yaml
+++ b/device-types/QTECH/QSW-6900-56LF.yaml
@@ -5,9 +5,8 @@ part_number: QSW-6900-56LF
 slug: qtech-qsw-6900-56lf
 u_height: 1
 is_full_depth: false
-weight:
-  - value: 8
-    unit: kg
+weight: 8
+weight_unit: kg
 airflow: front-to-rear
 comments: '[QTECH QSW-6900-56LF](https://ftp.qtech.ru/Switch/Data%20Center/QSW-6900/Manual/Installation%20Guide%20%5bEng%5d/QSW-6900-56LF%20Installation%20Manual_Eng.pdf)'
 console-ports:

--- a/device-types/Ubiquiti/USIP-R.yml
+++ b/device-types/Ubiquiti/USIP-R.yml
@@ -6,9 +6,8 @@ part_number: UISP-R
 u_height: 0
 is_full_depth: false
 airflow: passive
-weight:
-  - value: 1.32
-    unit: lb
+weight: 1.32
+weight_unit: lb
 comments: '[UISP Router](https://store.ui.com/collections/operator-isp-infrastructure/products/uisp-router)'
 power-ports:
   - name: Input 27V

--- a/device-types/Ubiquiti/WAVE-LR.yaml
+++ b/device-types/Ubiquiti/WAVE-LR.yaml
@@ -6,9 +6,8 @@ part_number: Wave-LR
 u_height: 0
 is_full_depth: false
 comments: The eth0 and prs0 are permanently bridged as this is a L2 bridge device. [](https://dl.ui.com/ds/wave-lr_ds.pdf)
-weight:
-  - value: 5.7
-    unit: lb
+weight: 5.7
+weight_unit: lb
 interfaces:
   - name: br0
     type: bridge

--- a/device-types/Zyxel/VMG1312-B10A.yaml
+++ b/device-types/Zyxel/VMG1312-B10A.yaml
@@ -4,9 +4,8 @@ model: VMG1312-B10A
 slug: zyxel-vmg1312-B10A
 part_number: '402444'
 u_height: 0
-weight:
-  - value: 245
-    unit: g
+weight: 245
+weight_unit: g
 is_full_depth: false
 airflow: passive
 comments: '[VMG1312-B series specs](https://service-provider.zyxel.com/global/en/products/dsl-cpe/vdsl/modemresidential-gateways/vmg1312-b-series)'

--- a/schema/components.json
+++ b/schema/components.json
@@ -600,27 +600,6 @@
                 }
             },
             "required": ["name"]
-        },
-
-        "weight": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "number",
-                    "minimum": 0,
-                    "multipleOf": 0.01
-                },
-                "unit": {
-                    "type": "string",
-                    "enum": [
-                        "kg",
-                        "g",
-                        "lb",
-                        "oz"
-                    ]
-                }
-            },
-            "required": ["value", "unit"]
         }
 
     }

--- a/schema/devicetype.json
+++ b/schema/devicetype.json
@@ -34,11 +34,18 @@
             ]
         },
         "weight": {
-            "type": "array",
-            "items": {
-                "$ref": "components.json#/definitions/weight"
-            },
-            "maxItems": 1
+            "type": "number",
+            "minimum": 0,
+            "multipleOf": 0.01
+        },
+        "weight_unit": {
+            "type": "string",
+            "enum": [
+                "kg",
+                "g",
+                "lb",
+                "oz"
+            ]
         },
         "subdevice_role": {
             "type": "string",

--- a/schema/moduletype.json
+++ b/schema/moduletype.json
@@ -10,6 +10,20 @@
         "part_number": {
             "type": "string"
         },
+        "weight": {
+            "type": "number",
+            "minimum": 0,
+            "multipleOf": 0.01
+        },
+        "weight_unit": {
+            "type": "string",
+            "enum": [
+                "kg",
+                "g",
+                "lb",
+                "oz"
+            ]
+        },
         "console-ports": {
             "type": "array",
             "items": {
@@ -54,13 +68,6 @@
         },
         "comments": {
             "type": "string"
-        },
-        "weight": {
-            "type": "array",
-            "items": {
-                "$ref": "components.json#/definitions/weight"
-            },
-            "maxItems": 1
         }
     },
     "required": ["manufacturer", "model"],


### PR DESCRIPTION
Please see [this discussion](https://github.com/netbox-community/Device-Type-Library-Import/discussions/80#discussioncomment-5254430) in regards to why this is necessary. 

The NetBox API requires weight to be modelled in the following format:
```
weight: 12.01
weight_unit: lb
```

This PR will migrate all current weight definitions to the supported format, and will also fix the test cases.