### PR TITLE
Fixed Mellanox SX6036

### DIFF
--- a/device-types/Mellanox/SX6036.yml
+++ b/device-types/Mellanox/SX6036.yml
@@ -8,10 +8,10 @@ console-ports:
   - name: Console
     type: rj-45
 power-ports:
-  - name: psu1
+  - name: PS1
     type: iec-60320-c14
     maximum_draw: 500
-  - name: psu2
+  - name: PS2
     type: iec-60320-c14
     maximum_draw: 500
 interfaces:
@@ -22,74 +22,74 @@ interfaces:
     type: 1000base-t
     mgmt_only: true
   - name: IB1/1
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/2
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/3
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/4
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/5
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/6
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/7
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/8
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/9
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/10
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/11
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/12
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/13
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/14
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/15
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/16
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/17
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/18
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/19
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/20
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/21
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/22
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/23
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/24
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/25
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/26
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/27
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/28
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/29
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/30
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/31
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/32
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/33
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/34
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/35
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr
   - name: IB1/36
-    type: 40gbase-x-qsfpp
+    type: infiniband-fdr


### PR DESCRIPTION
- Default port mode is IB FDR
- PSUs are PS1 and PS2 in OS

Similar to SX6012, which we still have