### PR TITLE
Add script to find duplicate module bay positions

### DIFF
--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -37,14 +37,18 @@ def get_bays_with_duplicate_positions(device_type):
         if len(bay_names) > 1:
             yield position, bay_names
 
+def iter_pairs(items):
+    count = len(items)
+    for i, item1 in enumerate(items):
+        for item2 in items[i+1:]:
+            yield item1, item2
+
 for file_path, file_rel_path in walk_device_type_files():
     with open(file_path, 'r', encoding='utf8') as f:
         device_type = yaml.safe_load(f)
     for position, bay_names in get_bays_with_duplicate_positions(device_type):
         # Iterate through these, pairwise, and report any bays with the same position and very similar names (low levenshtein distances)
-        count = len(bay_names)
-        for i, bay1 in enumerate(bay_names):
-            for bay2 in bay_names[i+1:]:
-                d = distance(bay1, bay2)
-                if d <= DISTANCE_THRESHOLD:
-                    print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")
+        for bay1, bay2 in iter_pairs(bay_names):
+            d = distance(bay1, bay2)
+            if d <= DISTANCE_THRESHOLD:
+                print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")

--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -43,12 +43,15 @@ def iter_pairs(items):
         for item2 in items[i+1:]:
             yield item1, item2
 
+def iter_similar_pairs(strings, threshold=DISTANCE_THRESHOLD):
+    for s1, s2 in iter_pairs(strings):
+        if distance(s1, s2) <= threshold:
+            yield s1, s2
+
 for file_path, file_rel_path in walk_device_type_files():
     with open(file_path, 'r', encoding='utf8') as f:
         device_type = yaml.safe_load(f)
     for position, bay_names in get_bays_with_duplicate_positions(device_type):
-        # Iterate through these, pairwise, and report any bays with the same position and very similar names (low levenshtein distances)
-        for bay1, bay2 in iter_pairs(bay_names):
-            d = distance(bay1, bay2)
-            if d <= DISTANCE_THRESHOLD:
-                print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")
+        # Find any pairs of module bays with the same positions and similar names
+        for bay1, bay2 in iter_similar_pairs(bay_names):
+            print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")

--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -2,7 +2,6 @@
 # pip install levenshtein
 
 import os, re, yaml
-from collections import defaultdict
 from itertools import groupby, combinations
 from Levenshtein import distance
 

--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -7,7 +7,7 @@ from itertools import groupby
 from Levenshtein import distance
 
 # Two module names with distance(name1, name2) > DISTANCE_THRESHHOLD are considered to be in different groups
-DISTANCE_THRESHHOLD = 2
+DISTANCE_THRESHOLD = 2
 
 def walk_device_type_files():
     root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "device-types")
@@ -46,5 +46,5 @@ for file_path, file_rel_path in walk_device_type_files():
         for i, bay1 in enumerate(bay_names):
             for bay2 in bay_names[i+1:]:
                 d = distance(bay1, bay2)
-                if d <= DISTANCE_THRESHHOLD:
+                if d <= DISTANCE_THRESHOLD:
                     print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")

--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -48,10 +48,11 @@ def iter_similar_pairs(strings, threshold=DISTANCE_THRESHOLD):
         if distance(s1, s2) <= threshold:
             yield s1, s2
 
-for file_path, file_rel_path in walk_device_type_files():
-    with open(file_path, 'r', encoding='utf8') as f:
-        device_type = yaml.safe_load(f)
-    for position, bay_names in get_bays_with_duplicate_positions(device_type):
-        # Find any pairs of module bays with the same positions and similar names
-        for bay1, bay2 in iter_similar_pairs(bay_names):
-            print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")
+if __name__ == '__main__':
+    for file_path, file_rel_path in walk_device_type_files():
+        with open(file_path, 'r', encoding='utf8') as f:
+            device_type = yaml.safe_load(f)
+        for position, bay_names in get_bays_with_duplicate_positions(device_type):
+            # Find any pairs of module bays with the same positions and similar names
+            for bay1, bay2 in iter_similar_pairs(bay_names):
+                print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")

--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -50,6 +50,6 @@ def iter_bays_with_duplicate_positions_and_similar_names(device_type):
 if __name__ == '__main__':
     for file_path, file_rel_path in walk_device_type_files():
         with open(file_path, 'r', encoding='utf8') as f:
-            device_type = yaml.safe_load(f)
+            device_type = yaml.load(f, Loader=yaml.CSafeLoader)
         for position, bay1, bay2 in iter_bays_with_duplicate_positions_and_similar_names(device_type):
             print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")

--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -1,0 +1,50 @@
+# pip install pyyaml
+# pip install levenshtein
+
+import os, re, yaml
+from collections import defaultdict
+from itertools import groupby
+from Levenshtein import distance
+
+# Two module names with distance(name1, name2) > DISTANCE_THRESHHOLD are considered to be in different groups
+DISTANCE_THRESHHOLD = 2
+
+def walk_device_type_files():
+    root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "device-types")
+    for root, dirs, files in os.walk(root_dir):
+        for file in files:
+            if re.match(r'.+\.ya?ml$', file, re.IGNORECASE):
+                full = os.path.join(root, file)
+                rel = os.path.relpath(full, root_dir)
+                yield full, rel
+
+def get_bays_with_duplicate_positions(device_type):
+    module_bays = device_type.get('module-bays')
+    if module_bays is None:
+        return
+
+    # First, we filter out any module bays that have no position or no name
+    module_bays = [bay for bay in module_bays if 'position' in bay and 'name' in bay]
+
+    # Then, we sort by position so that itertools.groupby can do its thing,
+    # and yield the groups, as long as there's at least 2 objects with the
+    # same position.
+
+    get_bay_position = lambda bay: bay['position']
+    module_bays.sort(key=get_bay_position)
+    for position, bays_iter in groupby(module_bays, get_bay_position):
+        bay_names = [bay['name'] for bay in bays_iter]
+        if len(bay_names) > 1:
+            yield position, bay_names
+
+for file_path, file_rel_path in walk_device_type_files():
+    with open(file_path, 'r', encoding='utf8') as f:
+        device_type = yaml.safe_load(f)
+    for position, bay_names in get_bays_with_duplicate_positions(device_type):
+        # Iterate through these, pairwise, and report any bays with the same position and very similar names (low levenshtein distances)
+        count = len(bay_names)
+        for i, bay1 in enumerate(bay_names):
+            for bay2 in bay_names[i+1:]:
+                d = distance(bay1, bay2)
+                if d <= DISTANCE_THRESHHOLD:
+                    print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")

--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -48,11 +48,15 @@ def iter_similar_pairs(strings, threshold=DISTANCE_THRESHOLD):
         if distance(s1, s2) <= threshold:
             yield s1, s2
 
+def iter_bays_with_duplicate_positions_and_similar_names(device_type):
+    for position, bay_names in get_bays_with_duplicate_positions(device_type):
+        # Find any pairs of module bays with the same positions and similar names
+        for bay1, bay2 in iter_similar_pairs(bay_names):
+            yield position, bay1, bay2
+
 if __name__ == '__main__':
     for file_path, file_rel_path in walk_device_type_files():
         with open(file_path, 'r', encoding='utf8') as f:
             device_type = yaml.safe_load(f)
-        for position, bay_names in get_bays_with_duplicate_positions(device_type):
-            # Find any pairs of module bays with the same positions and similar names
-            for bay1, bay2 in iter_similar_pairs(bay_names):
-                print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")
+        for position, bay1, bay2 in iter_bays_with_duplicate_positions_and_similar_names(device_type):
+            print(f"In {file_rel_path}, module bays {bay1} and {bay2} both have position {position}.")

--- a/scripts/find-duplicate-positions.py
+++ b/scripts/find-duplicate-positions.py
@@ -3,7 +3,7 @@
 
 import os, re, yaml
 from collections import defaultdict
-from itertools import groupby
+from itertools import groupby, combinations
 from Levenshtein import distance
 
 # Two module names with distance(name1, name2) > DISTANCE_THRESHHOLD are considered to be in different groups
@@ -37,14 +37,8 @@ def get_bays_with_duplicate_positions(device_type):
         if len(bay_names) > 1:
             yield position, bay_names
 
-def iter_pairs(items):
-    count = len(items)
-    for i, item1 in enumerate(items):
-        for item2 in items[i+1:]:
-            yield item1, item2
-
 def iter_similar_pairs(strings, threshold=DISTANCE_THRESHOLD):
-    for s1, s2 in iter_pairs(strings):
+    for s1, s2 in combinations(strings, 2):
         if distance(s1, s2) <= threshold:
             yield s1, s2
 


### PR DESCRIPTION
This adds a script that looks for mistakes in device type definitions, specifically where multiple module bays have the same position, and also have similar names.

This will find mistakes such as:

```yaml
module-bays:
  - name: PSU1
    position: PSU1
  - name: PSU2
    position: PSU1
```

But will ignore situations like:

```yaml
module-bays:
  - name: Power Supply 1
    position: '1'
  - name: Power Supply 2
    position: '2'
  - name: Expansion Slot 1
    position: '1'
  - name: Expansion Slot 2
    position: '2'
```

Because "Power Supply 1" and "Expansion Slot 1" are dissimilar names ([Levensthein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) > 2).

This script was created to see if the same/similar errors as in #1584 occur in more than one model. This is the output at time of writing:

```
In HPE\ProLiant-DL325-Gen10-Plus-v2.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-DL325-Gen10-Plus.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-DL325-Gen10.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-DL360-Gen10-Plus.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-DL360-Gen10.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-DL365-Gen11.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-DL380-Gen10-Plus.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-DL380-Gen10.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-DL560-Gen10.yaml, module bays PSU1 and PSU2 both have position PSU1.
In HPE\ProLiant-ML350p-Gen8.yaml, module bays PCIe8 and PCIe9 both have position PCIe9.
In QNAP\TS-873.yml, module bays Slot 1 and Slot 2 both have position rear.
```

I'm keeping the PR to introduce this script seperate to fixing the models above for clarity. A second PR will be created to fix the mistakes above.