### PR TITLE
Pre-Commit Update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest==7.4.0
 PyYAML==6.0.1
 yamllint==1.32.0
 gitpython==3.1.32
+psutil==5.9.5

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -21,6 +21,11 @@ COMPONENT_TYPES = (
     'module-bays',
 )
 
+PRECOMMIT_ALL_SWITCHES = [
+  '-a',
+  '--all-files'
+]
+
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..'))
 
 KNOWN_SLUGS = set()


### PR DESCRIPTION
Updating pre-commit pytest script so that if `-a` or `--all-files` is called, it actually checks all files in the repository