### PR TITLE
FS LGX fiber splitter modules

### DIFF
--- a/device-types/FS/FMU-1UFMX-N.yaml
+++ b/device-types/FS/FMU-1UFMX-N.yaml
@@ -2,11 +2,13 @@
 manufacturer: FS
 model: FMU-1UFMX-N
 slug: fs-fmu-1ufmx-n
-comments: FMU 2-Slot 1U Rack-Chassis
+comments: FMU 3-Slot 1U Rack-Chassis
 part_number: FMU-1UFMX-N
 u_height: 1
 is_full_depth: false
+airflow: passive
 subdevice_role: parent
 device-bays:
   - name: '1'
   - name: '2'
+  - name: '3'

--- a/module-types/FS/FLG-PLC1x16LGX1LCA.yaml
+++ b/module-types/FS/FLG-PLC1x16LGX1LCA.yaml
@@ -1,0 +1,92 @@
+---
+manufacturer: FS
+model: FLG-PLC1x16LGX1LCA
+part_number: FLG-PLC1x16LGX1LCA
+comments: 1 x 16 PLC Fiber Splitter, Standard LGX Cassette, LC/APC, Singlemode
+front-ports:
+  - name: '{module}/IN'
+    type: lc
+    rear_port: '{module}/IN'
+  - name: '{module}/1'
+    type: lc
+    rear_port: '{module}/1'
+  - name: '{module}/2'
+    type: lc
+    rear_port: '{module}/2'
+  - name: '{module}/3'
+    type: lc
+    rear_port: '{module}/3'
+  - name: '{module}/4'
+    type: lc
+    rear_port: '{module}/4'
+  - name: '{module}/5'
+    type: lc
+    rear_port: '{module}/5'
+  - name: '{module}/6'
+    type: lc
+    rear_port: '{module}/6'
+  - name: '{module}/7'
+    type: lc
+    rear_port: '{module}/7'
+  - name: '{module}/8'
+    type: lc
+    rear_port: '{module}/8'
+  - name: '{module}/9'
+    type: lc
+    rear_port: '{module}/9'
+  - name: '{module}/10'
+    type: lc
+    rear_port: '{module}/10'
+  - name: '{module}/11'
+    type: lc
+    rear_port: '{module}/11'
+  - name: '{module}/12'
+    type: lc
+    rear_port: '{module}/12'
+  - name: '{module}/13'
+    type: lc
+    rear_port: '{module}/13'
+  - name: '{module}/14'
+    type: lc
+    rear_port: '{module}/14'
+  - name: '{module}/15'
+    type: lc
+    rear_port: '{module}/15'
+  - name: '{module}/16'
+    type: lc
+    rear_port: '{module}/16'
+rear-ports:
+  - name: '{module}/IN'
+    type: lc
+  - name: '{module}/1'
+    type: lc
+  - name: '{module}/2'
+    type: lc
+  - name: '{module}/3'
+    type: lc
+  - name: '{module}/4'
+    type: lc
+  - name: '{module}/5'
+    type: lc
+  - name: '{module}/6'
+    type: lc
+  - name: '{module}/7'
+    type: lc
+  - name: '{module}/8'
+    type: lc
+  - name: '{module}/9'
+    type: lc
+  - name: '{module}/10'
+    type: lc
+  - name: '{module}/11'
+    type: lc
+  - name: '{module}/12'
+    type: lc
+  - name: '{module}/13'
+    type: lc
+  - name: '{module}/14'
+    type: lc
+  - name: '{module}/15'
+    type: lc
+  - name: '{module}/16'
+    type: lc

--- a/module-types/FS/FLG-PLC1x2LGX1LCA.yaml
+++ b/module-types/FS/FLG-PLC1x2LGX1LCA.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: FS
+model: FLG-PLC1x2LGX1LCA
+part_number: FLG-PLC1x2LGX1LCA
+comments: 1 x 2 PLC Fiber Splitter, Standard LGX Cassette, LC/APC, Singlemode
+front-ports:
+  - name: '{module}/IN'
+    type: lc
+    rear_port: '{module}/IN'
+  - name: '{module}/1'
+    type: lc
+    rear_port: '{module}/1'
+  - name: '{module}/2'
+    type: lc
+    rear_port: '{module}/2'
+rear-ports:
+  - name: '{module}/IN'
+    type: lc
+  - name: '{module}/1'
+    type: lc
+  - name: '{module}/2'
+    type: lc

--- a/module-types/FS/FLG-PLC1x2LGX1SCA.yaml
+++ b/module-types/FS/FLG-PLC1x2LGX1SCA.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: FS
+model: FLG-PLC1x2LGX1SCA
+part_number: FLG-PLC1x2LGX1SCA
+comments: 1 x 2 PLC Fiber Splitter, Standard LGX Cassette, SC/APC, Singlemode
+front-ports:
+  - name: '{module}/IN'
+    type: sc
+    rear_port: '{module}/IN'
+  - name: '{module}/1'
+    type: sc
+    rear_port: '{module}/1'
+  - name: '{module}/2'
+    type: sc
+    rear_port: '{module}/2'
+rear-ports:
+  - name: '{module}/IN'
+    type: sc
+  - name: '{module}/1'
+    type: sc
+  - name: '{module}/2'
+    type: sc

--- a/module-types/FS/FLG-PLC1x4LGX1LCA.yaml
+++ b/module-types/FS/FLG-PLC1x4LGX1LCA.yaml
@@ -1,0 +1,32 @@
+---
+manufacturer: FS
+model: FLG-PLC1x4LGX1LCA
+part_number: FLG-PLC1x4LGX1LCA
+comments: 1 x 4 PLC Fiber Splitter, Standard LGX Cassette, LC/APC, Singlemode
+front-ports:
+  - name: '{module}/IN'
+    type: lc
+    rear_port: '{module}/IN'
+  - name: '{module}/1'
+    type: lc
+    rear_port: '{module}/1'
+  - name: '{module}/2'
+    type: lc
+    rear_port: '{module}/2'
+  - name: '{module}/3'
+    type: lc
+    rear_port: '{module}/3'
+  - name: '{module}/4'
+    type: lc
+    rear_port: '{module}/4'
+rear-ports:
+  - name: '{module}/IN'
+    type: lc
+  - name: '{module}/1'
+    type: lc
+  - name: '{module}/2'
+    type: lc
+  - name: '{module}/3'
+    type: lc
+  - name: '{module}/4'
+    type: lc

--- a/module-types/FS/FLG-PLC1x4LGX1SCA.yaml
+++ b/module-types/FS/FLG-PLC1x4LGX1SCA.yaml
@@ -1,0 +1,32 @@
+---
+manufacturer: FS
+model: FLG-PLC1x4LGX1SCA
+part_number: FLG-PLC1x4LGX1SCA
+comments: 1 x 4 PLC Fiber Splitter, Standard LGX Cassette, SC/APC, Singlemode
+front-ports:
+  - name: '{module}/IN'
+    type: sc
+    rear_port: '{module}/IN'
+  - name: '{module}/1'
+    type: sc
+    rear_port: '{module}/1'
+  - name: '{module}/2'
+    type: sc
+    rear_port: '{module}/2'
+  - name: '{module}/3'
+    type: sc
+    rear_port: '{module}/3'
+  - name: '{module}/4'
+    type: sc
+    rear_port: '{module}/4'
+rear-ports:
+  - name: '{module}/IN'
+    type: sc
+  - name: '{module}/1'
+    type: sc
+  - name: '{module}/2'
+    type: sc
+  - name: '{module}/3'
+    type: sc
+  - name: '{module}/4'
+    type: sc

--- a/module-types/FS/FLG-PLC1x8LGX1LCA.yaml
+++ b/module-types/FS/FLG-PLC1x8LGX1LCA.yaml
@@ -1,0 +1,52 @@
+---
+manufacturer: FS
+model: FLG-PLC1x8LGX1LCA
+part_number: FLG-PLC1x8LGX1LCA
+comments: 1 x 8 PLC Fiber Splitter, Standard LGX Cassette, LC/APC, Singlemode
+front-ports:
+  - name: '{module}/IN'
+    type: lc
+    rear_port: '{module}/IN'
+  - name: '{module}/1'
+    type: lc
+    rear_port: '{module}/1'
+  - name: '{module}/2'
+    type: lc
+    rear_port: '{module}/2'
+  - name: '{module}/3'
+    type: lc
+    rear_port: '{module}/3'
+  - name: '{module}/4'
+    type: lc
+    rear_port: '{module}/4'
+  - name: '{module}/5'
+    type: lc
+    rear_port: '{module}/5'
+  - name: '{module}/6'
+    type: lc
+    rear_port: '{module}/6'
+  - name: '{module}/7'
+    type: lc
+    rear_port: '{module}/7'
+  - name: '{module}/8'
+    type: lc
+    rear_port: '{module}/8'
+rear-ports:
+  - name: '{module}/IN'
+    type: lc
+  - name: '{module}/1'
+    type: lc
+  - name: '{module}/2'
+    type: lc
+  - name: '{module}/3'
+    type: lc
+  - name: '{module}/4'
+    type: lc
+  - name: '{module}/5'
+    type: lc
+  - name: '{module}/6'
+    type: lc
+  - name: '{module}/7'
+    type: lc
+  - name: '{module}/8'
+    type: lc

--- a/module-types/FS/FLG-PLC1x8LGX1SCA.yaml
+++ b/module-types/FS/FLG-PLC1x8LGX1SCA.yaml
@@ -1,0 +1,52 @@
+---
+manufacturer: FS
+model: FLG-PLC1x8LGX1SCA
+part_number: FLG-PLC1x8LGX1SCA
+comments: 1 x 8 PLC Fiber Splitter, Standard LGX Cassette, SC/APC, Singlemode
+front-ports:
+  - name: '{module}/IN'
+    type: sc
+    rear_port: '{module}/IN'
+  - name: '{module}/1'
+    type: sc
+    rear_port: '{module}/1'
+  - name: '{module}/2'
+    type: sc
+    rear_port: '{module}/2'
+  - name: '{module}/3'
+    type: sc
+    rear_port: '{module}/3'
+  - name: '{module}/4'
+    type: sc
+    rear_port: '{module}/4'
+  - name: '{module}/5'
+    type: sc
+    rear_port: '{module}/5'
+  - name: '{module}/6'
+    type: sc
+    rear_port: '{module}/6'
+  - name: '{module}/7'
+    type: sc
+    rear_port: '{module}/7'
+  - name: '{module}/8'
+    type: sc
+    rear_port: '{module}/8'
+rear-ports:
+  - name: '{module}/IN'
+    type: sc
+  - name: '{module}/1'
+    type: sc
+  - name: '{module}/2'
+    type: sc
+  - name: '{module}/3'
+    type: sc
+  - name: '{module}/4'
+    type: sc
+  - name: '{module}/5'
+    type: sc
+  - name: '{module}/6'
+    type: sc
+  - name: '{module}/7'
+    type: sc
+  - name: '{module}/8'
+    type: sc


### PR DESCRIPTION
Modules for LGX fiber splitter modules from FS

Fix the 1U enclosure - it actually has three bays, not two.

Add the LGX Cassette modules which go into the enclosure.

These are PON splitters and I couldn't find a better way of representing these in Netbox other than just defining them as patch panels.

Note, although the units themselves have a duplex connector for the "IN" port, only the top one is used for the splitter so I haven't added these as duplex.