### PR TITLE
Improve documentation for module bay positions (and remove a spurious position)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The available fields for each type of component are listed below.
 
 - `name`: Name
 - `label`: Label
-- `position`: The module bay's position within the parent device
+- `position`: The alphanumeric position in which this module bay is situated within the parent device. When creating module components, the string `{position}` in the component name will be replaced with the module bay's `position`. See the [NetBox Documentation](https://docs.netbox.dev/en/stable/models/dcim/moduletype/#automatic-component-renaming) for more details.
 
 #### Device Bays
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The available fields for each type of component are listed below.
 
 - `name`: Name
 - `label`: Label
-- `position`: The alphanumeric position in which this module bay is situated within the parent device. When creating module components, the string `{position}` in the component name will be replaced with the module bay's `position`. See the [NetBox Documentation](https://docs.netbox.dev/en/stable/models/dcim/moduletype/#automatic-component-renaming) for more details.
+- `position`: The alphanumeric position in which this module bay is situated within the parent device. When creating module components, the string `{module}` in the component name will be replaced with the module bay's `position`. See the [NetBox Documentation](https://docs.netbox.dev/en/stable/models/dcim/moduletype/#automatic-component-renaming) for more details.
 
 #### Device Bays
 

--- a/device-types/QNAP/TS-873.yml
+++ b/device-types/QNAP/TS-873.yml
@@ -16,9 +16,7 @@ device-bays:
   - name: Disk 8
 module-bays:
   - name: Slot 1
-    position: rear
   - name: Slot 2
-    position: rear
 comments: '[TS-873 | Hardware Specs | QNAP](https://www.qnap.com/en-me/product/ts-873/specs/hardware)'
 power-ports:
   - name: PSU


### PR DESCRIPTION
The documentation for the "position" attribute in README.md was misleading. This is what the documentation says:

> The module bay's position within the parent device

This isn't very clear, and it can easilly be interpreted as a physical description of where you can find the port. For example, this module bay definition that I found for the QNAP TS-873:

```yaml
module-bays:
  - name: Slot 1
    position: rear
  - name: Slot 2
    position: rear
```

This PR clears up the documentation for module bay positions to clarify what the position attribute is for, removes this spurious position definition, and attempts to teach users how the Automatic Component Renaming feature works, hopefully this will lead to better models.

(I've not done an exhaustive search for mis-use of the position attribute on module bays, this just popped up when doing an unrelated search for duplicate module bay positions, see #1585)