### PR TITLE
APC PDUs

### DIFF
--- a/device-types/APC/AP4421.yaml
+++ b/device-types/APC/AP4421.yaml
@@ -1,0 +1,47 @@
+---
+manufacturer: APC
+model: AP4421
+slug: apc-ap4421
+part_number: AP4421
+u_height: 1
+is_full_depth: false
+comments: RACK ATS, 230V, 10A, C14 IN, (12) C13 OUT
+console-ports:
+  - name: Serial
+    type: rj-12
+  - name: usb
+    type: usb-a
+power-ports:
+  - name: Source A
+    type: iec-60320-c14
+  - name: Source B
+    type: iec-60320-c14
+power-outlets:
+  - name: Power Outlet 1
+    type: iec-60320-c13
+  - name: Power Outlet 2
+    type: iec-60320-c13
+  - name: Power Outlet 3
+    type: iec-60320-c13
+  - name: Power Outlet 4
+    type: iec-60320-c13
+  - name: Power Outlet 5
+    type: iec-60320-c13
+  - name: Power Outlet 6
+    type: iec-60320-c13
+  - name: Power Outlet 7
+    type: iec-60320-c13
+  - name: Power Outlet 8
+    type: iec-60320-c13
+  - name: Power Outlet 9
+    type: iec-60320-c13
+  - name: Power Outlet 10
+    type: iec-60320-c13
+  - name: Power Outlet 11
+    type: iec-60320-c13
+  - name: Power Outlet 12
+    type: iec-60320-c13
+interfaces:
+  - name: Management
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP7850.yaml
+++ b/device-types/APC/AP7850.yaml
@@ -1,0 +1,51 @@
+---
+manufacturer: APC
+model: AP7850
+slug: apc-ap7850
+part_number: AP7850
+u_height: 0
+is_full_depth: false
+comments: Rack PDU, Metered, Zero U, 10A, 230V, (16) C13
+console-ports:
+  - name: Serial
+    type: rj-12
+power-ports:
+  - name: Power Port 1
+    type: iec-60309-p-n-e-6h
+power-outlets:
+  - name: Power Outlet 1
+    type: iec-60320-c13
+  - name: Power Outlet 2
+    type: iec-60320-c13
+  - name: Power Outlet 3
+    type: iec-60320-c13
+  - name: Power Outlet 4
+    type: iec-60320-c13
+  - name: Power Outlet 5
+    type: iec-60320-c13
+  - name: Power Outlet 6
+    type: iec-60320-c13
+  - name: Power Outlet 7
+    type: iec-60320-c13
+  - name: Power Outlet 8
+    type: iec-60320-c13
+  - name: Power Outlet 9
+    type: iec-60320-c13
+  - name: Power Outlet 10
+    type: iec-60320-c13
+  - name: Power Outlet 11
+    type: iec-60320-c13
+  - name: Power Outlet 12
+    type: iec-60320-c13
+  - name: Power Outlet 13
+    type: iec-60320-c13
+  - name: Power Outlet 14
+    type: iec-60320-c13
+  - name: Power Outlet 15
+    type: iec-60320-c13
+  - name: Power Outlet 16
+    type: iec-60320-c13
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP7853.yaml
+++ b/device-types/APC/AP7853.yaml
@@ -1,0 +1,67 @@
+---
+manufacturer: APC
+model: AP7853
+slug: apc-ap7853
+part_number: AP7853
+u_height: 0
+is_full_depth: false
+comments: Rack PDU, Metered, Zero U, 32A, 230V, (20)C13 & (4)C19
+console-ports:
+  - name: Serial
+    type: rj-12
+power-ports:
+  - name: Power Port 1
+    type: iec-60309-p-n-e-6h
+power-outlets:
+  - name: Power Outlet 1
+    type: iec-60320-c13
+  - name: Power Outlet 2
+    type: iec-60320-c13
+  - name: Power Outlet 3
+    type: iec-60320-c19
+  - name: Power Outlet 4
+    type: iec-60320-c13
+  - name: Power Outlet 5
+    type: iec-60320-c13
+  - name: Power Outlet 6
+    type: iec-60320-c13
+  - name: Power Outlet 7
+    type: iec-60320-c13
+  - name: Power Outlet 8
+    type: iec-60320-c19
+  - name: Power Outlet 9
+    type: iec-60320-c13
+  - name: Power Outlet 10
+    type: iec-60320-c13
+  - name: Power Outlet 11
+    type: iec-60320-c13
+  - name: Power Outlet 12
+    type: iec-60320-c13
+  - name: Power Outlet 13
+    type: iec-60320-c13
+  - name: Power Outlet 14
+    type: iec-60320-c13
+  - name: Power Outlet 15
+    type: iec-60320-c13
+  - name: Power Outlet 16
+    type: iec-60320-c13
+  - name: Power Outlet 17
+    type: iec-60320-c19
+  - name: Power Outlet 18
+    type: iec-60320-c13
+  - name: Power Outlet 19
+    type: iec-60320-c13
+  - name: Power Outlet 20
+    type: iec-60320-c13
+  - name: Power Outlet 21
+    type: iec-60320-c13
+  - name: Power Outlet 22
+    type: iec-60320-c19
+  - name: Power Outlet 23
+    type: iec-60320-c13
+  - name: Power Outlet 24
+    type: iec-60320-c13
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP7921.yaml
+++ b/device-types/APC/AP7921.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: APC
+model: AP7921
+slug: apc-ap7921
+part_number: AP7921
+u_height: 1
+is_full_depth: false
+comments: APC NetShelter Switched Rack PDU, 1U, 1PH, 3.7kW 230V 16A or 3.3kW 208V 16A, 8 C13 outlets, C20 cord
+console-ports:
+  - name: Serial
+    type: rj-12
+power-ports:
+  - name: Power Port 1
+    type: iec-60320-c20
+power-outlets:
+  - name: Outlet 1
+    type: iec-60320-c13
+    power_port: Power Port 1
+  - name: Outlet 2
+    type: iec-60320-c13
+    power_port: Power Port 1
+  - name: Outlet 3
+    type: iec-60320-c13
+    power_port: Power Port 1
+  - name: Outlet 4
+    type: iec-60320-c13
+    power_port: Power Port 1
+  - name: Outlet 5
+    type: iec-60320-c13
+    power_port: Power Port 1
+  - name: Outlet 6
+    type: iec-60320-c13
+    power_port: Power Port 1
+  - name: Outlet 7
+    type: iec-60320-c13
+    power_port: Power Port 1
+  - name: Outlet 8
+    type: iec-60320-c13
+    power_port: Power Port 1
+interfaces:
+  - name: Ethernet
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP7951.yaml
+++ b/device-types/APC/AP7951.yaml
@@ -1,0 +1,67 @@
+---
+manufacturer: APC
+model: AP7951
+slug: apc-ap7951
+part_number: AP7951
+u_height: 0
+is_full_depth: false
+comments: Rack PDU,Switched,ZeroU,16A,230V,(21)C13&(3)C19,IEC309
+console-ports:
+  - name: Serial
+    type: rj-12
+power-ports:
+  - name: Power Port 1
+    type: iec-60309-p-n-e-6h
+power-outlets:
+  - name: Power Outlet 1
+    type: iec-60320-c19
+  - name: Power Outlet 2
+    type: iec-60320-c13
+  - name: Power Outlet 3
+    type: iec-60320-c13
+  - name: Power Outlet 4
+    type: iec-60320-c13
+  - name: Power Outlet 5
+    type: iec-60320-c13
+  - name: Power Outlet 6
+    type: iec-60320-c13
+  - name: Power Outlet 7
+    type: iec-60320-c13
+  - name: Power Outlet 8
+    type: iec-60320-c13
+  - name: Power Outlet 9
+    type: iec-60320-c19
+  - name: Power Outlet 10
+    type: iec-60320-c13
+  - name: Power Outlet 11
+    type: iec-60320-c13
+  - name: Power Outlet 12
+    type: iec-60320-c13
+  - name: Power Outlet 13
+    type: iec-60320-c13
+  - name: Power Outlet 14
+    type: iec-60320-c13
+  - name: Power Outlet 15
+    type: iec-60320-c13
+  - name: Power Outlet 16
+    type: iec-60320-c13
+  - name: Power Outlet 17
+    type: iec-60320-c19
+  - name: Power Outlet 18
+    type: iec-60320-c13
+  - name: Power Outlet 19
+    type: iec-60320-c13
+  - name: Power Outlet 20
+    type: iec-60320-c13
+  - name: Power Outlet 21
+    type: iec-60320-c13
+  - name: Power Outlet 22
+    type: iec-60320-c13
+  - name: Power Outlet 23
+    type: iec-60320-c13
+  - name: Power Outlet 24
+    type: iec-60320-c13
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP7953.yaml
+++ b/device-types/APC/AP7953.yaml
@@ -1,0 +1,67 @@
+---
+manufacturer: APC
+model: AP7953
+slug: apc-ap7953
+part_number: AP7953
+u_height: 0
+is_full_depth: false
+comments: Rack PDU, Switched, Zero U, 32A, 230V, (21)C13 & (3)C19
+console-ports:
+  - name: Serial
+    type: rj-12
+power-ports:
+  - name: Power Port 1
+    type: iec-60309-p-n-e-6h
+power-outlets:
+  - name: Power Outlet 1
+    type: iec-60320-c19
+  - name: Power Outlet 2
+    type: iec-60320-c13
+  - name: Power Outlet 3
+    type: iec-60320-c13
+  - name: Power Outlet 4
+    type: iec-60320-c13
+  - name: Power Outlet 5
+    type: iec-60320-c13
+  - name: Power Outlet 6
+    type: iec-60320-c13
+  - name: Power Outlet 7
+    type: iec-60320-c13
+  - name: Power Outlet 8
+    type: iec-60320-c13
+  - name: Power Outlet 9
+    type: iec-60320-c19
+  - name: Power Outlet 10
+    type: iec-60320-c13
+  - name: Power Outlet 11
+    type: iec-60320-c13
+  - name: Power Outlet 12
+    type: iec-60320-c13
+  - name: Power Outlet 13
+    type: iec-60320-c13
+  - name: Power Outlet 14
+    type: iec-60320-c13
+  - name: Power Outlet 15
+    type: iec-60320-c13
+  - name: Power Outlet 16
+    type: iec-60320-c13
+  - name: Power Outlet 17
+    type: iec-60320-c19
+  - name: Power Outlet 18
+    type: iec-60320-c13
+  - name: Power Outlet 19
+    type: iec-60320-c13
+  - name: Power Outlet 20
+    type: iec-60320-c13
+  - name: Power Outlet 21
+    type: iec-60320-c13
+  - name: Power Outlet 22
+    type: iec-60320-c13
+  - name: Power Outlet 23
+    type: iec-60320-c13
+  - name: Power Outlet 24
+    type: iec-60320-c13
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true

--- a/device-types/APC/AP7954.yaml
+++ b/device-types/APC/AP7954.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: APC
-model: AP7954B2
-slug: apc-ap7954b2
-part_number: AP7954B2
+model: AP7954
+slug: apc-ap7954
+part_number: AP7954
 u_height: 0
 is_full_depth: false
 comments: Rack PDU, Switched, Zero U,16A,230V,(21)C13&(3)C19, IEC309
@@ -15,100 +15,52 @@ power-ports:
 power-outlets:
   - name: Power Outlet 1
     type: iec-60320-c19
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 2
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 3
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 4
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 5
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 6
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 7
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 8
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 9
     type: iec-60320-c19
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 10
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 11
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 12
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 13
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 14
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 15
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 16
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 17
     type: iec-60320-c19
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 18
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 19
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 20
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 21
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 22
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 23
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
   - name: Power Outlet 24
     type: iec-60320-c13
-    power_port: Power Port 1
-    feed_leg: A
 interfaces:
   - name: Network
     type: 100base-tx

--- a/device-types/APC/AP7954B2.yaml
+++ b/device-types/APC/AP7954B2.yaml
@@ -1,0 +1,115 @@
+---
+manufacturer: APC
+model: AP7954B2
+slug: apc-ap7954b2
+part_number: AP7954B2
+u_height: 0
+is_full_depth: false
+comments: Rack PDU, Switched, Zero U,16A,230V,(21)C13&(3)C19, IEC309
+console-ports:
+  - name: Serial
+    type: rj-12
+power-ports:
+  - name: Power Port 1
+    type: iec-60309-p-n-e-6h
+power-outlets:
+  - name: Power Outlet 1
+    type: iec-60320-c19
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 2
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 3
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 4
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 5
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 6
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 7
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 8
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 9
+    type: iec-60320-c19
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 10
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 11
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 12
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 13
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 14
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 15
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 16
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 17
+    type: iec-60320-c19
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 18
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 19
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 20
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 21
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 22
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 23
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+  - name: Power Outlet 24
+    type: iec-60320-c13
+    power_port: Power Port 1
+    feed_leg: A
+interfaces:
+  - name: Network
+    type: 100base-tx
+    mgmt_only: true


### PR DESCRIPTION
Added new APC PDU models:

- AP4421
- AP7850
- AP7853
- AP7921
- AP7951
- AP7953
- AP7954
