### PR TITLE
Palo Alto PA-5450 Power Supply (PAN-PWR-2200W-AC)

### DIFF
--- a/module-types/Palo Alto/PAN-PWR-2200W-AC.yaml
+++ b/module-types/Palo Alto/PAN-PWR-2200W-AC.yaml
@@ -5,6 +5,6 @@ part_number: PAN-PWR-2200W-AC
 power-ports:
   - name: PS{module}
     type: iec-60320-c14
-    maximum_draw: 60
-    allocated_draw: 48
+    maximum_draw: 2200
+    allocated_draw: 777
     label: PS{module}

--- a/module-types/Palo Alto/PAN-PWR-2200W-AC.yaml
+++ b/module-types/Palo Alto/PAN-PWR-2200W-AC.yaml
@@ -1,0 +1,10 @@
+---
+manufacturer: Palo Alto
+model: PAN-PWR-2200W-AC
+part_number: PAN-PWR-2200W-AC
+power-ports:
+  - name: PS{module}
+    type: iec-60320-c14
+    maximum_draw: 60
+    allocated_draw: 48
+    label: PS{module}


### PR DESCRIPTION
This is the power supply for the Palo Alto PA-5450