### PR TITLE
Adding Intel NUC Model NUC11TNHi5 (Used for network monitoring)

### DIFF
--- a/device-types/Intel/NUC11TNHi5.yaml
+++ b/device-types/Intel/NUC11TNHi5.yaml
@@ -12,6 +12,5 @@ interfaces:
   - name: eth0
     type: 2.5gbase-t
 power-ports:
-  - name: 12VDC (Barrel Jack)
+  - name: PSU1
     type: dc-terminal
-    maximum_draw: 120

--- a/device-types/Intel/NUC11TNHi5.yaml
+++ b/device-types/Intel/NUC11TNHi5.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Intel
+model: NUC11TNBi5
+slug: intel-nuc11tnbi5
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 0.64
+weight_unit: kg
+comments: '[NUC11TNBi5 Data Sheet on intel.com](https://ark.intel.com/content/www/us/en/ark/products/205594/intel-nuc-11-pro-kit-nuc11tnhi5.html)'
+interfaces:
+  - name: eth0
+    type: 2.5gbase-t
+power-ports:
+  - name: 12VDC (Barrel Jack)
+    type: dc-terminal
+    maximum_draw: 120


### PR DESCRIPTION
Adding the Intel NUC device - used for network monitoring