### PR TITLE
renames Watchguard to WatchGuard

### DIFF
--- a/device-types/WatchGuard/Firebox-M370.yaml
+++ b/device-types/WatchGuard/Firebox-M370.yaml
@@ -1,5 +1,5 @@
 ---
-manufacturer: Watchguard
+manufacturer: WatchGuard
 model: Firebox M370
 slug: watchguard-firebox-m370
 u_height: 1.0

--- a/device-types/WatchGuard/Firebox-T80.yaml
+++ b/device-types/WatchGuard/Firebox-T80.yaml
@@ -1,5 +1,5 @@
 ---
-manufacturer: Watchguard
+manufacturer: WatchGuard
 model: Firebox T80
 slug: watchguard-firebox-t80
 u_height: 1.0


### PR DESCRIPTION
Having to nearly identical manufacturer definitions which in the end result in the same slug value makes importing the whole list impossible.

This commit removes Watchguard and renames to manufacturer of both Firebox device types to WatchGuard.

This fixes issue #1970 