### PR TITLE
Updated JSON schema to allow `description`

### DIFF
--- a/schema/devicetype.json
+++ b/schema/devicetype.json
@@ -103,6 +103,9 @@
                 "$ref": "components.json#/definitions/inventory-item"
             }
         },
+        "description": {
+            "type": "string"
+        },
         "comments": {
             "type": "string"
         }

--- a/schema/moduletype.json
+++ b/schema/moduletype.json
@@ -58,6 +58,9 @@
                 "$ref": "components.json#/definitions/rear-port"
             }
         },
+        "description": {
+            "type": "string"
+        },
         "comments": {
             "type": "string"
         }


### PR DESCRIPTION
I missed the commend after issue #1715 closed the first time.  The schema is the same as the one for `comment` so I'm not sure what kind of tests would be needed.