### PR TITLE
Add Juniper EX4100 device types modified from EX3400 models

### DIFF
--- a/device-types/Juniper/EX4100-24P.yaml
+++ b/device-types/Juniper/EX4100-24P.yaml
@@ -73,13 +73,13 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: Power Supply 0
-    position: 0
+    position: '0'
   - name: Power Supply 1
-    position: 1
+    position: '1'
   - name: Fan tray 0
-    position: 0
+    position: '0'
   - name: Fan tray 1
-    position: 1
+    position: '1'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Juniper/EX4100-24P.yaml
+++ b/device-types/Juniper/EX4100-24P.yaml
@@ -71,13 +71,15 @@ interfaces:
   - name: me0
     type: 1000base-t
     mgmt_only: true
-power-ports:
-  - name: PSU0
-    type: iec-60320-c14
-    maximum_draw: 920
-  - name: PSU1
-    type: iec-60320-c14
-    maximum_draw: 920
+module-bays:
+  - name: Power Supply 0
+    position: 0
+  - name: Power Supply 1
+    position: 1
+  - name: Fan tray 0
+    position: 0
+  - name: Fan tray 1
+    position: 1
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Juniper/EX4100-24P.yaml
+++ b/device-types/Juniper/EX4100-24P.yaml
@@ -1,0 +1,85 @@
+---
+manufacturer: Juniper
+model: EX4100-24P
+slug: ex4100-24p
+u_height: 1
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/0/4
+    type: 1000base-t
+  - name: ge-0/0/5
+    type: 1000base-t
+  - name: ge-0/0/6
+    type: 1000base-t
+  - name: ge-0/0/7
+    type: 1000base-t
+  - name: ge-0/0/8
+    type: 1000base-t
+  - name: ge-0/0/9
+    type: 1000base-t
+  - name: ge-0/0/10
+    type: 1000base-t
+  - name: ge-0/0/11
+    type: 1000base-t
+  - name: ge-0/0/12
+    type: 1000base-t
+  - name: ge-0/0/13
+    type: 1000base-t
+  - name: ge-0/0/14
+    type: 1000base-t
+  - name: ge-0/0/15
+    type: 1000base-t
+  - name: ge-0/0/16
+    type: 1000base-t
+  - name: ge-0/0/17
+    type: 1000base-t
+  - name: ge-0/0/18
+    type: 1000base-t
+  - name: ge-0/0/19
+    type: 1000base-t
+  - name: ge-0/0/20
+    type: 1000base-t
+  - name: ge-0/0/21
+    type: 1000base-t
+  - name: ge-0/0/22
+    type: 1000base-t
+  - name: ge-0/0/23
+    type: 1000base-t
+  - name: et-0/1/0
+    type: 25gbase-x-sfp28
+  - name: et-0/1/1
+    type: 25gbase-x-sfp28
+  - name: et-0/1/1
+    type: 25gbase-x-sfp28
+  - name: et-0/1/2
+    type: 25gbase-x-sfp28
+  - name: xe-0/2/0
+    type: 1000base-x-sfp
+  - name: xe-0/2/1
+    type: 1000base-x-sfp
+  - name: xe-0/2/2
+    type: 10gbase-x-sfpp
+  - name: xe-0/2/3
+    type: 10gbase-x-sfpp
+  - name: me0
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 920
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 920
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console (USB)
+    type: usb-c

--- a/device-types/Juniper/EX4100-24P.yaml
+++ b/device-types/Juniper/EX4100-24P.yaml
@@ -56,9 +56,9 @@ interfaces:
     type: 25gbase-x-sfp28
   - name: et-0/1/1
     type: 25gbase-x-sfp28
-  - name: et-0/1/1
-    type: 25gbase-x-sfp28
   - name: et-0/1/2
+    type: 25gbase-x-sfp28
+  - name: et-0/1/3
     type: 25gbase-x-sfp28
   - name: xe-0/2/0
     type: 1000base-x-sfp

--- a/device-types/Juniper/EX4100-24P.yaml
+++ b/device-types/Juniper/EX4100-24P.yaml
@@ -3,6 +3,11 @@ manufacturer: Juniper
 model: EX4100-24P
 slug: ex4100-24p
 u_height: 1
+part_number: EX4100-24P
+is_full_depth: false
+airflow: front-to-rear
+weight: 10
+weight_unit: lb
 interfaces:
   - name: ge-0/0/0
     type: 1000base-t

--- a/device-types/Juniper/EX4100-24P.yaml
+++ b/device-types/Juniper/EX4100-24P.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Juniper
 model: EX4100-24P
-slug: ex4100-24p
+slug: juniper-ex4100-24p
 u_height: 1
 part_number: EX4100-24P
 is_full_depth: false

--- a/device-types/Juniper/EX4100-24T.yaml
+++ b/device-types/Juniper/EX4100-24T.yaml
@@ -71,13 +71,15 @@ interfaces:
   - name: me0
     type: 1000base-t
     mgmt_only: true
-power-ports:
-  - name: PSU0
-    type: iec-60320-c14
-    maximum_draw: 150
-  - name: PSU1
-    type: iec-60320-c14
-    maximum_draw: 150
+module-bays:
+  - name: Power Supply 0
+    position: 0
+  - name: Power Supply 1
+    position: 1
+  - name: Fan tray 0
+    position: 0
+  - name: Fan tray 1
+    position: 1
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Juniper/EX4100-24T.yaml
+++ b/device-types/Juniper/EX4100-24T.yaml
@@ -1,0 +1,85 @@
+---
+manufacturer: Juniper
+model: EX4100-24T
+slug: ex4100-24t
+u_height: 1
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/0/4
+    type: 1000base-t
+  - name: ge-0/0/5
+    type: 1000base-t
+  - name: ge-0/0/6
+    type: 1000base-t
+  - name: ge-0/0/7
+    type: 1000base-t
+  - name: ge-0/0/8
+    type: 1000base-t
+  - name: ge-0/0/9
+    type: 1000base-t
+  - name: ge-0/0/10
+    type: 1000base-t
+  - name: ge-0/0/11
+    type: 1000base-t
+  - name: ge-0/0/12
+    type: 1000base-t
+  - name: ge-0/0/13
+    type: 1000base-t
+  - name: ge-0/0/14
+    type: 1000base-t
+  - name: ge-0/0/15
+    type: 1000base-t
+  - name: ge-0/0/16
+    type: 1000base-t
+  - name: ge-0/0/17
+    type: 1000base-t
+  - name: ge-0/0/18
+    type: 1000base-t
+  - name: ge-0/0/19
+    type: 1000base-t
+  - name: ge-0/0/20
+    type: 1000base-t
+  - name: ge-0/0/21
+    type: 1000base-t
+  - name: ge-0/0/22
+    type: 1000base-t
+  - name: ge-0/0/23
+    type: 1000base-t
+  - name: et-0/1/0
+    type: 25gbase-x-sfp28
+  - name: et-0/1/1
+    type: 25gbase-x-sfp28
+  - name: et-0/1/1
+    type: 25gbase-x-sfp28
+  - name: et-0/1/2
+    type: 25gbase-x-sfp28
+  - name: xe-0/2/0
+    type: 1000base-x-sfp
+  - name: xe-0/2/1
+    type: 1000base-x-sfp
+  - name: xe-0/2/2
+    type: 10gbase-x-sfpp
+  - name: xe-0/2/3
+    type: 10gbase-x-sfpp
+  - name: me0
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 150
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console (USB)
+    type: usb-c

--- a/device-types/Juniper/EX4100-24T.yaml
+++ b/device-types/Juniper/EX4100-24T.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Juniper
 model: EX4100-24T
-slug: ex4100-24t
+slug: juniper-ex4100-24t
 u_height: 1
 part_number: EX4100-24T
 is_full_depth: false

--- a/device-types/Juniper/EX4100-24T.yaml
+++ b/device-types/Juniper/EX4100-24T.yaml
@@ -73,13 +73,13 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: Power Supply 0
-    position: 0
+    position: '0'
   - name: Power Supply 1
-    position: 1
+    position: '1'
   - name: Fan tray 0
-    position: 0
+    position: '0'
   - name: Fan tray 1
-    position: 1
+    position: '1'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Juniper/EX4100-24T.yaml
+++ b/device-types/Juniper/EX4100-24T.yaml
@@ -3,6 +3,11 @@ manufacturer: Juniper
 model: EX4100-24T
 slug: ex4100-24t
 u_height: 1
+part_number: EX4100-24T
+is_full_depth: false
+airflow: front-to-rear
+weight: 9.72
+weight_unit: lb
 interfaces:
   - name: ge-0/0/0
     type: 1000base-t

--- a/device-types/Juniper/EX4100-24T.yaml
+++ b/device-types/Juniper/EX4100-24T.yaml
@@ -56,9 +56,9 @@ interfaces:
     type: 25gbase-x-sfp28
   - name: et-0/1/1
     type: 25gbase-x-sfp28
-  - name: et-0/1/1
-    type: 25gbase-x-sfp28
   - name: et-0/1/2
+    type: 25gbase-x-sfp28
+  - name: et-0/1/3
     type: 25gbase-x-sfp28
   - name: xe-0/2/0
     type: 1000base-x-sfp

--- a/device-types/Juniper/EX4100-48P.yaml
+++ b/device-types/Juniper/EX4100-48P.yaml
@@ -1,0 +1,133 @@
+---
+manufacturer: Juniper
+model: EX4100-48P
+slug: ex4100-48p
+u_height: 1
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/0/4
+    type: 1000base-t
+  - name: ge-0/0/5
+    type: 1000base-t
+  - name: ge-0/0/6
+    type: 1000base-t
+  - name: ge-0/0/7
+    type: 1000base-t
+  - name: ge-0/0/8
+    type: 1000base-t
+  - name: ge-0/0/9
+    type: 1000base-t
+  - name: ge-0/0/10
+    type: 1000base-t
+  - name: ge-0/0/11
+    type: 1000base-t
+  - name: ge-0/0/12
+    type: 1000base-t
+  - name: ge-0/0/13
+    type: 1000base-t
+  - name: ge-0/0/14
+    type: 1000base-t
+  - name: ge-0/0/15
+    type: 1000base-t
+  - name: ge-0/0/16
+    type: 1000base-t
+  - name: ge-0/0/17
+    type: 1000base-t
+  - name: ge-0/0/18
+    type: 1000base-t
+  - name: ge-0/0/19
+    type: 1000base-t
+  - name: ge-0/0/20
+    type: 1000base-t
+  - name: ge-0/0/21
+    type: 1000base-t
+  - name: ge-0/0/22
+    type: 1000base-t
+  - name: ge-0/0/23
+    type: 1000base-t
+  - name: ge-0/0/24
+    type: 1000base-t
+  - name: ge-0/0/25
+    type: 1000base-t
+  - name: ge-0/0/26
+    type: 1000base-t
+  - name: ge-0/0/27
+    type: 1000base-t
+  - name: ge-0/0/28
+    type: 1000base-t
+  - name: ge-0/0/29
+    type: 1000base-t
+  - name: ge-0/0/30
+    type: 1000base-t
+  - name: ge-0/0/31
+    type: 1000base-t
+  - name: ge-0/0/32
+    type: 1000base-t
+  - name: ge-0/0/33
+    type: 1000base-t
+  - name: ge-0/0/34
+    type: 1000base-t
+  - name: ge-0/0/35
+    type: 1000base-t
+  - name: ge-0/0/36
+    type: 1000base-t
+  - name: ge-0/0/37
+    type: 1000base-t
+  - name: ge-0/0/38
+    type: 1000base-t
+  - name: ge-0/0/39
+    type: 1000base-t
+  - name: ge-0/0/40
+    type: 1000base-t
+  - name: ge-0/0/41
+    type: 1000base-t
+  - name: ge-0/0/42
+    type: 1000base-t
+  - name: ge-0/0/43
+    type: 1000base-t
+  - name: ge-0/0/44
+    type: 1000base-t
+  - name: ge-0/0/45
+    type: 1000base-t
+  - name: ge-0/0/46
+    type: 1000base-t
+  - name: ge-0/0/47
+    type: 1000base-t
+  - name: et-0/1/0
+    type: 25gbase-x-sfp28
+  - name: et-0/1/1
+    type: 25gbase-x-sfp28
+  - name: et-0/1/1
+    type: 25gbase-x-sfp28
+  - name: et-0/1/2
+    type: 25gbase-x-sfp28
+  - name: xe-0/2/0
+    type: 1000base-x-sfp
+  - name: xe-0/2/1
+    type: 1000base-x-sfp
+  - name: xe-0/2/2
+    type: 10gbase-x-sfpp
+  - name: xe-0/2/3
+    type: 10gbase-x-sfpp
+  - name: me0
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 920
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 920
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console (USB)
+    type: usb-c

--- a/device-types/Juniper/EX4100-48P.yaml
+++ b/device-types/Juniper/EX4100-48P.yaml
@@ -119,13 +119,15 @@ interfaces:
   - name: me0
     type: 1000base-t
     mgmt_only: true
-power-ports:
-  - name: PSU0
-    type: iec-60320-c14
-    maximum_draw: 920
-  - name: PSU1
-    type: iec-60320-c14
-    maximum_draw: 920
+module-bays:
+  - name: Power Supply 0
+    position: 0
+  - name: Power Supply 1
+    position: 1
+  - name: Fan tray 0
+    position: 0
+  - name: Fan tray 1
+    position: 1
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Juniper/EX4100-48P.yaml
+++ b/device-types/Juniper/EX4100-48P.yaml
@@ -121,13 +121,13 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: Power Supply 0
-    position: 0
+    position: '0'
   - name: Power Supply 1
-    position: 1
+    position: '1'
   - name: Fan tray 0
-    position: 0
+    position: '0'
   - name: Fan tray 1
-    position: 1
+    position: '1'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Juniper/EX4100-48P.yaml
+++ b/device-types/Juniper/EX4100-48P.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Juniper
 model: EX4100-48P
-slug: ex4100-48p
+slug: juniper-ex4100-48p
 u_height: 1
 part_number: EX4100-48P
 is_full_depth: false

--- a/device-types/Juniper/EX4100-48P.yaml
+++ b/device-types/Juniper/EX4100-48P.yaml
@@ -104,9 +104,9 @@ interfaces:
     type: 25gbase-x-sfp28
   - name: et-0/1/1
     type: 25gbase-x-sfp28
-  - name: et-0/1/1
-    type: 25gbase-x-sfp28
   - name: et-0/1/2
+    type: 25gbase-x-sfp28
+  - name: et-0/1/3
     type: 25gbase-x-sfp28
   - name: xe-0/2/0
     type: 1000base-x-sfp

--- a/device-types/Juniper/EX4100-48P.yaml
+++ b/device-types/Juniper/EX4100-48P.yaml
@@ -3,6 +3,11 @@ manufacturer: Juniper
 model: EX4100-48P
 slug: ex4100-48p
 u_height: 1
+part_number: EX4100-48P
+is_full_depth: false
+airflow: front-to-rear
+weight: 10.27
+weight_unit: lb
 interfaces:
   - name: ge-0/0/0
     type: 1000base-t

--- a/device-types/Juniper/EX4100-48T.yaml
+++ b/device-types/Juniper/EX4100-48T.yaml
@@ -1,0 +1,133 @@
+---
+manufacturer: Juniper
+model: EX4100-48T
+slug: ex4100-48t
+u_height: 1
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/0/4
+    type: 1000base-t
+  - name: ge-0/0/5
+    type: 1000base-t
+  - name: ge-0/0/6
+    type: 1000base-t
+  - name: ge-0/0/7
+    type: 1000base-t
+  - name: ge-0/0/8
+    type: 1000base-t
+  - name: ge-0/0/9
+    type: 1000base-t
+  - name: ge-0/0/10
+    type: 1000base-t
+  - name: ge-0/0/11
+    type: 1000base-t
+  - name: ge-0/0/12
+    type: 1000base-t
+  - name: ge-0/0/13
+    type: 1000base-t
+  - name: ge-0/0/14
+    type: 1000base-t
+  - name: ge-0/0/15
+    type: 1000base-t
+  - name: ge-0/0/16
+    type: 1000base-t
+  - name: ge-0/0/17
+    type: 1000base-t
+  - name: ge-0/0/18
+    type: 1000base-t
+  - name: ge-0/0/19
+    type: 1000base-t
+  - name: ge-0/0/20
+    type: 1000base-t
+  - name: ge-0/0/21
+    type: 1000base-t
+  - name: ge-0/0/22
+    type: 1000base-t
+  - name: ge-0/0/23
+    type: 1000base-t
+  - name: ge-0/0/24
+    type: 1000base-t
+  - name: ge-0/0/25
+    type: 1000base-t
+  - name: ge-0/0/26
+    type: 1000base-t
+  - name: ge-0/0/27
+    type: 1000base-t
+  - name: ge-0/0/28
+    type: 1000base-t
+  - name: ge-0/0/29
+    type: 1000base-t
+  - name: ge-0/0/30
+    type: 1000base-t
+  - name: ge-0/0/31
+    type: 1000base-t
+  - name: ge-0/0/32
+    type: 1000base-t
+  - name: ge-0/0/33
+    type: 1000base-t
+  - name: ge-0/0/34
+    type: 1000base-t
+  - name: ge-0/0/35
+    type: 1000base-t
+  - name: ge-0/0/36
+    type: 1000base-t
+  - name: ge-0/0/37
+    type: 1000base-t
+  - name: ge-0/0/38
+    type: 1000base-t
+  - name: ge-0/0/39
+    type: 1000base-t
+  - name: ge-0/0/40
+    type: 1000base-t
+  - name: ge-0/0/41
+    type: 1000base-t
+  - name: ge-0/0/42
+    type: 1000base-t
+  - name: ge-0/0/43
+    type: 1000base-t
+  - name: ge-0/0/44
+    type: 1000base-t
+  - name: ge-0/0/45
+    type: 1000base-t
+  - name: ge-0/0/46
+    type: 1000base-t
+  - name: ge-0/0/47
+    type: 1000base-t
+  - name: et-0/1/0
+    type: 25gbase-x-sfp28
+  - name: et-0/1/1
+    type: 25gbase-x-sfp28
+  - name: et-0/1/1
+    type: 25gbase-x-sfp28
+  - name: et-0/1/2
+    type: 25gbase-x-sfp28
+  - name: xe-0/2/0
+    type: 1000base-x-sfp
+  - name: xe-0/2/1
+    type: 1000base-x-sfp
+  - name: xe-0/2/2
+    type: 10gbase-x-sfpp
+  - name: xe-0/2/3
+    type: 10gbase-x-sfpp
+  - name: me0
+    type: 1000base-t
+    mgmt_only: true
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 150
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 150
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console (USB)
+    type: usb-c

--- a/device-types/Juniper/EX4100-48T.yaml
+++ b/device-types/Juniper/EX4100-48T.yaml
@@ -121,13 +121,13 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: Power Supply 0
-    position: 0
+    position: '0'
   - name: Power Supply 1
-    position: 1
+    position: '1'
   - name: Fan tray 0
-    position: 0
+    position: '0'
   - name: Fan tray 1
-    position: 1
+    position: '1'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Juniper/EX4100-48T.yaml
+++ b/device-types/Juniper/EX4100-48T.yaml
@@ -104,9 +104,9 @@ interfaces:
     type: 25gbase-x-sfp28
   - name: et-0/1/1
     type: 25gbase-x-sfp28
-  - name: et-0/1/1
-    type: 25gbase-x-sfp28
   - name: et-0/1/2
+    type: 25gbase-x-sfp28
+  - name: et-0/1/3
     type: 25gbase-x-sfp28
   - name: xe-0/2/0
     type: 1000base-x-sfp

--- a/device-types/Juniper/EX4100-48T.yaml
+++ b/device-types/Juniper/EX4100-48T.yaml
@@ -119,13 +119,15 @@ interfaces:
   - name: me0
     type: 1000base-t
     mgmt_only: true
-power-ports:
-  - name: PSU0
-    type: iec-60320-c14
-    maximum_draw: 150
-  - name: PSU1
-    type: iec-60320-c14
-    maximum_draw: 150
+module-bays:
+  - name: Power Supply 0
+    position: 0
+  - name: Power Supply 1
+    position: 1
+  - name: Fan tray 0
+    position: 0
+  - name: Fan tray 1
+    position: 1
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Juniper/EX4100-48T.yaml
+++ b/device-types/Juniper/EX4100-48T.yaml
@@ -1,8 +1,13 @@
 ---
 manufacturer: Juniper
 model: EX4100-48T
-slug: ex4100-48t
+slug: juniper-ex4100-48t
 u_height: 1
+part_number: EX4100-48T
+is_full_depth: false
+airflow: front-to-rear
+weight: 10
+weight_unit: lb
 interfaces:
   - name: ge-0/0/0
     type: 1000base-t

--- a/module-types/Juniper/ex4100-fan-afi.yaml
+++ b/module-types/Juniper/ex4100-fan-afi.yaml
@@ -1,0 +1,7 @@
+---
+manufacturer: Juniper
+model: EX4100-FAN-AFI
+comments: |
+  fan with back-to-front airflow
+
+  [Juniper EX4100 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/switches/ex4100-line-of-ethernet-switches-datasheet.pdf)

--- a/module-types/Juniper/ex4100-fan-afo.yaml
+++ b/module-types/Juniper/ex4100-fan-afo.yaml
@@ -1,0 +1,8 @@
+---
+manufacturer: Juniper
+model: EX4100-FAN-AFO
+part_number: 660-156849
+comments: |
+  fan with front-to-back airflow
+
+  [Juniper EX4100 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/switches/ex4100-line-of-ethernet-switches-datasheet.pdf)

--- a/module-types/Juniper/jpsu-150-ac-afi.yaml
+++ b/module-types/Juniper/jpsu-150-ac-afi.yaml
@@ -1,0 +1,16 @@
+---
+manufacturer: Juniper
+model: JPSU-150-AC-AFI
+part_number: 640-060604
+comments: |
+  EX Series 150 W AC power supply (back-to-front airflow)
+
+  Compatible with
+  * EX3400 non-PoE models
+  * EX4100 non-PoE models
+
+  [Juniper EX4100 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/switches/ex4100-line-of-ethernet-switches-datasheet.pdf)
+power-ports:
+  - name: Power Supply {module}
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/module-types/Juniper/jpsu-150-ac-afo.yaml
+++ b/module-types/Juniper/jpsu-150-ac-afo.yaml
@@ -1,0 +1,16 @@
+---
+manufacturer: Juniper
+model: JPSU-150-AC-AFO
+part_number: 640-060603
+comments: |
+  EX Series 150 W AC power supply (front-to-back airflow)
+
+  Compatible with
+  * EX3400 non-PoE models
+  * EX4100 non-PoE models
+
+  [Juniper EX4100 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/switches/ex4100-line-of-ethernet-switches-datasheet.pdf)
+power-ports:
+  - name: Power Supply {module}
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/module-types/Juniper/jpsu-150-dc-afo.yaml
+++ b/module-types/Juniper/jpsu-150-dc-afo.yaml
@@ -1,0 +1,16 @@
+---
+manufacturer: Juniper
+model: JPSU-150-DC-AFO
+part_number: 640-061542
+comments: |
+  EX Series 150 W DC power supply (front-to-back airflow)
+
+  Compatible with
+  * EX3400 non-PoE models
+  * EX4100 non-PoE models
+
+  [Juniper EX4100 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/switches/ex4100-line-of-ethernet-switches-datasheet.pdf)
+power-ports:
+  - name: Power Supply {module}
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/module-types/Juniper/jpsu-920-ac-afo.yaml
+++ b/module-types/Juniper/jpsu-920-ac-afo.yaml
@@ -1,0 +1,16 @@
+---
+manufacturer: Juniper
+model: JPSU-920-AC-AFO
+part_number: 640-060601
+comments: |
+  EX Series 920 W AC power supply (front-to-back airflow)
+
+  Compatible with
+  * EX3400 PoE models
+  * EX4100 PoE models
+
+  [Juniper EX4100 Data Sheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/switches/ex4100-line-of-ethernet-switches-datasheet.pdf)
+power-ports:
+  - name: Power Supply {module}
+    type: iec-60320-c14
+    maximum_draw: 920


### PR DESCRIPTION
These are based on the EX3400 device types.