### PR TITLE
adds Intel XL710-QDA1 network card module

### DIFF
--- a/module-types/Intel/XL710-QDA1.yaml
+++ b/module-types/Intel/XL710-QDA1.yaml
@@ -1,0 +1,8 @@
+---
+manufacturer: Intel
+model: XL710-QDA1
+part_number: XL710-QDA1
+comments: '[Intel Ethernet Converged Network Adapter XL710-QDA1](https://www.intel.com/content/www/us/en/products/sku/83966/intel-ethernet-converged-network-adapter-xl710qda1/specifications.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 40gbase-x-qsfpp


### PR DESCRIPTION
Add module-type for the Intel XL710 network card.
Based on: https://github.com/netbox-community/devicetype-library/blob/master/module-types/Intel/XL710-QDA2.yaml