### PR TITLE
Fix height of WS-C3750G-24TS-S

### DIFF
--- a/device-types/Cisco/WS-C3750G-24TS-S.yaml
+++ b/device-types/Cisco/WS-C3750G-24TS-S.yaml
@@ -4,7 +4,7 @@ model: Catalyst 3750G-24TS-S
 slug: cisco-ws-c3750g-24ts-s
 part_number: WS-C3750G-24TS-S
 is_full_depth: false
-u_height: 1.5
+u_height: 1
 interfaces:
   - name: GigabitEthernet1/0/1
     type: 1000base-t


### PR DESCRIPTION
Looks like height was accidentally set to 1.5U in commit 6f1fa04a7401e7ac321a9b54e2fb6c93f573fceb that was intended to implement half-height units.

My best guess is this device type was edited for test purposes and accidentally committed.

I've got this device in front of me and it's definitely 1U.