### PR TITLE
device-types/Cisco/WS-C2960CG-8TC-L.yaml: Add missing port

### DIFF
--- a/device-types/Cisco/WS-C2960CG-8TC-L.yaml
+++ b/device-types/Cisco/WS-C2960CG-8TC-L.yaml
@@ -26,6 +26,8 @@ interfaces:
     type: 1000base-t
   - name: GigabitEthernet0/7
     type: 1000base-t
+  - name: GigabitEthernet0/8
+    type: 1000base-t
   - name: GigabitEthernet0/9
     type: 1000base-t
   - name: GigabitEthernet0/10


### PR DESCRIPTION
The missing interface GigabitEthernet0/8 has been added to the template.