### PR TITLE
Add Generic SC 12 double port fiber patch panel

### DIFF
--- a/device-types/Generic/SC-12-double-port_fiber_patch_panel.yaml
+++ b/device-types/Generic/SC-12-double-port_fiber_patch_panel.yaml
@@ -1,0 +1,177 @@
+---
+manufacturer: Generic
+model: SC-12-double-port Fiber Patch Panel
+slug: sc-12-double-port-fiber-patch-panel
+u_height: 1
+is_full_depth: true
+airflow: passive
+front-ports:
+  - name: '1.1'
+    type: sc
+    rear_port: '1.1'
+    rear_port_position: 1
+  - name: '2.1'
+    type: sc
+    rear_port: '2.1'
+    rear_port_position: 1
+  - name: '3.1'
+    type: sc
+    rear_port: '3.1'
+    rear_port_position: 1
+  - name: '4.1'
+    type: sc
+    rear_port: '4.1'
+    rear_port_position: 1
+  - name: '5.1'
+    type: sc
+    rear_port: '5.1'
+    rear_port_position: 1
+  - name: '6.1'
+    type: sc
+    rear_port: '6.1'
+    rear_port_position: 1
+  - name: '7.1'
+    type: sc
+    rear_port: '7.1'
+    rear_port_position: 1
+  - name: '8.1'
+    type: sc
+    rear_port: '8.1'
+    rear_port_position: 1
+  - name: '9.1'
+    type: sc
+    rear_port: '9.1'
+    rear_port_position: 1
+  - name: '10.1'
+    type: sc
+    rear_port: '10.1'
+    rear_port_position: 1
+  - name: '11.1'
+    type: sc
+    rear_port: '11.1'
+    rear_port_position: 1
+  - name: '12.1'
+    type: sc
+    rear_port: '12.1'
+    rear_port_position: 1
+  - name: '1.2'
+    type: sc
+    rear_port: '1.2'
+    rear_port_position: 1
+  - name: '2.2'
+    type: sc
+    rear_port: '2.2'
+    rear_port_position: 1
+  - name: '3.2'
+    type: sc
+    rear_port: '3.2'
+    rear_port_position: 1
+  - name: '4.2'
+    type: sc
+    rear_port: '4.2'
+    rear_port_position: 1
+  - name: '5.2'
+    type: sc
+    rear_port: '5.2'
+    rear_port_position: 1
+  - name: '6.2'
+    type: sc
+    rear_port: '6.2'
+    rear_port_position: 1
+  - name: '7.2'
+    type: sc
+    rear_port: '7.2'
+    rear_port_position: 1
+  - name: '8.2'
+    type: sc
+    rear_port: '8.2'
+    rear_port_position: 1
+  - name: '9.2'
+    type: sc
+    rear_port: '9.2'
+    rear_port_position: 1
+  - name: '10.2'
+    type: sc
+    rear_port: '10.2'
+    rear_port_position: 1
+  - name: '11.2'
+    type: sc
+    rear_port: '11.2'
+    rear_port_position: 1
+  - name: '12.2'
+    type: sc
+    rear_port: '12.2'
+    rear_port_position: 1
+rear-ports:
+  - name: '1.1'
+    type: sc
+    positions: 1
+  - name: '2.1'
+    type: sc
+    positions: 1
+  - name: '3.1'
+    type: sc
+    positions: 1
+  - name: '4.1'
+    type: sc
+    positions: 1
+  - name: '5.1'
+    type: sc
+    positions: 1
+  - name: '6.1'
+    type: sc
+    positions: 1
+  - name: '7.1'
+    type: sc
+    positions: 1
+  - name: '8.1'
+    type: sc
+    positions: 1
+  - name: '9.1'
+    type: sc
+    positions: 1
+  - name: '10.1'
+    type: sc
+    positions: 1
+  - name: '11.1'
+    type: sc
+    positions: 1
+  - name: '12.1'
+    type: sc
+    positions: 1
+  - name: '1.2'
+    type: sc
+    positions: 1
+  - name: '2.2'
+    type: sc
+    positions: 1
+  - name: '3.2'
+    type: sc
+    positions: 1
+  - name: '4.2'
+    type: sc
+    positions: 1
+  - name: '5.2'
+    type: sc
+    positions: 1
+  - name: '6.2'
+    type: sc
+    positions: 1
+  - name: '7.2'
+    type: sc
+    positions: 1
+  - name: '8.2'
+    type: sc
+    positions: 1
+  - name: '9.2'
+    type: sc
+    positions: 1
+  - name: '10.2'
+    type: sc
+    positions: 1
+  - name: '11.2'
+    type: sc
+    positions: 1
+  - name: '12.2'
+    type: sc
+    positions: 1


### PR DESCRIPTION
Adding a 12 double port version of this fiber patch panel so we don't have to delete 12 ports on every patch panel we create