### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following fields may **optionally** be declared:
 - `is_full_depth`: A boolean which indicates whether the device type consumes both the front and rear rack faces. (**Default: true**)
   - Type: Boolean
 > :test_tube: **Example**: `is_full_depth: false`
-- `airflow`: A decleration of the airflow pattern for the device. (**Default: None**)
+- `airflow`: A declaration of the airflow pattern for the device. (**Default: None**)
   - Type: String
   - Options:
     - `front-to-rear`


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "decleration" to "declaration" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.