### PR TITLE
Fix wrong amount of interfaces for FGT-60E

### DIFF
--- a/device-types/Fortinet/FG-60E.yaml
+++ b/device-types/Fortinet/FG-60E.yaml
@@ -5,14 +5,18 @@ slug: fg-60e
 part_number: FG-60E
 u_height: 1
 is_full_depth: false
+airflow: passive
+weight: 0.9
+weight_unit: kg
 console-ports:
   - name: Console
     type: rj-45
 power-ports:
   - name: PS1
-    type: nema-5-15p
+    type: dc-terminal
     maximum_draw: 14
     allocated_draw: 12
+    label: 12V DC
 interfaces:
   - name: dmz
     type: 1000base-t
@@ -29,8 +33,6 @@ interfaces:
   - name: internal6
     type: 1000base-t
   - name: internal7
-    type: 1000base-t
-  - name: internal8
     type: 1000base-t
   - name: wan1
     type: 1000base-t


### PR DESCRIPTION
According to the [spec sheet](https://www.allfirewalls.de/out/media/FG-60E_68a9f553ab0392c8e6347c8481b0cb13a4059ddc_FortiGate_FortiWiFi_60E_Series.pdf) the FGT-60E actually only has 7 internal ports (+3 DMZ/WAN Ports).

Additionally, the power port was given the wrong type. It is a DC terminal 12VDC port.