### PR TITLE
Update Cisco ASA 5500 series

### DIFF
--- a/device-types/Cisco/ASA5506-X.yaml
+++ b/device-types/Cisco/ASA5506-X.yaml
@@ -4,7 +4,7 @@ model: ASA5506-X
 slug: cisco-asa5506-x
 part_number: ASA5506
 u_height: 1
-is_full_depth: true
+is_full_depth: false
 console-ports:
   - name: Con 0
     type: rj-45

--- a/device-types/Cisco/ASA5508-X.yaml
+++ b/device-types/Cisco/ASA5508-X.yaml
@@ -4,7 +4,7 @@ model: ASA5508-X
 slug: cisco-asa5508-x
 part_number: ASA5508
 u_height: 1
-is_full_depth: true
+is_full_depth: false
 console-ports:
   - name: Con 0
     type: rj-45

--- a/device-types/Cisco/ASA5516-X.yaml
+++ b/device-types/Cisco/ASA5516-X.yaml
@@ -4,6 +4,7 @@ model: ASA5516-X
 slug: cisco-asa5516x-k8
 part_number: ASA5516X-K8
 u_height: 1
+is_full_depth: false
 console-ports:
   - name: Con 0
     type: rj-45

--- a/device-types/Cisco/ASA5525-X.yaml
+++ b/device-types/Cisco/ASA5525-X.yaml
@@ -4,7 +4,7 @@ model: ASA5525-X
 slug: cisco-asa5525-x
 part_number: ASA5525
 u_height: 1
-is_full_depth: true
+is_full_depth: false
 console-ports:
   - name: Con 0
     type: rj-45


### PR DESCRIPTION
I noticed several Cisco ASA 5500 Series boxes had the wrong `is_full_depth` value. I verified with [Cisco's website](https://www.cisco.com/c/en/us/products/collateral/security/asa-firepower-services/datasheet-c78-742475.html) and updated the values