### PR TITLE
Netgear M5300 series

### DIFF
--- a/device-types/Netgear/GSM7228PS.yaml
+++ b/device-types/Netgear/GSM7228PS.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7228ps
 part_number: GSM7228PS
 comments: '[GSM7228PS – ProSAFE 28-Port-L2-Managed-Stackable-Gigabit-Ethernet-Switch with PoE](https://netgear.de/support/product/gsm7228ps#docs)'
 u_height: 1
+weight: 6.3
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 535
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-t

--- a/device-types/Netgear/GSM7228PS.yaml
+++ b/device-types/Netgear/GSM7228PS.yaml
@@ -1,0 +1,69 @@
+---
+manufacturer: Netgear
+model: ProSafe M5300-28G-POE+ (GSM7228PS)
+slug: netgear-prosafe-gsm7228ps
+part_number: GSM7228PS
+comments: '[GSM7228PS – ProSAFE 28-Port-L2-Managed-Stackable-Gigabit-Ethernet-Switch with PoE](https://netgear.de/support/product/gsm7228ps#docs)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 535
+interfaces:
+  - name: 1/0/1
+    type: 1000base-t
+  - name: 1/0/2
+    type: 1000base-t
+  - name: 1/0/3
+    type: 1000base-t
+  - name: 1/0/4
+    type: 1000base-t
+  - name: 1/0/5
+    type: 1000base-t
+  - name: 1/0/6
+    type: 1000base-t
+  - name: 1/0/7
+    type: 1000base-t
+  - name: 1/0/8
+    type: 1000base-t
+  - name: 1/0/9
+    type: 1000base-t
+  - name: 1/0/10
+    type: 1000base-t
+  - name: 1/0/11
+    type: 1000base-t
+  - name: 1/0/12
+    type: 1000base-t
+  - name: 1/0/13
+    type: 1000base-t
+  - name: 1/0/14
+    type: 1000base-t
+  - name: 1/0/15
+    type: 1000base-t
+  - name: 1/0/16
+    type: 1000base-t
+  - name: 1/0/17
+    type: 1000base-t
+  - name: 1/0/18
+    type: 1000base-t
+  - name: 1/0/19
+    type: 1000base-t
+  - name: 1/0/20
+    type: 1000base-t
+  - name: 1/0/21
+    type: 1000base-t
+  - name: 1/0/22
+    type: 1000base-t
+  - name: 1/0/23
+    type: 1000base-t
+  - name: 1/0/24
+    type: 1000base-t
+  - name: 1/0/25
+    type: 1000base-x-sfp
+  - name: 1/0/26
+    type: 1000base-x-sfp
+  - name: 1/0/27
+    type: 1000base-x-sfp
+  - name: 1/0/28
+    type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7228S.yaml
+++ b/device-types/Netgear/GSM7228S.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7228s
 part_number: GSM7228S
 comments: '[M5300-28G (GSM7228S) – ProSAFE 24-Port-L2+-Managed-Stackable-Gigabit-Switch](https://netgear.de/support/product/m5300-28g%20(gsm7228s)#docs)'
 u_height: 1
+weight: 6.3
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 55
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-t

--- a/device-types/Netgear/GSM7228S.yaml
+++ b/device-types/Netgear/GSM7228S.yaml
@@ -1,0 +1,69 @@
+---
+manufacturer: Netgear
+model: ProSafe M5300-28G (GSM7228S)
+slug: netgear-prosafe-gsm7228s
+part_number: GSM7228S
+comments: '[M5300-28G (GSM7228S) – ProSAFE 24-Port-L2+-Managed-Stackable-Gigabit-Switch](https://netgear.de/support/product/m5300-28g%20(gsm7228s)#docs)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 55
+interfaces:
+  - name: 1/0/1
+    type: 1000base-t
+  - name: 1/0/2
+    type: 1000base-t
+  - name: 1/0/3
+    type: 1000base-t
+  - name: 1/0/4
+    type: 1000base-t
+  - name: 1/0/5
+    type: 1000base-t
+  - name: 1/0/6
+    type: 1000base-t
+  - name: 1/0/7
+    type: 1000base-t
+  - name: 1/0/8
+    type: 1000base-t
+  - name: 1/0/9
+    type: 1000base-t
+  - name: 1/0/10
+    type: 1000base-t
+  - name: 1/0/11
+    type: 1000base-t
+  - name: 1/0/12
+    type: 1000base-t
+  - name: 1/0/13
+    type: 1000base-t
+  - name: 1/0/14
+    type: 1000base-t
+  - name: 1/0/15
+    type: 1000base-t
+  - name: 1/0/16
+    type: 1000base-t
+  - name: 1/0/17
+    type: 1000base-t
+  - name: 1/0/18
+    type: 1000base-t
+  - name: 1/0/19
+    type: 1000base-t
+  - name: 1/0/20
+    type: 1000base-t
+  - name: 1/0/21
+    type: 1000base-t
+  - name: 1/0/22
+    type: 1000base-t
+  - name: 1/0/23
+    type: 1000base-t
+  - name: 1/0/24
+    type: 1000base-t
+  - name: 1/0/25
+    type: 1000base-x-sfp
+  - name: 1/0/26
+    type: 1000base-x-sfp
+  - name: 1/0/27
+    type: 1000base-x-sfp
+  - name: 1/0/28
+    type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7252PS.yaml
+++ b/device-types/Netgear/GSM7252PS.yaml
@@ -1,0 +1,117 @@
+---
+manufacturer: Netgear
+model: ProSafe M5300-52G-POE+ (GSM7252PS)
+slug: netgear-prosafe-gsm7252ps
+part_number: GSM7252PS
+comments: '[GSM7252PS – ProSAFE 52-Port-L2-Managed-Stackable-Gigabit-Ethernet-Switch with PoE](https://netgear.de/support/product/gsm7252ps#docs)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 556
+interfaces:
+  - name: 1/0/1
+    type: 1000base-t
+  - name: 1/0/2
+    type: 1000base-t
+  - name: 1/0/3
+    type: 1000base-t
+  - name: 1/0/4
+    type: 1000base-t
+  - name: 1/0/5
+    type: 1000base-t
+  - name: 1/0/6
+    type: 1000base-t
+  - name: 1/0/7
+    type: 1000base-t
+  - name: 1/0/8
+    type: 1000base-t
+  - name: 1/0/9
+    type: 1000base-t
+  - name: 1/0/10
+    type: 1000base-t
+  - name: 1/0/11
+    type: 1000base-t
+  - name: 1/0/12
+    type: 1000base-t
+  - name: 1/0/13
+    type: 1000base-t
+  - name: 1/0/14
+    type: 1000base-t
+  - name: 1/0/15
+    type: 1000base-t
+  - name: 1/0/16
+    type: 1000base-t
+  - name: 1/0/17
+    type: 1000base-t
+  - name: 1/0/18
+    type: 1000base-t
+  - name: 1/0/19
+    type: 1000base-t
+  - name: 1/0/20
+    type: 1000base-t
+  - name: 1/0/21
+    type: 1000base-t
+  - name: 1/0/22
+    type: 1000base-t
+  - name: 1/0/23
+    type: 1000base-t
+  - name: 1/0/24
+    type: 1000base-t
+  - name: 1/0/25
+    type: 1000base-t
+  - name: 1/0/26
+    type: 1000base-t
+  - name: 1/0/27
+    type: 1000base-t
+  - name: 1/0/28
+    type: 1000base-t
+  - name: 1/0/29
+    type: 1000base-t
+  - name: 1/0/30
+    type: 1000base-t
+  - name: 1/0/31
+    type: 1000base-t
+  - name: 1/0/32
+    type: 1000base-t
+  - name: 1/0/33
+    type: 1000base-t
+  - name: 1/0/34
+    type: 1000base-t
+  - name: 1/0/35
+    type: 1000base-t
+  - name: 1/0/36
+    type: 1000base-t
+  - name: 1/0/37
+    type: 1000base-t
+  - name: 1/0/38
+    type: 1000base-t
+  - name: 1/0/39
+    type: 1000base-t
+  - name: 1/0/40
+    type: 1000base-t
+  - name: 1/0/41
+    type: 1000base-t
+  - name: 1/0/42
+    type: 1000base-t
+  - name: 1/0/43
+    type: 1000base-t
+  - name: 1/0/44
+    type: 1000base-t
+  - name: 1/0/45
+    type: 1000base-t
+  - name: 1/0/46
+    type: 1000base-t
+  - name: 1/0/47
+    type: 1000base-t
+  - name: 1/0/48
+    type: 1000base-t
+  - name: 1/0/49
+    type: 1000base-x-sfp
+  - name: 1/0/50
+    type: 1000base-x-sfp
+  - name: 1/0/51
+    type: 1000base-x-sfp
+  - name: 1/0/52
+    type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7252PS.yaml
+++ b/device-types/Netgear/GSM7252PS.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7252ps
 part_number: GSM7252PS
 comments: '[GSM7252PS – ProSAFE 52-Port-L2-Managed-Stackable-Gigabit-Ethernet-Switch with PoE](https://netgear.de/support/product/gsm7252ps#docs)'
 u_height: 1
+weight: 6.8
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 556
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-t

--- a/device-types/Netgear/GSM7252S.yaml
+++ b/device-types/Netgear/GSM7252S.yaml
@@ -1,0 +1,117 @@
+---
+manufacturer: Netgear
+model: ProSafe M5300-52G (GSM7252S)
+slug: netgear-prosafe-gsm7252s
+part_number: GSM7252S
+comments: '[M5300-52G (GSM7252S) – ProSAFE 48-Port-L2+-Managed-Stackable-Gigabit-Switch](https://netgear.de/support/product/m5300-52g%20(gsm7252s)#docs)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 79
+interfaces:
+  - name: 1/0/1
+    type: 1000base-t
+  - name: 1/0/2
+    type: 1000base-t
+  - name: 1/0/3
+    type: 1000base-t
+  - name: 1/0/4
+    type: 1000base-t
+  - name: 1/0/5
+    type: 1000base-t
+  - name: 1/0/6
+    type: 1000base-t
+  - name: 1/0/7
+    type: 1000base-t
+  - name: 1/0/8
+    type: 1000base-t
+  - name: 1/0/9
+    type: 1000base-t
+  - name: 1/0/10
+    type: 1000base-t
+  - name: 1/0/11
+    type: 1000base-t
+  - name: 1/0/12
+    type: 1000base-t
+  - name: 1/0/13
+    type: 1000base-t
+  - name: 1/0/14
+    type: 1000base-t
+  - name: 1/0/15
+    type: 1000base-t
+  - name: 1/0/16
+    type: 1000base-t
+  - name: 1/0/17
+    type: 1000base-t
+  - name: 1/0/18
+    type: 1000base-t
+  - name: 1/0/19
+    type: 1000base-t
+  - name: 1/0/20
+    type: 1000base-t
+  - name: 1/0/21
+    type: 1000base-t
+  - name: 1/0/22
+    type: 1000base-t
+  - name: 1/0/23
+    type: 1000base-t
+  - name: 1/0/24
+    type: 1000base-t
+  - name: 1/0/25
+    type: 1000base-t
+  - name: 1/0/26
+    type: 1000base-t
+  - name: 1/0/27
+    type: 1000base-t
+  - name: 1/0/28
+    type: 1000base-t
+  - name: 1/0/29
+    type: 1000base-t
+  - name: 1/0/30
+    type: 1000base-t
+  - name: 1/0/31
+    type: 1000base-t
+  - name: 1/0/32
+    type: 1000base-t
+  - name: 1/0/33
+    type: 1000base-t
+  - name: 1/0/34
+    type: 1000base-t
+  - name: 1/0/35
+    type: 1000base-t
+  - name: 1/0/36
+    type: 1000base-t
+  - name: 1/0/37
+    type: 1000base-t
+  - name: 1/0/38
+    type: 1000base-t
+  - name: 1/0/39
+    type: 1000base-t
+  - name: 1/0/40
+    type: 1000base-t
+  - name: 1/0/41
+    type: 1000base-t
+  - name: 1/0/42
+    type: 1000base-t
+  - name: 1/0/43
+    type: 1000base-t
+  - name: 1/0/44
+    type: 1000base-t
+  - name: 1/0/45
+    type: 1000base-t
+  - name: 1/0/46
+    type: 1000base-t
+  - name: 1/0/47
+    type: 1000base-t
+  - name: 1/0/48
+    type: 1000base-t
+  - name: 1/0/49
+    type: 1000base-x-sfp
+  - name: 1/0/50
+    type: 1000base-x-sfp
+  - name: 1/0/51
+    type: 1000base-x-sfp
+  - name: 1/0/52
+    type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7252S.yaml
+++ b/device-types/Netgear/GSM7252S.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7252s
 part_number: GSM7252S
 comments: '[M5300-52G (GSM7252S) – ProSAFE 48-Port-L2+-Managed-Stackable-Gigabit-Switch](https://netgear.de/support/product/m5300-52g%20(gsm7252s)#docs)'
 u_height: 1
+weight: 6.8
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 79
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-t

--- a/device-types/Netgear/GSM7328FS.yaml
+++ b/device-types/Netgear/GSM7328FS.yaml
@@ -1,0 +1,69 @@
+---
+manufacturer: Netgear
+model: ProSafe GSM7328FS
+slug: netgear-prosafe-gsm7328fs
+part_number: GSM7328FS
+comments: '[GSM7328FS – ProSAFE L3-Managed-Stackable-Switch (24 SFP, 4 GbE)](https://netgear.de/support/product/gsm7328fs#docs)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 78
+interfaces:
+  - name: 1/0/1
+    type: 1000base-x-sfp
+  - name: 1/0/2
+    type: 1000base-x-sfp
+  - name: 1/0/3
+    type: 1000base-x-sfp
+  - name: 1/0/4
+    type: 1000base-x-sfp
+  - name: 1/0/5
+    type: 1000base-x-sfp
+  - name: 1/0/6
+    type: 1000base-x-sfp
+  - name: 1/0/7
+    type: 1000base-x-sfp
+  - name: 1/0/8
+    type: 1000base-x-sfp
+  - name: 1/0/9
+    type: 1000base-x-sfp
+  - name: 1/0/10
+    type: 1000base-x-sfp
+  - name: 1/0/11
+    type: 1000base-x-sfp
+  - name: 1/0/12
+    type: 1000base-x-sfp
+  - name: 1/0/13
+    type: 1000base-x-sfp
+  - name: 1/0/14
+    type: 1000base-x-sfp
+  - name: 1/0/15
+    type: 1000base-x-sfp
+  - name: 1/0/16
+    type: 1000base-x-sfp
+  - name: 1/0/17
+    type: 1000base-x-sfp
+  - name: 1/0/18
+    type: 1000base-x-sfp
+  - name: 1/0/19
+    type: 1000base-x-sfp
+  - name: 1/0/20
+    type: 1000base-x-sfp
+  - name: 1/0/21
+    type: 1000base-x-sfp
+  - name: 1/0/22
+    type: 1000base-x-sfp
+  - name: 1/0/23
+    type: 1000base-x-sfp
+  - name: 1/0/24
+    type: 1000base-x-sfp
+  - name: 1/0/25
+    type: 1000base-t
+  - name: 1/0/26
+    type: 1000base-t
+  - name: 1/0/27
+    type: 1000base-t
+  - name: 1/0/28
+    type: 1000base-t

--- a/device-types/Netgear/GSM7328FS.yaml
+++ b/device-types/Netgear/GSM7328FS.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7328fs
 part_number: GSM7328FS
 comments: '[GSM7328FS – ProSAFE L3-Managed-Stackable-Switch (24 SFP, 4 GbE)](https://netgear.de/support/product/gsm7328fs#docs)'
 u_height: 1
+weight: 5.4
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 78
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7328Sv1.yaml
+++ b/device-types/Netgear/GSM7328Sv1.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7328sv1
 part_number: GSM7328Sv1
 comments: '[GSM7328Sv1 – ProSAFE L3-Managed-Stackable-Gigabit-Ethernet-Switch (24+4)](https://netgear.de/support/product/gsm7328sv1#docs)'
 u_height: 1
+weight: 4.5
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 80
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-t

--- a/device-types/Netgear/GSM7328Sv1.yaml
+++ b/device-types/Netgear/GSM7328Sv1.yaml
@@ -1,0 +1,69 @@
+---
+manufacturer: Netgear
+model: ProSafe GSM7328Sv1
+slug: netgear-prosafe-gsm7328sv1
+part_number: GSM7328Sv1
+comments: '[GSM7328Sv1 – ProSAFE L3-Managed-Stackable-Gigabit-Ethernet-Switch (24+4)](https://netgear.de/support/product/gsm7328sv1#docs)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 80
+interfaces:
+  - name: 1/0/1
+    type: 1000base-t
+  - name: 1/0/2
+    type: 1000base-t
+  - name: 1/0/3
+    type: 1000base-t
+  - name: 1/0/4
+    type: 1000base-t
+  - name: 1/0/5
+    type: 1000base-t
+  - name: 1/0/6
+    type: 1000base-t
+  - name: 1/0/7
+    type: 1000base-t
+  - name: 1/0/8
+    type: 1000base-t
+  - name: 1/0/9
+    type: 1000base-t
+  - name: 1/0/10
+    type: 1000base-t
+  - name: 1/0/11
+    type: 1000base-t
+  - name: 1/0/12
+    type: 1000base-t
+  - name: 1/0/13
+    type: 1000base-t
+  - name: 1/0/14
+    type: 1000base-t
+  - name: 1/0/15
+    type: 1000base-t
+  - name: 1/0/16
+    type: 1000base-t
+  - name: 1/0/17
+    type: 1000base-t
+  - name: 1/0/18
+    type: 1000base-t
+  - name: 1/0/19
+    type: 1000base-t
+  - name: 1/0/20
+    type: 1000base-t
+  - name: 1/0/21
+    type: 1000base-t
+  - name: 1/0/22
+    type: 1000base-t
+  - name: 1/0/23
+    type: 1000base-t
+  - name: 1/0/24
+    type: 1000base-t
+  - name: 1/0/25
+    type: 1000base-x-sfp
+  - name: 1/0/26
+    type: 1000base-x-sfp
+  - name: 1/0/27
+    type: 1000base-x-sfp
+  - name: 1/0/28
+    type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7328Sv2.yaml
+++ b/device-types/Netgear/GSM7328Sv2.yaml
@@ -1,0 +1,69 @@
+---
+manufacturer: Netgear
+model: ProSafe GSM7328Sv2
+slug: netgear-prosafe-gsm7328sv2
+part_number: GSM7328Sv2
+comments: '[GSM7328Sv2 – ProSAFE L3-Managed-Stackable-Gigabit-Ethernet-Switch (24+4)](https://netgear.de/support/product/gsm7328sv2#docs)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 80
+interfaces:
+  - name: 1/0/1
+    type: 1000base-t
+  - name: 1/0/2
+    type: 1000base-t
+  - name: 1/0/3
+    type: 1000base-t
+  - name: 1/0/4
+    type: 1000base-t
+  - name: 1/0/5
+    type: 1000base-t
+  - name: 1/0/6
+    type: 1000base-t
+  - name: 1/0/7
+    type: 1000base-t
+  - name: 1/0/8
+    type: 1000base-t
+  - name: 1/0/9
+    type: 1000base-t
+  - name: 1/0/10
+    type: 1000base-t
+  - name: 1/0/11
+    type: 1000base-t
+  - name: 1/0/12
+    type: 1000base-t
+  - name: 1/0/13
+    type: 1000base-t
+  - name: 1/0/14
+    type: 1000base-t
+  - name: 1/0/15
+    type: 1000base-t
+  - name: 1/0/16
+    type: 1000base-t
+  - name: 1/0/17
+    type: 1000base-t
+  - name: 1/0/18
+    type: 1000base-t
+  - name: 1/0/19
+    type: 1000base-t
+  - name: 1/0/20
+    type: 1000base-t
+  - name: 1/0/21
+    type: 1000base-t
+  - name: 1/0/22
+    type: 1000base-t
+  - name: 1/0/23
+    type: 1000base-t
+  - name: 1/0/24
+    type: 1000base-t
+  - name: 1/0/25
+    type: 1000base-x-sfp
+  - name: 1/0/26
+    type: 1000base-x-sfp
+  - name: 1/0/27
+    type: 1000base-x-sfp
+  - name: 1/0/28
+    type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7328Sv2.yaml
+++ b/device-types/Netgear/GSM7328Sv2.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7328sv2
 part_number: GSM7328Sv2
 comments: '[GSM7328Sv2 – ProSAFE L3-Managed-Stackable-Gigabit-Ethernet-Switch (24+4)](https://netgear.de/support/product/gsm7328sv2#docs)'
 u_height: 1
+weight: 4.5
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 80
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-t

--- a/device-types/Netgear/GSM7352Sv1.yaml
+++ b/device-types/Netgear/GSM7352Sv1.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7352sv1
 part_number: GSM7352Sv1
 comments: '[GSM7352Sv1 – ProSAFE L3-Managed-Stackable-Gigabit-Ethernet-Switch (48+4)](https://netgear.de/support/product/gsm7352sv1)'
 u_height: 1
+weight: 5.4
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 80
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-t

--- a/device-types/Netgear/GSM7352Sv1.yaml
+++ b/device-types/Netgear/GSM7352Sv1.yaml
@@ -1,0 +1,117 @@
+---
+manufacturer: Netgear
+model: ProSafe GSM7352Sv1
+slug: netgear-prosafe-gsm7352sv1
+part_number: GSM7352Sv1
+comments: '[GSM7352Sv1 – ProSAFE L3-Managed-Stackable-Gigabit-Ethernet-Switch (48+4)](https://netgear.de/support/product/gsm7352sv1)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 80
+interfaces:
+  - name: 1/0/1
+    type: 1000base-t
+  - name: 1/0/2
+    type: 1000base-t
+  - name: 1/0/3
+    type: 1000base-t
+  - name: 1/0/4
+    type: 1000base-t
+  - name: 1/0/5
+    type: 1000base-t
+  - name: 1/0/6
+    type: 1000base-t
+  - name: 1/0/7
+    type: 1000base-t
+  - name: 1/0/8
+    type: 1000base-t
+  - name: 1/0/9
+    type: 1000base-t
+  - name: 1/0/10
+    type: 1000base-t
+  - name: 1/0/11
+    type: 1000base-t
+  - name: 1/0/12
+    type: 1000base-t
+  - name: 1/0/13
+    type: 1000base-t
+  - name: 1/0/14
+    type: 1000base-t
+  - name: 1/0/15
+    type: 1000base-t
+  - name: 1/0/16
+    type: 1000base-t
+  - name: 1/0/17
+    type: 1000base-t
+  - name: 1/0/18
+    type: 1000base-t
+  - name: 1/0/19
+    type: 1000base-t
+  - name: 1/0/20
+    type: 1000base-t
+  - name: 1/0/21
+    type: 1000base-t
+  - name: 1/0/22
+    type: 1000base-t
+  - name: 1/0/23
+    type: 1000base-t
+  - name: 1/0/24
+    type: 1000base-t
+  - name: 1/0/25
+    type: 1000base-t
+  - name: 1/0/26
+    type: 1000base-t
+  - name: 1/0/27
+    type: 1000base-t
+  - name: 1/0/28
+    type: 1000base-t
+  - name: 1/0/29
+    type: 1000base-t
+  - name: 1/0/30
+    type: 1000base-t
+  - name: 1/0/31
+    type: 1000base-t
+  - name: 1/0/32
+    type: 1000base-t
+  - name: 1/0/33
+    type: 1000base-t
+  - name: 1/0/34
+    type: 1000base-t
+  - name: 1/0/35
+    type: 1000base-t
+  - name: 1/0/36
+    type: 1000base-t
+  - name: 1/0/37
+    type: 1000base-t
+  - name: 1/0/38
+    type: 1000base-t
+  - name: 1/0/39
+    type: 1000base-t
+  - name: 1/0/40
+    type: 1000base-t
+  - name: 1/0/41
+    type: 1000base-t
+  - name: 1/0/42
+    type: 1000base-t
+  - name: 1/0/43
+    type: 1000base-t
+  - name: 1/0/44
+    type: 1000base-t
+  - name: 1/0/45
+    type: 1000base-t
+  - name: 1/0/46
+    type: 1000base-t
+  - name: 1/0/47
+    type: 1000base-t
+  - name: 1/0/48
+    type: 1000base-t
+  - name: 1/0/49
+    type: 1000base-x-sfp
+  - name: 1/0/50
+    type: 1000base-x-sfp
+  - name: 1/0/51
+    type: 1000base-x-sfp
+  - name: 1/0/52
+    type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7352Sv2.yaml
+++ b/device-types/Netgear/GSM7352Sv2.yaml
@@ -1,0 +1,117 @@
+---
+manufacturer: Netgear
+model: ProSafe GSM7352Sv2
+slug: netgear-prosafe-gsm7352sv2
+part_number: GSM7352Sv2
+comments: '[GSM7352Sv2 – ProSAFE L3-Managed-Stackable-Gigabit-Ethernet-Switch (48+4)](https://netgear.de/support/product/gsm7352sv2)'
+u_height: 1
+is_full_depth: false
+power-ports:
+  - name: Power
+    type: iec-60320-c14
+    maximum_draw: 92
+interfaces:
+  - name: 1/0/1
+    type: 1000base-t
+  - name: 1/0/2
+    type: 1000base-t
+  - name: 1/0/3
+    type: 1000base-t
+  - name: 1/0/4
+    type: 1000base-t
+  - name: 1/0/5
+    type: 1000base-t
+  - name: 1/0/6
+    type: 1000base-t
+  - name: 1/0/7
+    type: 1000base-t
+  - name: 1/0/8
+    type: 1000base-t
+  - name: 1/0/9
+    type: 1000base-t
+  - name: 1/0/10
+    type: 1000base-t
+  - name: 1/0/11
+    type: 1000base-t
+  - name: 1/0/12
+    type: 1000base-t
+  - name: 1/0/13
+    type: 1000base-t
+  - name: 1/0/14
+    type: 1000base-t
+  - name: 1/0/15
+    type: 1000base-t
+  - name: 1/0/16
+    type: 1000base-t
+  - name: 1/0/17
+    type: 1000base-t
+  - name: 1/0/18
+    type: 1000base-t
+  - name: 1/0/19
+    type: 1000base-t
+  - name: 1/0/20
+    type: 1000base-t
+  - name: 1/0/21
+    type: 1000base-t
+  - name: 1/0/22
+    type: 1000base-t
+  - name: 1/0/23
+    type: 1000base-t
+  - name: 1/0/24
+    type: 1000base-t
+  - name: 1/0/25
+    type: 1000base-t
+  - name: 1/0/26
+    type: 1000base-t
+  - name: 1/0/27
+    type: 1000base-t
+  - name: 1/0/28
+    type: 1000base-t
+  - name: 1/0/29
+    type: 1000base-t
+  - name: 1/0/30
+    type: 1000base-t
+  - name: 1/0/31
+    type: 1000base-t
+  - name: 1/0/32
+    type: 1000base-t
+  - name: 1/0/33
+    type: 1000base-t
+  - name: 1/0/34
+    type: 1000base-t
+  - name: 1/0/35
+    type: 1000base-t
+  - name: 1/0/36
+    type: 1000base-t
+  - name: 1/0/37
+    type: 1000base-t
+  - name: 1/0/38
+    type: 1000base-t
+  - name: 1/0/39
+    type: 1000base-t
+  - name: 1/0/40
+    type: 1000base-t
+  - name: 1/0/41
+    type: 1000base-t
+  - name: 1/0/42
+    type: 1000base-t
+  - name: 1/0/43
+    type: 1000base-t
+  - name: 1/0/44
+    type: 1000base-t
+  - name: 1/0/45
+    type: 1000base-t
+  - name: 1/0/46
+    type: 1000base-t
+  - name: 1/0/47
+    type: 1000base-t
+  - name: 1/0/48
+    type: 1000base-t
+  - name: 1/0/49
+    type: 1000base-x-sfp
+  - name: 1/0/50
+    type: 1000base-x-sfp
+  - name: 1/0/51
+    type: 1000base-x-sfp
+  - name: 1/0/52
+    type: 1000base-x-sfp

--- a/device-types/Netgear/GSM7352Sv2.yaml
+++ b/device-types/Netgear/GSM7352Sv2.yaml
@@ -5,11 +5,16 @@ slug: netgear-prosafe-gsm7352sv2
 part_number: GSM7352Sv2
 comments: '[GSM7352Sv2 – ProSAFE L3-Managed-Stackable-Gigabit-Ethernet-Switch (48+4)](https://netgear.de/support/product/gsm7352sv2)'
 u_height: 1
+weight: 5.4
+weight_unit: kg
 is_full_depth: false
 power-ports:
   - name: Power
     type: iec-60320-c14
     maximum_draw: 92
+console-ports:
+  - name: console
+    type: de-9
 interfaces:
   - name: 1/0/1
     type: 1000base-t


### PR DESCRIPTION
This includes the Netgear M5300 series of managed switches (24/48 port managed). If there's anything to change/update, drop me a note.

Unfortunately I have no images available, and while the manuals include proper front/back views of the devices, those likely conflict with this project's license, thus were not used.