### PR TITLE
Thales/SafeNet Network HSMs

### DIFF
--- a/device-types/Thales/K6.yaml
+++ b/device-types/Thales/K6.yaml
@@ -1,17 +1,15 @@
 ---
 manufacturer: Thales
-model: Luna-T7
-slug: thales-luna-t7
-part_number: 972-500080-001
+model: Luna K6
+slug: thales-luna-k6
+part_number: 808-000054-001
 u_height: 1
 is_full_depth: true
 airflow: front-to-rear
-weight: 28
-weight_unit: lb
-comments: Luna Network HSM T-2000
+comments: SafeNet Luna Network HSM K6
 console-ports:
   - name: Console
-    type: rj-45
+    type: de-9
 module-bays:
   - name: PSU1
     position: '1'
@@ -21,8 +19,4 @@ interfaces:
   - name: eth0
     type: 1000base-t
   - name: eth1
-    type: 1000base-t
-  - name: eth2
-    type: 1000base-t
-  - name: eth3
     type: 1000base-t

--- a/device-types/Thales/T2000.yaml
+++ b/device-types/Thales/T2000.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Thales
+model: Luna-T7
+slug: thales-luna-t7
+part_number: 972-500080-001
+u_height: 1
+is_full_depth: true
+weight: 28
+weight_unit: lb
+comments: Luna Network HSM T-2000
+console-ports:
+  - name: Console
+    type: rj-45
+module-bays:
+  - name: PSU1
+    position: '1'
+  - name: PSU2
+    position: '2'
+interfaces:
+  - name: eth0
+    type: 1000base-t
+  - name: eth1
+    type: 1000base-t
+  - name: eth2
+    type: 1000base-t
+  - name: eth3
+    type: 1000base-t

--- a/module-types/Thales/YM-2301E.yaml
+++ b/module-types/Thales/YM-2301E.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Thales
+model: YM-2301E
+part_number: YM-2301RA23R
+comments: Primarily used with Luna Network HSM T-2000
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c14
+    maximum_draw: 300

--- a/module-types/Thales/YM-2451C.yaml
+++ b/module-types/Thales/YM-2451C.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Thales
+model: YM-2451C
+part_number: YM-2451CA06R
+comments: Primarily used with SafeNet Luna Network HSM K6
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c14
+    maximum_draw: 450


### PR DESCRIPTION
Adding Thales/SafeNet/Gemalto Network HSMs and their PSUs
- Luna T7 (T2000)
- Luna K6