### PR TITLE
Fortigate 3200D, 1000D and powersupply bays

### DIFF
--- a/device-types/Fortinet/FG-1000D.yaml
+++ b/device-types/Fortinet/FG-1000D.yaml
@@ -5,6 +5,7 @@ part_number: FG-1000D
 slug: fortinet-fg-1000d
 is_full_depth: false
 u_height: 2
+airflow: front-to-rear
 weight: 11.2
 weight_unit: kg
 console-ports:

--- a/device-types/Fortinet/FG-1000D.yaml
+++ b/device-types/Fortinet/FG-1000D.yaml
@@ -1,41 +1,49 @@
 ---
 manufacturer: Fortinet
-model: FortiGate 300E
-slug: fortinet-fg-300e
-part_number: FG-300E
-u_height: 1
+model: FortiGate 1000D
+part_number: FG-1000D
+slug: fortinet-fg-1000d
 is_full_depth: false
-comments: Same as FG-301E , but **WITHOUT** 2 x 240GB SSD on-board.
+u_height: 2
+weight: 11.2
+weight_unit: kg
 console-ports:
   - name: Console
     type: rj-45
+  - name: usbmgmt
+    type: usb-mini-b
+  - name: usbport1
+    type: usb-a
+  - name: usbport2
+    type: usb-a
 module-bays:
   - name: PS1
     position: '1'
   - name: PS2
     position: '2'
 interfaces:
-  - name: ha
+  - name: mgmt1
     type: 1000base-t
-  - name: mgmt
+    mgmt_only: true
+  - name: mgmt2
     type: 1000base-t
     mgmt_only: true
   - name: port1
-    type: 1000base-t
+    type: 1000base-x-sfp
   - name: port2
-    type: 1000base-t
+    type: 1000base-x-sfp
   - name: port3
-    type: 1000base-t
+    type: 1000base-x-sfp
   - name: port4
-    type: 1000base-t
+    type: 1000base-x-sfp
   - name: port5
-    type: 1000base-t
+    type: 1000base-x-sfp
   - name: port6
-    type: 1000base-t
+    type: 1000base-x-sfp
   - name: port7
-    type: 1000base-t
+    type: 1000base-x-sfp
   - name: port8
-    type: 1000base-t
+    type: 1000base-x-sfp
   - name: port9
     type: 1000base-t
   - name: port10
@@ -69,18 +77,22 @@ interfaces:
   - name: port24
     type: 1000base-x-sfp
   - name: port25
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: port26
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: port27
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: port28
-    type: 1000base-x-sfp
-  - name: s1
-    type: 1000base-x-sfp
-  - name: s2
-    type: 1000base-x-sfp
-  - name: vw1
-    type: 1000base-x-sfp
-  - name: vw2
-    type: 1000base-x-sfp
+    type: 1000base-t
+  - name: port29
+    type: 1000base-t
+  - name: port30
+    type: 1000base-t
+  - name: port31
+    type: 1000base-t
+  - name: port32
+    type: 1000base-t
+  - name: portA
+    type: 10gbase-x-sfpp
+  - name: portB
+    type: 10gbase-x-sfpp

--- a/device-types/Fortinet/FG-3200D.yaml
+++ b/device-types/Fortinet/FG-3200D.yaml
@@ -1,0 +1,124 @@
+---
+manufacturer: Fortinet
+model: FortiGate 3200D
+part_number: FG-3200D
+slug: fortinet-fg-3200d
+is_full_depth: true
+u_height: 2
+weight: 17.2
+weight_unit: kg
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: usbmgmt
+    type: usb-mini-b
+  - name: usbport
+    type: usb-a
+module-bays:
+  - name: PS1
+    position: '1'
+  - name: PS2
+    position: '2'
+interfaces:
+  - name: mgmt1
+    type: 1000base-t
+    mgmt_only: true
+  - name: mgmt2
+    type: 1000base-t
+    mgmt_only: true
+  - name: port1
+    type: 10gbase-x-sfpp
+  - name: port2
+    type: 10gbase-x-sfpp
+  - name: port3
+    type: 10gbase-x-sfpp
+  - name: port4
+    type: 10gbase-x-sfpp
+  - name: port5
+    type: 10gbase-x-sfpp
+  - name: port6
+    type: 10gbase-x-sfpp
+  - name: port7
+    type: 10gbase-x-sfpp
+  - name: port8
+    type: 10gbase-x-sfpp
+  - name: port9
+    type: 10gbase-x-sfpp
+  - name: port10
+    type: 10gbase-x-sfpp
+  - name: port11
+    type: 10gbase-x-sfpp
+  - name: port12
+    type: 10gbase-x-sfpp
+  - name: port13
+    type: 10gbase-x-sfpp
+  - name: port14
+    type: 10gbase-x-sfpp
+  - name: port15
+    type: 10gbase-x-sfpp
+  - name: port16
+    type: 10gbase-x-sfpp
+  - name: port17
+    type: 10gbase-x-sfpp
+  - name: port18
+    type: 10gbase-x-sfpp
+  - name: port19
+    type: 10gbase-x-sfpp
+  - name: port20
+    type: 10gbase-x-sfpp
+  - name: port21
+    type: 10gbase-x-sfpp
+  - name: port22
+    type: 10gbase-x-sfpp
+  - name: port23
+    type: 10gbase-x-sfpp
+  - name: port24
+    type: 10gbase-x-sfpp
+  - name: port25
+    type: 10gbase-x-sfpp
+  - name: port26
+    type: 10gbase-x-sfpp
+  - name: port27
+    type: 10gbase-x-sfpp
+  - name: port28
+    type: 10gbase-x-sfpp
+  - name: port29
+    type: 10gbase-x-sfpp
+  - name: port30
+    type: 10gbase-x-sfpp
+  - name: port31
+    type: 10gbase-x-sfpp
+  - name: port32
+    type: 10gbase-x-sfpp
+  - name: port33
+    type: 10gbase-x-sfpp
+  - name: port34
+    type: 10gbase-x-sfpp
+  - name: port35
+    type: 10gbase-x-sfpp
+  - name: port36
+    type: 10gbase-x-sfpp
+  - name: port37
+    type: 10gbase-x-sfpp
+  - name: port38
+    type: 10gbase-x-sfpp
+  - name: port39
+    type: 10gbase-x-sfpp
+  - name: port40
+    type: 10gbase-x-sfpp
+  - name: port41
+    type: 10gbase-x-sfpp
+  - name: port42
+    type: 10gbase-x-sfpp
+  - name: port43
+    type: 10gbase-x-sfpp
+  - name: port44
+    type: 10gbase-x-sfpp
+  - name: port45
+    type: 10gbase-x-sfpp
+  - name: port46
+    type: 10gbase-x-sfpp
+  - name: port47
+    type: 10gbase-x-sfpp
+  - name: port48
+    type: 10gbase-x-sfpp

--- a/device-types/Fortinet/FG-3200D.yaml
+++ b/device-types/Fortinet/FG-3200D.yaml
@@ -5,6 +5,7 @@ part_number: FG-3200D
 slug: fortinet-fg-3200d
 is_full_depth: true
 u_height: 2
+airflow: front-to-rear
 weight: 17.2
 weight_unit: kg
 console-ports:

--- a/device-types/Fortinet/FG-500E.yaml
+++ b/device-types/Fortinet/FG-500E.yaml
@@ -8,15 +8,11 @@ is_full_depth: false
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
+module-bays:
   - name: PS1
-    type: iec-60320-c14
-    maximum_draw: 193
-    allocated_draw: 95
+    position: '1'
   - name: PS2
-    type: iec-60320-c14
-    maximum_draw: 193
-    allocated_draw: 95
+    position: '2'
 interfaces:
   - name: ha
     type: 1000base-t

--- a/device-types/Fortinet/FG-600E.yaml
+++ b/device-types/Fortinet/FG-600E.yaml
@@ -9,16 +9,11 @@ comments: Same as FG-601E , but **WITHOUT** 2 x 240GB SSDs on-board.
 console-ports:
   - name: Console
     type: rj-45
-power-ports:
+module-bays:
   - name: PS1
-    type: iec-60320-c14
-    maximum_draw: 244
-    allocated_draw: 129
-  # Option to install a second PSU Uncomment out to add
-  #- name: PS1
-  #  type: iec-60320-c14
-  #  maximum_draw: 244
-  #  allocated_draw: 129
+    position: '1'
+  - name: PS2
+    position: '2'
 interfaces:
   - name: ha
     type: 1000base-t


### PR DESCRIPTION
I have removed some information on the power supply ports because those fortigates have power supply bays and each power supply has its own part number.