### PR TITLE
Remove type2-ieee802.3az

### DIFF
--- a/device-types/Datto/DSW100-24P-4X.yaml
+++ b/device-types/Datto/DSW100-24P-4X.yaml
@@ -17,99 +17,99 @@ interfaces:
   - name: Port 1
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 2
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 3
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 4
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 5
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 6
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 7
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 8
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 9
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 10
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 11
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 12
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 13
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 14
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 15
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 16
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 17
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 18
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 19
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 20
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 21
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 22
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 23
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 24
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: SFP 1
     type: 10gbase-x-sfpp
   - name: SFP 2

--- a/device-types/Datto/DSW100-84P-4X.yaml
+++ b/device-types/Datto/DSW100-84P-4X.yaml
@@ -17,195 +17,195 @@ interfaces:
   - name: Port 1
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 2
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 3
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 4
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 5
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 6
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 7
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 8
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 9
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 10
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 11
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 12
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 13
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 14
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 15
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 16
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 17
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 18
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 19
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 20
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 21
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 22
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 23
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 24
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 25
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 26
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 27
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 28
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 29
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 30
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 31
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 32
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 33
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 34
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 35
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 36
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 37
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 38
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 39
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 40
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 41
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 42
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 43
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 44
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 45
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 46
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 47
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 48
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: SFP 1
     type: 10gbase-x-sfpp
   - name: SFP 2

--- a/device-types/Datto/DSW100-8P-2G.yaml
+++ b/device-types/Datto/DSW100-8P-2G.yaml
@@ -17,35 +17,35 @@ interfaces:
   - name: Port 1
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 2
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 3
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 4
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 5
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 6
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 7
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 8
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: SFP 1
     type: 1000base-x-sfp
   - name: SFP 2

--- a/device-types/Datto/DSW250-8P-2X.yaml
+++ b/device-types/Datto/DSW250-8P-2X.yaml
@@ -17,35 +17,35 @@ interfaces:
   - name: Port 1
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 2
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 3
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 4
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 5
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 6
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 7
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: Port 8
     type: 1000base-t
     poe_mode: pse
-    poe_type: type2-ieee802.3az
+    poe_type: type2-ieee802.3at
   - name: SFP 1
     type: 10gbase-x-sfpp
   - name: SFP 2

--- a/schema/components.json
+++ b/schema/components.json
@@ -413,7 +413,6 @@
                     "enum": [
                         "type1-ieee802.3af",
                         "type2-ieee802.3at",
-                        "type2-ieee802.3az",
                         "type3-ieee802.3bt",
                         "type4-ieee802.3bt",
                         "passive-24v-2pair",


### PR DESCRIPTION
As per my conversation with Braden McGrath, type2-ieee802.3az isnt a poe standard, but rather a type of energy efficent ethernet - thus these devices are type2-ieee802.3at based on the poe rating