### PR TITLE
Update CCR2004-16G-2S-Plus.yaml

### DIFF
--- a/device-types/MikroTik/CCR2004-16G-2S-Plus.yaml
+++ b/device-types/MikroTik/CCR2004-16G-2S-Plus.yaml
@@ -32,6 +32,12 @@ interfaces:
     type: 1000base-t
   - name: ether13
     type: 1000base-t
+  - name: ether14
+    type: 1000base-t
+  - name: ether15
+    type: 1000base-t
+  - name: ether16
+    type: 1000base-t
   - name: sfp-sfpplus1
     type: 10gbase-x-sfpp
   - name: sfp-sfpplus2


### PR DESCRIPTION
The CCR2004-16G-2S-Plus, as the name implies, has 16 ethernet ports, instead of the 13 specified before