### PR TITLE
Add Fortinet devices (10 switches, 1 firewall)

### DIFF
--- a/device-types/Fortinet/FG-90G.yaml
+++ b/device-types/Fortinet/FG-90G.yaml
@@ -1,0 +1,50 @@
+---
+manufacturer: Fortinet
+model: FortiGate 90G
+slug: fortinet-fg-90g
+part_number: FG-90G
+u_height: 1
+is_full_depth: false
+weight: 1.12
+weight_unit: kg
+airflow: side-to-rear
+comments: The 10G WAN interfaces and SFP+ interfaces are shared media ports
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: USB
+    type: usb-a
+power-ports:
+  - name: PSU1
+    type: dc-terminal
+    maximum_draw: 20
+    allocated_draw: 19
+    label: DC+12V
+  - name: PSU2
+    type: dc-terminal
+    maximum_draw: 20
+    allocated_draw: 19
+    label: DC+12V
+interfaces:
+  - name: internal1
+    type: 1000base-t
+  - name: internal2
+    type: 1000base-t
+  - name: internal3
+    type: 1000base-t
+  - name: internal4
+    type: 1000base-t
+  - name: internal5
+    type: 1000base-t
+  - name: internal6
+    type: 1000base-t
+  - name: a
+    type: 1000base-t
+  - name: b
+    type: 1000base-t
+  - name: wan1
+    type: 10gbase-x-sfpp
+    description: Shared media (You can use 1 of the 2 ports **WITH** this name. One is 10gbase-x-sfpp, the other is 10gbase-t.)
+  - name: wan2
+    type: 10gbase-x-sfpp
+    description: Shared media (You can use 1 of the 2 ports **WITH** this name. One is 1000base-x-sfp, the other is 10gbase-t.)

--- a/device-types/Fortinet/FS-108E-FPOE.yaml
+++ b/device-types/Fortinet/FS-108E-FPOE.yaml
@@ -1,0 +1,57 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 108E-FPOE
+slug: fortinet-fs-108e-fpoe
+part_number: FS-108E-FPOE
+u_height: 1
+weight: 2.04
+weight_unit: kg
+is_full_depth: false
+airflow: passive
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 108E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-108e-series-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 136
+    allocated_draw: 135
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-x-sfp
+  - name: port10
+    type: 1000base-x-sfp

--- a/device-types/Fortinet/FS-108E-POE.yaml
+++ b/device-types/Fortinet/FS-108E-POE.yaml
@@ -1,0 +1,49 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 108E-POE
+slug: fortinet-fs-108e-poe
+part_number: FS-108E-POE
+u_height: 1
+weight: 1.95
+weight_unit: kg
+is_full_depth: false
+airflow: passive
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 108E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-108e-series-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 71
+    allocated_draw: 70
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+  - name: port6
+    type: 1000base-t
+  - name: port7
+    type: 1000base-t
+  - name: port8
+    type: 1000base-t
+  - name: port9
+    type: 1000base-x-sfp
+  - name: port10
+    type: 1000base-x-sfp

--- a/device-types/Fortinet/FS-108F-FPOE.yaml
+++ b/device-types/Fortinet/FS-108F-FPOE.yaml
@@ -1,0 +1,57 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 108F-FPOE
+slug: fortinet-fs-108f-fpoe
+part_number: FS-108F-FPOE
+u_height: 1
+weight: 1.84
+weight_unit: kg
+is_full_depth: false
+airflow: passive
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 108F Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-108f-series-qsg)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 139
+    allocated_draw: 139
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-x-sfp
+  - name: port10
+    type: 1000base-x-sfp

--- a/device-types/Fortinet/FS-108F-POE.yaml
+++ b/device-types/Fortinet/FS-108F-POE.yaml
@@ -1,0 +1,57 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 108F-POE
+slug: fortinet-fs-108f-poe
+part_number: FS-108F-POE
+u_height: 1
+weight: 1.7
+weight_unit: kg
+is_full_depth: false
+airflow: passive
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 108F Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-108f-series-qsg)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 74
+    allocated_draw: 74
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-x-sfp
+  - name: port10
+    type: 1000base-x-sfp

--- a/device-types/Fortinet/FS-108F.yaml
+++ b/device-types/Fortinet/FS-108F.yaml
@@ -1,0 +1,44 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 108F
+slug: fortinet-fs-108f
+part_number: FS-108F
+u_height: 1
+weight: 0.62
+weight_unit: kg
+is_full_depth: false
+airflow: passive
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 108F Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-108f-series-qsg)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: dc-terminal
+    maximum_draw: 6
+    allocated_draw: 6
+    label: 12VDC
+interfaces:
+  - name: port1
+    type: 1000base-t
+  - name: port2
+    type: 1000base-t
+  - name: port3
+    type: 1000base-t
+  - name: port4
+    type: 1000base-t
+  - name: port5
+    type: 1000base-t
+  - name: port6
+    type: 1000base-t
+  - name: port7
+    type: 1000base-t
+  - name: port8
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+  - name: port9
+    type: 1000base-x-sfp
+  - name: port10
+    type: 1000base-x-sfp

--- a/device-types/Fortinet/FS-124E-FPOE.yaml
+++ b/device-types/Fortinet/FS-124E-FPOE.yaml
@@ -1,0 +1,125 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 124E-FPOE
+slug: fortinet-fs-124e-fpoe
+part_number: FS-124E-FPOE
+u_height: 1
+weight: 5.03
+weight_unit: kg
+is_full_depth: false
+airflow: side-to-rear
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 124E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-124e-series-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 390
+    allocated_draw: 387
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port13
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port14
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port15
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port16
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port17
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port18
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port19
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port20
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port21
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port22
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port23
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port24
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port25
+    type: 1000base-x-sfp
+  - name: port26
+    type: 1000base-x-sfp
+  - name: port27
+    type: 1000base-x-sfp
+  - name: port28
+    type: 1000base-x-sfp

--- a/device-types/Fortinet/FS-124E-POE.yaml
+++ b/device-types/Fortinet/FS-124E-POE.yaml
@@ -1,0 +1,101 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 124E-POE
+slug: fortinet-fs-124e-poe
+part_number: FS-124E-POE
+u_height: 1
+weight: 5.03
+weight_unit: kg
+is_full_depth: false
+airflow: side-to-rear
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 124E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-124e-series-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 205
+    allocated_draw: 202
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port13
+    type: 1000base-t
+  - name: port14
+    type: 1000base-t
+  - name: port15
+    type: 1000base-t
+  - name: port16
+    type: 1000base-t
+  - name: port17
+    type: 1000base-t
+  - name: port18
+    type: 1000base-t
+  - name: port19
+    type: 1000base-t
+  - name: port20
+    type: 1000base-t
+  - name: port21
+    type: 1000base-t
+  - name: port22
+    type: 1000base-t
+  - name: port23
+    type: 1000base-t
+  - name: port24
+    type: 1000base-t
+  - name: port25
+    type: 1000base-x-sfp
+  - name: port26
+    type: 1000base-x-sfp
+  - name: port27
+    type: 1000base-x-sfp
+  - name: port28
+    type: 1000base-x-sfp

--- a/device-types/Fortinet/FS-124F-FPOE.yaml
+++ b/device-types/Fortinet/FS-124F-FPOE.yaml
@@ -1,0 +1,127 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 124F-FPOE
+slug: fortinet-fs-124f-fpoe
+part_number: FS-124F-FPOE
+u_height: 1
+weight: 3.82
+weight_unit: kg
+is_full_depth: false
+airflow: side-to-rear
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 124F Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-124f-series-qsg)'
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: USB
+    type: usb-a
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 451
+    allocated_draw: 449
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port13
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port14
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port15
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port16
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port17
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port18
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port19
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port20
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port21
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port22
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port23
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port24
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port25
+    type: 10gbase-x-sfpp
+  - name: port26
+    type: 10gbase-x-sfpp
+  - name: port27
+    type: 10gbase-x-sfpp
+  - name: port28
+    type: 10gbase-x-sfpp

--- a/device-types/Fortinet/FS-124F-POE.yaml
+++ b/device-types/Fortinet/FS-124F-POE.yaml
@@ -1,0 +1,103 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 124F-POE
+slug: fortinet-fs-124f-poe
+part_number: FS-124F-POE
+u_height: 1
+weight: 3.56
+weight_unit: kg
+is_full_depth: false
+airflow: side-to-rear
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 124F Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-124f-series-qsg)'
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: USB
+    type: usb-a
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 237
+    allocated_draw: 235
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port13
+    type: 1000base-t
+  - name: port14
+    type: 1000base-t
+  - name: port15
+    type: 1000base-t
+  - name: port16
+    type: 1000base-t
+  - name: port17
+    type: 1000base-t
+  - name: port18
+    type: 1000base-t
+  - name: port19
+    type: 1000base-t
+  - name: port20
+    type: 1000base-t
+  - name: port21
+    type: 1000base-t
+  - name: port22
+    type: 1000base-t
+  - name: port23
+    type: 1000base-t
+  - name: port24
+    type: 1000base-t
+  - name: port25
+    type: 10gbase-x-sfpp
+  - name: port26
+    type: 10gbase-x-sfpp
+  - name: port27
+    type: 10gbase-x-sfpp
+  - name: port28
+    type: 10gbase-x-sfpp

--- a/device-types/Fortinet/FS-248E-POE.yaml
+++ b/device-types/Fortinet/FS-248E-POE.yaml
@@ -1,0 +1,180 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 248E-POE
+slug: fortinet-fs-248e-poe
+part_number: FS-248E-POE
+u_height: 1
+weight: 5.5
+weight_unit: kg
+is_full_depth: false
+airflow: side-to-rear
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch 248E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-248e-series-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 466
+    allocated_draw: 457
+  - name: RPScon
+    type: dc-terminal
+    maximum_draw: 466
+    allocated_draw: 457
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port13
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port14
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port15
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port16
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port17
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port18
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port19
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port20
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port21
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port22
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port23
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port24
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port25
+    type: 1000base-t
+  - name: port26
+    type: 1000base-t
+  - name: port27
+    type: 1000base-t
+  - name: port28
+    type: 1000base-t
+  - name: port29
+    type: 1000base-t
+  - name: port30
+    type: 1000base-t
+  - name: port31
+    type: 1000base-t
+  - name: port32
+    type: 1000base-t
+  - name: port33
+    type: 1000base-t
+  - name: port34
+    type: 1000base-t
+  - name: port35
+    type: 1000base-t
+  - name: port36
+    type: 1000base-t
+  - name: port37
+    type: 1000base-t
+  - name: port38
+    type: 1000base-t
+  - name: port39
+    type: 1000base-t
+  - name: port40
+    type: 1000base-t
+  - name: port41
+    type: 1000base-t
+  - name: port42
+    type: 1000base-t
+  - name: port43
+    type: 1000base-t
+  - name: port44
+    type: 1000base-t
+  - name: port45
+    type: 1000base-t
+  - name: port46
+    type: 1000base-t
+  - name: port47
+    type: 1000base-t
+  - name: port48
+    type: 1000base-t
+  - name: port49
+    type: 1000base-x-sfp
+  - name: port50
+    type: 1000base-x-sfp
+  - name: port51
+    type: 1000base-x-sfp
+  - name: port52
+    type: 1000base-x-sfp
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true


### PR DESCRIPTION
Add device types:
- FortiGate 90G
- FortiSwitch 108E-FPOE
- FortiSwitch 108E-POE
- FortiSwitch 108F-FPOE
- FortiSwitch 108F-POE
- FortiSwitch 108F
- FortiSwitch 124E-FPOE
- FortiSwitch 124E-POE
- FortiSwitch 124F-FPOE
- FortiSwitch 124F-POE
- FortiSwitch 248E-POE