### PR TITLE
Fix wrong port types and add missing portsl, add FG-1801F

### DIFF
--- a/device-types/Fortinet/FG-1801F.yaml
+++ b/device-types/Fortinet/FG-1801F.yaml
@@ -1,11 +1,11 @@
 ---
 manufacturer: Fortinet
-model: FortiGate 1800F
-slug: fortinet-fg-1800f
-part_number: FG-1800F
+model: FortiGate 1801F
+slug: fortinet-fg-1801f
+part_number: FG-1801F
 u_height: 2
 is_full_depth: true
-weight: 13.7
+weight: 13.8
 weight_unit: kg
 airflow: front-to-rear
 comments: '[FortiGate 1800F Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/fortigate-1800f-series.pdf)'


### PR DESCRIPTION
- Add missing HA ports
- Fixed port speed SFP28 instead of SFP+
- Fixed port speed QSFP28 instead of QSFP
- Changed power supplies to modular
- Add link to Datasheet to comments
- Fixed name of mgmt2 port
- Add model FG-1801F