### PR TITLE
Pytest Test Case - Renamed File w/o Slug/PN Change

### DIFF
--- a/tests/definitions_test.py
+++ b/tests/definitions_test.py
@@ -67,11 +67,11 @@ def _get_diff_from_upstream():
             if file.change_type in CHANGE_TYPE_LIST:
                 # If the file is renamed, ensure we are picking the right schema
                 if 'R' in file.change_type and path in file.rename_to:
-                    file_list.append((file.rename_to, schema))
+                    file_list.append((file.rename_from, schema, file.change_type))
                 elif path in file.a_path:
-                    file_list.append((file.a_path, schema))
+                    file_list.append((file.a_path, schema, file.change_type))
                 elif path in file.b_path:
-                    file_list.append((file.b_path, schema))
+                    file_list.append((file.b_path, schema, file.change_type))
 
     return file_list
 
@@ -127,8 +127,8 @@ else:
     KNOWN_MODULES = pickle_operations.read_pickle_data(f'{temp_dir.name}/tests/known-modules.pickle')
 
 
-@pytest.mark.parametrize(('file_path', 'schema'), definition_files)
-def test_definitions(file_path, schema):
+@pytest.mark.parametrize(('file_path', 'schema', 'change_type'), definition_files)
+def test_definitions(file_path, schema, change_type):
     """
     Validate each definition file using the provided JSON schema and check for duplicate entries.
     """
@@ -161,10 +161,10 @@ def test_definitions(file_path, schema):
     # Identify if the definition is for a Device or Module
     if "device-types" in file_path:
         # A device
-        this_device = DeviceType(definition, file_path)
+        this_device = DeviceType(definition, file_path, change_type)
     else:
         # A module
-        this_device = ModuleType(definition, file_path)
+        this_device = ModuleType(definition, file_path, change_type)
 
     # Verify the slug is valid, only if the definition type is a Device
     if this_device.isDevice:

--- a/tests/definitions_test.py
+++ b/tests/definitions_test.py
@@ -32,7 +32,7 @@ def _get_definition_files():
 
         # Map each definition file to its schema as a tuple (file, schema)
         for file in sorted(glob.glob(f"{path}/*/*", recursive=True)):
-            file_list.append((file, schema))
+            file_list.append((file, schema, 'skip'))
 
     return file_list
 

--- a/tests/device_types.py
+++ b/tests/device_types.py
@@ -4,7 +4,7 @@ class DeviceType:
     def __new__(cls, *args, **kwargs):
         return super().__new__(cls)
 
-    def __init__(self, definition, file_path):
+    def __init__(self, definition, file_path, change_type):
         self.file_path = file_path
         self.isDevice = True
         self.definition = definition
@@ -16,6 +16,7 @@ class DeviceType:
         self.part_number = definition.get('part_number', "")
         self._slug_part_number = self._slugify_part_number()
         self.failureMessage = None
+        self.change_type = change_type
 
     def _slugify_manufacturer(self):
         return self.manufacturer.casefold().replace(" ", "-").replace("sfp+", "sfpp").replace("poe+", "poep").replace("-+", "-plus-").replace("+", "-plus").replace("_", "-").replace("!", "").replace("/", "-").replace(",", "").replace("'", "").replace("*", "-").replace("&", "and")
@@ -48,8 +49,9 @@ class DeviceType:
             pass
         elif len(known_slug_list_intersect) == 1:
             if self.file_path not in known_slug_list_intersect[0][1]:
-                self.failureMessage = f'{self.file_path} has a duplicate slug: "{self.slug}"'
-                return False
+                if 'R' not in self.change_type:
+                    self.failureMessage = f'{self.file_path} has a duplicate slug: "{self.slug}"'
+                    return False
             return True
         else:
             self.failureMessage = f'{self.file_path} has a duplicate slug "{self.slug}"'
@@ -126,7 +128,7 @@ class ModuleType:
     def __new__(cls, *args, **kwargs):
         return super().__new__(cls)
 
-    def __init__(self, definition, file_path):
+    def __init__(self, definition, file_path, change_type):
         self.file_path = file_path
         self.isDevice = False
         self.definition = definition
@@ -135,6 +137,7 @@ class ModuleType:
         self._slug_model = self._slugify_model()
         self.part_number = definition.get('part_number', "")
         self._slug_part_number = self._slugify_part_number()
+        self.change_type = change_type
 
     def get_filepath(self):
         return self.file_path


### PR DESCRIPTION
As discovered in #1667 by @mihailim we have a missing test case (failure during test run) when a file is renamed to a valid name, but the slug and/or part number does not change. These changes implement checking for renamed files which should solve the issue