### PR TITLE
Improve HPE BladeSystem c7000 modelling

### DIFF
--- a/device-types/HPE/456204-B21.yaml
+++ b/device-types/HPE/456204-B21.yaml
@@ -1,0 +1,14 @@
+---
+manufacturer: HPE
+model: BladeSystem c7000 DDR2 Onboard Administrator with KVM
+slug: hpe-456204-b21
+part_number: 456204-B21
+u_height: 0
+subdevice_role: child
+interfaces:
+  - name: iLO
+    type: 1000base-t
+    mgmt_only: true
+console-ports:
+  - name: Console
+    type: de-9

--- a/device-types/HPE/571956-B21.yaml
+++ b/device-types/HPE/571956-B21.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: HPE
+model: Virtual Connect FlexFabric 10Gb/24-Port Module for c-Class BladeSystem
+comments: '[QuickSpecs](https://www.hpe.com/psnow/doc/c04154400)'
+part_number: 571956-B21
+slug: hpe-571956-b21
+subdevice_role: child
+interfaces:
+  - name: Port X1
+    type: 10gbase-x-sfpp
+  - name: Port X2
+    type: 10gbase-x-sfpp
+  - name: Port X3
+    type: 10gbase-x-sfpp
+  - name: Port X4
+    type: 10gbase-x-sfpp
+  - name: Port X5
+    type: 10gbase-x-sfpp
+  - name: Port X6
+    type: 10gbase-x-sfpp
+  - name: Port X7
+    type: 10gbase-x-sfpp
+  - name: Port X8
+    type: 10gbase-x-sfpp

--- a/device-types/HPE/571956-B21.yaml
+++ b/device-types/HPE/571956-B21.yaml
@@ -5,6 +5,7 @@ comments: '[QuickSpecs](https://www.hpe.com/psnow/doc/c04154400)'
 part_number: 571956-B21
 slug: hpe-571956-b21
 subdevice_role: child
+u_height: 0
 interfaces:
   - name: Port X1
     type: 10gbase-x-sfpp

--- a/device-types/HPE/638526-B21.yaml
+++ b/device-types/HPE/638526-B21.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: HPE
+model: HPE Virtual Connect Flex-10/10D Module for c-Class BladeSystem
+comments: '[QuickSpecs](https://www.hpe.com/psnow/doc/c04154336)'
+part_number: 638526-B21
+slug: hpe-638526-b21
+subdevice_role: child
+interfaces:
+  - name: Port X1
+    type: 10gbase-x-sfpp
+  - name: Port X2
+    type: 10gbase-x-sfpp
+  - name: Port X3
+    type: 10gbase-x-sfpp
+  - name: Port X4
+    type: 10gbase-x-sfpp
+  - name: Port X5
+    type: 10gbase-x-sfpp
+  - name: Port X6
+    type: 10gbase-x-sfpp
+  - name: Port X7
+    type: 10gbase-x-sfpp
+  - name: Port X8
+    type: 10gbase-x-sfpp
+  - name: Port X9
+    type: 10gbase-x-sfpp
+  - name: Port X10
+    type: 10gbase-x-sfpp

--- a/device-types/HPE/638526-B21.yaml
+++ b/device-types/HPE/638526-B21.yaml
@@ -5,6 +5,7 @@ comments: '[QuickSpecs](https://www.hpe.com/psnow/doc/c04154336)'
 part_number: 638526-B21
 slug: hpe-638526-b21
 subdevice_role: child
+u_height: 0
 interfaces:
   - name: Port X1
     type: 10gbase-x-sfpp

--- a/device-types/HPE/BladeSystem-c7000.yaml
+++ b/device-types/HPE/BladeSystem-c7000.yaml
@@ -43,3 +43,5 @@ device-bays:
   - name: Interconnect Bay 6
   - name: Interconnect Bay 7
   - name: Interconnect Bay 8
+  - name: Onboard Administrator Bay 1
+  - name: Onboard Administrator Bay 2

--- a/device-types/HPE/BladeSystem-c7000.yaml
+++ b/device-types/HPE/BladeSystem-c7000.yaml
@@ -35,3 +35,11 @@ device-bays:
   - name: Device Bay 14
   - name: Device Bay 15
   - name: Device Bay 16
+  - name: Interconnect Bay 1
+  - name: Interconnect Bay 2
+  - name: Interconnect Bay 3
+  - name: Interconnect Bay 4
+  - name: Interconnect Bay 5
+  - name: Interconnect Bay 6
+  - name: Interconnect Bay 7
+  - name: Interconnect Bay 8

--- a/device-types/HPE/BladeSystem-c7000.yaml
+++ b/device-types/HPE/BladeSystem-c7000.yaml
@@ -5,25 +5,19 @@ slug: hpe-bladesystem-c7000
 u_height: 10
 is_full_depth: true
 subdevice_role: parent
-power-ports:
+module-bays:
   - name: PS1
-    type: iec-60320-c20
-    maximum_draw: 2650
+    position: '1'
   - name: PS2
-    type: iec-60320-c20
-    maximum_draw: 2650
+    position: '2'
   - name: PS3
-    type: iec-60320-c20
-    maximum_draw: 2650
+    position: '3'
   - name: PS4
-    type: iec-60320-c20
-    maximum_draw: 2650
+    position: '4'
   - name: PS5
-    type: iec-60320-c20
-    maximum_draw: 2650
+    position: '5'
   - name: PS6
-    type: iec-60320-c20
-    maximum_draw: 2650
+    position: '6'
 device-bays:
   - name: Device Bay 1
   - name: Device Bay 2

--- a/device-types/HPE/BladeSystem-c7000.yaml
+++ b/device-types/HPE/BladeSystem-c7000.yaml
@@ -45,3 +45,8 @@ device-bays:
   - name: Interconnect Bay 8
   - name: Onboard Administrator Bay 1
   - name: Onboard Administrator Bay 2
+interfaces:
+  - name: Enclosure Link Down
+    type: 1000base-t
+  - name: Enclosure Link Up
+    type: 1000base-t

--- a/device-types/HPE/ProLiant-BL460c-Gen10.yaml
+++ b/device-types/HPE/ProLiant-BL460c-Gen10.yaml
@@ -1,0 +1,7 @@
+---
+manufacturer: HPE
+model: ProLiant 460c Gen10
+slug: hpe-proliant-bl460c-gen10
+part_number: 863442-B21
+u_height: 0
+subdevice_role: child

--- a/device-types/HPE/ProLiant-BL460c-Gen10.yaml
+++ b/device-types/HPE/ProLiant-BL460c-Gen10.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: HPE
-model: ProLiant 460c Gen10
+model: ProLiant BL460c Gen10
 slug: hpe-proliant-bl460c-gen10
 part_number: 863442-B21
 u_height: 0

--- a/device-types/HPE/ProLiant-BL460c-Gen9.yaml
+++ b/device-types/HPE/ProLiant-BL460c-Gen9.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: HPE
-model: ProLiant 460c Gen9
+model: ProLiant BL460c Gen9
 slug: hpe-proliant-bl460c-gen9
 part_number: 813197-B21
 u_height: 0

--- a/device-types/HPE/ProLiant-BL460c-Gen9.yaml
+++ b/device-types/HPE/ProLiant-BL460c-Gen9.yaml
@@ -1,0 +1,7 @@
+---
+manufacturer: HPE
+model: ProLiant 460c Gen9
+slug: hpe-proliant-bl460c-gen9
+part_number: 813197-B21
+u_height: 0
+subdevice_role: child

--- a/module-types/HPE/499253-B21.yaml
+++ b/module-types/HPE/499253-B21.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: HPE
+model: 499253-B21
+part_number: 499253-B21
+comments: HP 2400W HE PSU
+power-ports:
+  - name: PS{module}
+    type: iec-60320-c20
+    maximum_draw: 2650

--- a/module-types/HPE/588603-B21.yaml
+++ b/module-types/HPE/588603-B21.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: HPE
+model: 588603-B21
+part_number: 588603-B21
+comments: HP 2400W 80 PLUS PLATINUM
+power-ports:
+  - name: PS{module}
+    type: iec-60320-c20
+    maximum_draw: 2650


### PR DESCRIPTION
Hi!

Did some work to improve the BladeSystem c7000 modelling. The existing model did nothing to model interconnects nor onboard administrators, didn't model the PSU's as modular, and didn't model enclosure interlinks.

I'm sure there's some stuff that could be added with respect to weight and airflow information, but I think I already spent enough time modelling this EOL device, good enough to put it into our own docs. Hope it's useful to others as well!