### PR TITLE
Add Juniper ACX2K series

### DIFF
--- a/device-types/Juniper/ACX2100-AC.yaml
+++ b/device-types/Juniper/ACX2100-AC.yaml
@@ -1,0 +1,97 @@
+---
+manufacturer: Juniper
+model: ACX2100-AC
+slug: juniper-acx2100-ac
+part_number: ACX2100-AC
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 60
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 60
+interfaces:
+  - name: ct1-0/0/0
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/0) or E1 (ce1-0/0/0) port
+  - name: ct1-0/0/1
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/1) or E1 (ce1-0/0/1) port
+  - name: ct1-0/0/2
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/2) or E1 (ce1-0/0/2) port
+  - name: ct1-0/0/3
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/3) or E1 (ce1-0/0/3) port
+  - name: ct1-0/0/4
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/4) or E1 (ce1-0/0/4) port
+  - name: ct1-0/0/5
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/5) or E1 (ce1-0/0/5) port
+  - name: ct1-0/0/6
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/6) or E1 (ce1-0/0/6) port
+  - name: ct1-0/0/7
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/7) or E1 (ce1-0/0/7) port
+  - name: ct1-0/0/8
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/8) or E1 (ce1-0/0/8) port
+  - name: ct1-0/0/9
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/9) or E1 (ce1-0/0/9) port
+  - name: ct1-0/0/10
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/10) or E1 (ce1-0/0/10) port
+  - name: ct1-0/0/11
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/11) or E1 (ce1-0/0/11) port
+  - name: ct1-0/0/12
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/12) or E1 (ce1-0/0/12) port
+  - name: ct1-0/0/13
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/13) or E1 (ce1-0/0/13) port
+  - name: ct1-0/0/14
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/14) or E1 (ce1-0/0/14) port
+  - name: ct1-0/0/15
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/15) or E1 (ce1-0/0/15) port
+  - name: ge-1/0/0
+    type: 1000base-t
+  - name: ge-1/0/1
+    type: 1000base-t
+  - name: ge-1/0/2
+    type: 1000base-t
+  - name: ge-1/0/3
+    type: 1000base-t
+  - name: ge-1/1/0
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-1/1/1
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-1/1/2
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-1/1/3
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-1/2/0
+    type: 1000base-x-sfp
+  - name: ge-1/2/1
+    type: 1000base-x-sfp
+  - name: xe-1/3/0
+    type: 10gbase-x-sfpp
+  - name: xe-1/3/1
+    type: 10gbase-x-sfpp
+  - name: fxp0
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Juniper/ACX2100-DC.yaml
+++ b/device-types/Juniper/ACX2100-DC.yaml
@@ -1,0 +1,97 @@
+---
+manufacturer: Juniper
+model: ACX2100-DC
+slug: juniper-acx2100-dc
+part_number: ACX2100-DC
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: dc-terminal
+    maximum_draw: 80
+  - name: PSU1
+    type: dc-terminal
+    maximum_draw: 80
+interfaces:
+  - name: ct1-0/0/0
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/0) or E1 (ce1-0/0/0) port
+  - name: ct1-0/0/1
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/1) or E1 (ce1-0/0/1) port
+  - name: ct1-0/0/2
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/2) or E1 (ce1-0/0/2) port
+  - name: ct1-0/0/3
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/3) or E1 (ce1-0/0/3) port
+  - name: ct1-0/0/4
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/4) or E1 (ce1-0/0/4) port
+  - name: ct1-0/0/5
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/5) or E1 (ce1-0/0/5) port
+  - name: ct1-0/0/6
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/6) or E1 (ce1-0/0/6) port
+  - name: ct1-0/0/7
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/7) or E1 (ce1-0/0/7) port
+  - name: ct1-0/0/8
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/8) or E1 (ce1-0/0/8) port
+  - name: ct1-0/0/9
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/9) or E1 (ce1-0/0/9) port
+  - name: ct1-0/0/10
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/10) or E1 (ce1-0/0/10) port
+  - name: ct1-0/0/11
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/11) or E1 (ce1-0/0/11) port
+  - name: ct1-0/0/12
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/12) or E1 (ce1-0/0/12) port
+  - name: ct1-0/0/13
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/13) or E1 (ce1-0/0/13) port
+  - name: ct1-0/0/14
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/14) or E1 (ce1-0/0/14) port
+  - name: ct1-0/0/15
+    type: t1
+  # comments: Channelized T1 (ct1-0/0/15) or E1 (ce1-0/0/15) port
+  - name: ge-1/0/0
+    type: 1000base-t
+  - name: ge-1/0/1
+    type: 1000base-t
+  - name: ge-1/0/2
+    type: 1000base-t
+  - name: ge-1/0/3
+    type: 1000base-t
+  - name: ge-1/1/0
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-1/1/1
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-1/1/2
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-1/1/3
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-1/2/0
+    type: 1000base-x-sfp
+  - name: ge-1/2/1
+    type: 1000base-x-sfp
+  - name: xe-1/3/0
+    type: 10gbase-x-sfpp
+  - name: xe-1/3/1
+    type: 10gbase-x-sfpp
+  - name: fxp0
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Juniper/ACX2200-AC.yaml
+++ b/device-types/Juniper/ACX2200-AC.yaml
@@ -1,0 +1,49 @@
+---
+manufacturer: Juniper
+model: ACX2200-AC
+slug: juniper-acx2200-ac
+part_number: ACX2200-AC
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: iec-60320-c14
+    maximum_draw: 35
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 35
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/1/0
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-0/1/1
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-0/1/2
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-0/1/3
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-0/2/0
+    type: 1000base-x-sfp
+  - name: ge-0/2/1
+    type: 1000base-x-sfp
+  - name: xe-0/3/0
+    type: 10gbase-x-sfpp
+  - name: xe-0/3/1
+    type: 10gbase-x-sfpp
+  - name: fxp0
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Juniper/ACX2200-DC.yaml
+++ b/device-types/Juniper/ACX2200-DC.yaml
@@ -11,10 +11,10 @@ console-ports:
 power-ports:
   - name: PSU0
     type: dc-terminal
-    maximum_draw: 42
+    maximum_draw: 40
   - name: PSU1
     type: dc-terminal
-    maximum_draw: 42
+    maximum_draw: 40
 interfaces:
   - name: ge-0/0/0
     type: 1000base-t

--- a/device-types/Juniper/ACX2200-DC.yaml
+++ b/device-types/Juniper/ACX2200-DC.yaml
@@ -1,0 +1,49 @@
+---
+manufacturer: Juniper
+model: ACX2200-DC
+slug: juniper-acx2200-dc
+part_number: ACX2200-DC
+u_height: 1
+is_full_depth: false
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PSU0
+    type: dc-terminal
+    maximum_draw: 42
+  - name: PSU1
+    type: dc-terminal
+    maximum_draw: 42
+interfaces:
+  - name: ge-0/0/0
+    type: 1000base-t
+  - name: ge-0/0/1
+    type: 1000base-t
+  - name: ge-0/0/2
+    type: 1000base-t
+  - name: ge-0/0/3
+    type: 1000base-t
+  - name: ge-0/1/0
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-0/1/1
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-0/1/2
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-0/1/3
+    type: 1000base-x-sfp
+  # comments: Combination (COMBO) port, either Gigabit Ethernet RJ-45 (1000base-t) or Gigabit Ethernet SFP (1000base-x-sfp)
+  - name: ge-0/2/0
+    type: 1000base-x-sfp
+  - name: ge-0/2/1
+    type: 1000base-x-sfp
+  - name: xe-0/3/0
+    type: 10gbase-x-sfpp
+  - name: xe-0/3/1
+    type: 10gbase-x-sfpp
+  - name: fxp0
+    type: 1000base-t
+    mgmt_only: true


### PR DESCRIPTION
Adding:

- ACX2100
  - AC variant
  - DC variant
- ACX2200
  - AC variant
  - DC variant
 
Some bits and pieces are missing from Juniper's documentation and the datasheet, however used the best available information from these and deployed hardware. Based the comments on the ports with interchangeable features on the ACX1100 which has already been added to the library.

[Hardware Guide - ACX2100](https://www.juniper.net/documentation/us/en/hardware/acx2000/index.html)
[Hardware Guide - ACX2200](https://www.juniper.net/documentation/us/en/hardware/acx2200/index.html)

[Datasheet](https://www.juniper.net/content/dam/www/assets/datasheets/us/en/routers/acx500-acx1000-acx2000-acx4000-universal-metro-routers-datasheet.pdf)