### PR TITLE
fix: multiple fixes on Panduit odf and cassettes

### DIFF
--- a/device-types/Panduit/FRME1.yaml
+++ b/device-types/Panduit/FRME1.yaml
@@ -7,7 +7,7 @@ u_height: 1
 is_full_depth: false
 subdevice_role: parent
 is_powered: false
-device-bays:
+module-bays:
   - name: A
   - name: B
   - name: C

--- a/device-types/Panduit/FRME2.yaml
+++ b/device-types/Panduit/FRME2.yaml
@@ -7,7 +7,7 @@ u_height: 2
 is_full_depth: false
 subdevice_role: parent
 is_powered: false
-device-bays:
+module-bays:
   - name: A
   - name: B
   - name: C

--- a/device-types/Panduit/FRME4.yaml
+++ b/device-types/Panduit/FRME4.yaml
@@ -7,7 +7,7 @@ u_height: 4
 is_full_depth: false
 subdevice_role: parent
 is_powered: false
-device-bays:
+module-bays:
   - name: A
   - name: B
   - name: C

--- a/module-types/Panduit/FC29N-24-10AS.yaml
+++ b/module-types/Panduit/FC29N-24-10AS.yaml
@@ -3,55 +3,130 @@ manufacturer: Panduit
 model: Opticom MPO-LC Fiber Cassette OS2, 24 Fiber, Method A
 part_number: FC29N-24-10AS
 front-ports:
-  - name: '01'
+  - name: '{module}:01'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 1
-  - name: '02'
+    label: 01-A
+  - name: '{module}:02'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 2
-  - name: '03'
+    label: 01-B
+  - name: '{module}:03'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 3
-  - name: '04'
+    label: 02-A
+  - name: '{module}:04'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 4
-  - name: '05'
+    label: 02-B
+  - name: '{module}:05'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 5
-  - name: '06'
+    label: 03-A
+  - name: '{module}:06'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 6
-  - name: '07'
+    label: 03-B
+  - name: '{module}:07'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 7
-  - name: '08'
+    label: 04-A
+  - name: '{module}:08'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 8
-  - name: '09'
+    label: 04-B
+  - name: '{module}:09'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 9
-  - name: '10'
+    label: 05-A
+  - name: '{module}:10'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 10
-  - name: '11'
+    label: 05-B
+  - name: '{module}:11'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 11
-  - name: '12'
+    label: 06-A
+  - name: '{module}:12'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 12
+    label: 06-B
+  - name: '{module}:13'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 1
+    label: 07-A
+  - name: '{module}:14'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 2
+    label: 07-B
+  - name: '{module}:15'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 3
+    label: 08-A
+  - name: '{module}:16'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 4
+    label: 08-B
+  - name: '{module}:17'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 5
+    label: 09-A
+  - name: '{module}:18'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 6
+    label: 09-B
+  - name: '{module}:19'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 7
+    label: 10-A
+  - name: '{module}:20'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 8
+    label: 10-B
+  - name: '{module}:21'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 9
+    label: 11-A
+  - name: '{module}:22'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 10
+    label: 11-B
+  - name: '{module}:23'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 11
+    label: 12-A
+  - name: '{module}:24'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 12
+    label: 12-B
 rear-ports:
-  - name: '01'
+  - name: '{module}:1'
+    type: mpo
+    positions: 12
+  - name: '{module}:2'
     type: mpo
     positions: 12

--- a/module-types/Panduit/FC29N-24-10U.yaml
+++ b/module-types/Panduit/FC29N-24-10U.yaml
@@ -3,55 +3,130 @@ manufacturer: Panduit
 model: Opticom MPO-LC Fiber Cassette OS2, 24 Fiber, Universal
 part_number: FC29N-24-10U
 front-ports:
-  - name: '01'
+  - name: '{module}:01'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
+    label: 01-A
     rear_port_position: 1
-  - name: '02'
+  - name: '{module}:02'
     type: lc
-    rear_port: '01'
-    rear_port_position: 2
-  - name: '03'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 3
-  - name: '04'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 4
-  - name: '05'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 5
-  - name: '06'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 6
-  - name: '07'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 7
-  - name: '08'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 8
-  - name: '09'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 9
-  - name: '10'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 10
-  - name: '11'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 11
-  - name: '12'
-    type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
+    label: 01-B
     rear_port_position: 12
+  - name: '{module}:03'
+    type: lc
+    rear_port: '{module}:1'
+    label: 02-A
+    rear_port_position: 2
+  - name: '{module}:04'
+    type: lc
+    rear_port: '{module}:1'
+    label: 02-B
+    rear_port_position: 11
+  - name: '{module}:05'
+    type: lc
+    rear_port: '{module}:1'
+    label: 03-A
+    rear_port_position: 3
+  - name: '{module}:06'
+    type: lc
+    rear_port: '{module}:1'
+    label: 03-B
+    rear_port_position: 10
+  - name: '{module}:07'
+    type: lc
+    rear_port: '{module}:1'
+    label: 04-A
+    rear_port_position: 4
+  - name: '{module}:08'
+    type: lc
+    rear_port: '{module}:1'
+    label: 04-B
+    rear_port_position: 9
+  - name: '{module}:09'
+    type: lc
+    rear_port: '{module}:1'
+    label: 05-A
+    rear_port_position: 5
+  - name: '{module}:10'
+    type: lc
+    rear_port: '{module}:1'
+    label: 05-B
+    rear_port_position: 8
+  - name: '{module}:11'
+    type: lc
+    rear_port: '{module}:1'
+    label: 06-A
+    rear_port_position: 6
+  - name: '{module}:12'
+    type: lc
+    rear_port: '{module}:1'
+    label: 06-B
+    rear_port_position: 7
+  - name: '{module}:13'
+    type: lc
+    rear_port: '{module}:2'
+    label: 07-A
+    rear_port_position: 1
+  - name: '{module}:14'
+    type: lc
+    rear_port: '{module}:2'
+    label: 07-B
+    rear_port_position: 12
+  - name: '{module}:15'
+    type: lc
+    rear_port: '{module}:2'
+    label: 08-A
+    rear_port_position: 2
+  - name: '{module}:16'
+    type: lc
+    rear_port: '{module}:2'
+    label: 08-B
+    rear_port_position: 11
+  - name: '{module}:17'
+    type: lc
+    rear_port: '{module}:2'
+    label: 09-A
+    rear_port_position: 3
+  - name: '{module}:18'
+    type: lc
+    rear_port: '{module}:2'
+    label: 09-B
+    rear_port_position: 10
+  - name: '{module}:19'
+    type: lc
+    rear_port: '{module}:2'
+    label: 10-A
+    rear_port_position: 4
+  - name: '{module}:20'
+    type: lc
+    rear_port: '{module}:2'
+    label: 10-B
+    rear_port_position: 9
+  - name: '{module}:21'
+    type: lc
+    rear_port: '{module}:2'
+    label: 11-A
+    rear_port_position: 5
+  - name: '{module}:22'
+    type: lc
+    rear_port: '{module}:2'
+    label: 11-B
+    rear_port_position: 8
+  - name: '{module}:23'
+    type: lc
+    rear_port: '{module}:2'
+    label: 12-A
+    rear_port_position: 6
+  - name: '{module}:24'
+    type: lc
+    rear_port: '{module}:2'
+    label: 12-B
+    rear_port_position: 7
 rear-ports:
-  - name: '01'
+  - name: '{module}:1'
+    type: mpo
+    positions: 12
+  - name: '{module}:2'
     type: mpo
     positions: 12

--- a/module-types/Panduit/FC29N-24-10U.yaml
+++ b/module-types/Panduit/FC29N-24-10U.yaml
@@ -7,122 +7,122 @@ front-ports:
     type: lc
     rear_port: '{module}:1'
     label: 01-A
-    rear_port_position: 1
+    rear_port_position: 12
   - name: '{module}:02'
     type: lc
     rear_port: '{module}:1'
     label: 01-B
-    rear_port_position: 12
+    rear_port_position: 1
   - name: '{module}:03'
     type: lc
     rear_port: '{module}:1'
     label: 02-A
-    rear_port_position: 2
+    rear_port_position: 11
   - name: '{module}:04'
     type: lc
     rear_port: '{module}:1'
     label: 02-B
-    rear_port_position: 11
+    rear_port_position: 2
   - name: '{module}:05'
     type: lc
     rear_port: '{module}:1'
     label: 03-A
-    rear_port_position: 3
+    rear_port_position: 10
   - name: '{module}:06'
     type: lc
     rear_port: '{module}:1'
     label: 03-B
-    rear_port_position: 10
+    rear_port_position: 3
   - name: '{module}:07'
     type: lc
     rear_port: '{module}:1'
     label: 04-A
-    rear_port_position: 4
+    rear_port_position: 9
   - name: '{module}:08'
     type: lc
     rear_port: '{module}:1'
     label: 04-B
-    rear_port_position: 9
+    rear_port_position: 4
   - name: '{module}:09'
     type: lc
     rear_port: '{module}:1'
     label: 05-A
-    rear_port_position: 5
+    rear_port_position: 8
   - name: '{module}:10'
     type: lc
     rear_port: '{module}:1'
     label: 05-B
-    rear_port_position: 8
+    rear_port_position: 5
   - name: '{module}:11'
     type: lc
     rear_port: '{module}:1'
     label: 06-A
-    rear_port_position: 6
+    rear_port_position: 7
   - name: '{module}:12'
     type: lc
     rear_port: '{module}:1'
     label: 06-B
-    rear_port_position: 7
+    rear_port_position: 6
   - name: '{module}:13'
     type: lc
     rear_port: '{module}:2'
     label: 07-A
-    rear_port_position: 1
+    rear_port_position: 12
   - name: '{module}:14'
     type: lc
     rear_port: '{module}:2'
     label: 07-B
-    rear_port_position: 12
+    rear_port_position: 1
   - name: '{module}:15'
     type: lc
     rear_port: '{module}:2'
     label: 08-A
-    rear_port_position: 2
+    rear_port_position: 11
   - name: '{module}:16'
     type: lc
     rear_port: '{module}:2'
     label: 08-B
-    rear_port_position: 11
+    rear_port_position: 2
   - name: '{module}:17'
     type: lc
     rear_port: '{module}:2'
     label: 09-A
-    rear_port_position: 3
+    rear_port_position: 10
   - name: '{module}:18'
     type: lc
     rear_port: '{module}:2'
     label: 09-B
-    rear_port_position: 10
+    rear_port_position: 3
   - name: '{module}:19'
     type: lc
     rear_port: '{module}:2'
     label: 10-A
-    rear_port_position: 4
+    rear_port_position: 9
   - name: '{module}:20'
     type: lc
     rear_port: '{module}:2'
     label: 10-B
-    rear_port_position: 9
+    rear_port_position: 4
   - name: '{module}:21'
     type: lc
     rear_port: '{module}:2'
     label: 11-A
-    rear_port_position: 5
+    rear_port_position: 8
   - name: '{module}:22'
     type: lc
     rear_port: '{module}:2'
     label: 11-B
-    rear_port_position: 8
+    rear_port_position: 5
   - name: '{module}:23'
     type: lc
     rear_port: '{module}:2'
     label: 12-A
-    rear_port_position: 6
+    rear_port_position: 7
   - name: '{module}:24'
     type: lc
     rear_port: '{module}:2'
     label: 12-B
-    rear_port_position: 7
+    rear_port_position: 6
 rear-ports:
   - name: '{module}:1'
     type: mpo

--- a/module-types/Panduit/FC2XO-24-10AS.yaml
+++ b/module-types/Panduit/FC2XO-24-10AS.yaml
@@ -3,55 +3,130 @@ manufacturer: Panduit
 model: Opticom MPO-LC Fiber Cassette OM3, 24 Fiber, Method A
 part_number: FC2XO-24-10AS
 front-ports:
-  - name: '01'
+  - name: '{module}:01'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 1
-  - name: '02'
+    label: 01-A
+  - name: '{module}:02'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 2
-  - name: '03'
+    label: 01-B
+  - name: '{module}:03'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 3
-  - name: '04'
+    label: 02-A
+  - name: '{module}:04'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 4
-  - name: '05'
+    label: 02-B
+  - name: '{module}:05'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 5
-  - name: '06'
+    label: 03-A
+  - name: '{module}:06'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 6
-  - name: '07'
+    label: 03-B
+  - name: '{module}:07'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 7
-  - name: '08'
+    label: 04-A
+  - name: '{module}:08'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 8
-  - name: '09'
+    label: 04-B
+  - name: '{module}:09'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 9
-  - name: '10'
+    label: 05-A
+  - name: '{module}:10'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 10
-  - name: '11'
+    label: 05-B
+  - name: '{module}:11'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 11
-  - name: '12'
+    label: 06-A
+  - name: '{module}:12'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
     rear_port_position: 12
+    label: 06-B
+  - name: '{module}:13'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 1
+    label: 07-A
+  - name: '{module}:14'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 2
+    label: 07-B
+  - name: '{module}:15'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 3
+    label: 08-A
+  - name: '{module}:16'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 4
+    label: 08-B
+  - name: '{module}:17'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 5
+    label: 09-A
+  - name: '{module}:18'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 6
+    label: 09-B
+  - name: '{module}:19'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 7
+    label: 10-A
+  - name: '{module}:20'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 8
+    label: 10-B
+  - name: '{module}:21'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 9
+    label: 11-A
+  - name: '{module}:22'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 10
+    label: 11-B
+  - name: '{module}:23'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 11
+    label: 12-A
+  - name: '{module}:24'
+    type: lc
+    rear_port: '{module}:2'
+    rear_port_position: 12
+    label: 12-B
 rear-ports:
-  - name: '01'
+  - name: '{module}:1'
+    type: mpo
+    positions: 12
+  - name: '{module}:2'
     type: mpo
     positions: 12

--- a/module-types/Panduit/FC2XO-24-10U.yaml
+++ b/module-types/Panduit/FC2XO-24-10U.yaml
@@ -3,55 +3,130 @@ manufacturer: Panduit
 model: Opticom MPO-LC Fiber Cassette OM3, 24 Fiber, Universal
 part_number: FC2XO-24-10U
 front-ports:
-  - name: '01'
+  - name: '{module}:01'
     type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
+    label: 01-A
     rear_port_position: 1
-  - name: '02'
+  - name: '{module}:02'
     type: lc
-    rear_port: '01'
-    rear_port_position: 2
-  - name: '03'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 3
-  - name: '04'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 4
-  - name: '05'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 5
-  - name: '06'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 6
-  - name: '07'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 7
-  - name: '08'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 8
-  - name: '09'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 9
-  - name: '10'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 10
-  - name: '11'
-    type: lc
-    rear_port: '01'
-    rear_port_position: 11
-  - name: '12'
-    type: lc
-    rear_port: '01'
+    rear_port: '{module}:1'
+    label: 01-B
     rear_port_position: 12
+  - name: '{module}:03'
+    type: lc
+    rear_port: '{module}:1'
+    label: 02-A
+    rear_port_position: 2
+  - name: '{module}:04'
+    type: lc
+    rear_port: '{module}:1'
+    label: 02-B
+    rear_port_position: 11
+  - name: '{module}:05'
+    type: lc
+    rear_port: '{module}:1'
+    label: 03-A
+    rear_port_position: 3
+  - name: '{module}:06'
+    type: lc
+    rear_port: '{module}:1'
+    label: 03-B
+    rear_port_position: 10
+  - name: '{module}:07'
+    type: lc
+    rear_port: '{module}:1'
+    label: 04-A
+    rear_port_position: 4
+  - name: '{module}:08'
+    type: lc
+    rear_port: '{module}:1'
+    label: 04-B
+    rear_port_position: 9
+  - name: '{module}:09'
+    type: lc
+    rear_port: '{module}:1'
+    label: 05-A
+    rear_port_position: 5
+  - name: '{module}:10'
+    type: lc
+    rear_port: '{module}:1'
+    label: 05-B
+    rear_port_position: 8
+  - name: '{module}:11'
+    type: lc
+    rear_port: '{module}:1'
+    label: 06-A
+    rear_port_position: 6
+  - name: '{module}:12'
+    type: lc
+    rear_port: '{module}:1'
+    label: 06-B
+    rear_port_position: 7
+  - name: '{module}:13'
+    type: lc
+    rear_port: '{module}:2'
+    label: 07-A
+    rear_port_position: 1
+  - name: '{module}:14'
+    type: lc
+    rear_port: '{module}:2'
+    label: 07-B
+    rear_port_position: 12
+  - name: '{module}:15'
+    type: lc
+    rear_port: '{module}:2'
+    label: 08-A
+    rear_port_position: 2
+  - name: '{module}:16'
+    type: lc
+    rear_port: '{module}:2'
+    label: 08-B
+    rear_port_position: 11
+  - name: '{module}:17'
+    type: lc
+    rear_port: '{module}:2'
+    label: 09-A
+    rear_port_position: 3
+  - name: '{module}:18'
+    type: lc
+    rear_port: '{module}:2'
+    label: 09-B
+    rear_port_position: 10
+  - name: '{module}:19'
+    type: lc
+    rear_port: '{module}:2'
+    label: 10-A
+    rear_port_position: 4
+  - name: '{module}:20'
+    type: lc
+    rear_port: '{module}:2'
+    label: 10-B
+    rear_port_position: 9
+  - name: '{module}:21'
+    type: lc
+    rear_port: '{module}:2'
+    label: 11-A
+    rear_port_position: 5
+  - name: '{module}:22'
+    type: lc
+    rear_port: '{module}:2'
+    label: 11-B
+    rear_port_position: 8
+  - name: '{module}:23'
+    type: lc
+    rear_port: '{module}:2'
+    label: 12-A
+    rear_port_position: 6
+  - name: '{module}:24'
+    type: lc
+    rear_port: '{module}:2'
+    label: 12-B
+    rear_port_position: 7
 rear-ports:
-  - name: '01'
+  - name: '{module}:1'
+    type: mpo
+    positions: 12
+  - name: '{module}:2'
     type: mpo
     positions: 12

--- a/module-types/Panduit/FC2XO-24-10U.yaml
+++ b/module-types/Panduit/FC2XO-24-10U.yaml
@@ -7,122 +7,122 @@ front-ports:
     type: lc
     rear_port: '{module}:1'
     label: 01-A
-    rear_port_position: 1
+    rear_port_position: 12
   - name: '{module}:02'
     type: lc
     rear_port: '{module}:1'
     label: 01-B
-    rear_port_position: 12
+    rear_port_position: 1
   - name: '{module}:03'
     type: lc
     rear_port: '{module}:1'
     label: 02-A
-    rear_port_position: 2
+    rear_port_position: 11
   - name: '{module}:04'
     type: lc
     rear_port: '{module}:1'
     label: 02-B
-    rear_port_position: 11
+    rear_port_position: 2
   - name: '{module}:05'
     type: lc
     rear_port: '{module}:1'
     label: 03-A
-    rear_port_position: 3
+    rear_port_position: 10
   - name: '{module}:06'
     type: lc
     rear_port: '{module}:1'
     label: 03-B
-    rear_port_position: 10
+    rear_port_position: 3
   - name: '{module}:07'
     type: lc
     rear_port: '{module}:1'
     label: 04-A
-    rear_port_position: 4
+    rear_port_position: 9
   - name: '{module}:08'
     type: lc
     rear_port: '{module}:1'
     label: 04-B
-    rear_port_position: 9
+    rear_port_position: 4
   - name: '{module}:09'
     type: lc
     rear_port: '{module}:1'
     label: 05-A
-    rear_port_position: 5
+    rear_port_position: 8
   - name: '{module}:10'
     type: lc
     rear_port: '{module}:1'
     label: 05-B
-    rear_port_position: 8
+    rear_port_position: 5
   - name: '{module}:11'
     type: lc
     rear_port: '{module}:1'
     label: 06-A
-    rear_port_position: 6
+    rear_port_position: 7
   - name: '{module}:12'
     type: lc
     rear_port: '{module}:1'
     label: 06-B
-    rear_port_position: 7
+    rear_port_position: 6
   - name: '{module}:13'
     type: lc
     rear_port: '{module}:2'
     label: 07-A
-    rear_port_position: 1
+    rear_port_position: 12
   - name: '{module}:14'
     type: lc
     rear_port: '{module}:2'
     label: 07-B
-    rear_port_position: 12
+    rear_port_position: 1
   - name: '{module}:15'
     type: lc
     rear_port: '{module}:2'
     label: 08-A
-    rear_port_position: 2
+    rear_port_position: 11
   - name: '{module}:16'
     type: lc
     rear_port: '{module}:2'
     label: 08-B
-    rear_port_position: 11
+    rear_port_position: 2
   - name: '{module}:17'
     type: lc
     rear_port: '{module}:2'
     label: 09-A
-    rear_port_position: 3
+    rear_port_position: 10
   - name: '{module}:18'
     type: lc
     rear_port: '{module}:2'
     label: 09-B
-    rear_port_position: 10
+    rear_port_position: 3
   - name: '{module}:19'
     type: lc
     rear_port: '{module}:2'
     label: 10-A
-    rear_port_position: 4
+    rear_port_position: 9
   - name: '{module}:20'
     type: lc
     rear_port: '{module}:2'
     label: 10-B
-    rear_port_position: 9
+    rear_port_position: 4
   - name: '{module}:21'
     type: lc
     rear_port: '{module}:2'
     label: 11-A
-    rear_port_position: 5
+    rear_port_position: 8
   - name: '{module}:22'
     type: lc
     rear_port: '{module}:2'
     label: 11-B
-    rear_port_position: 8
+    rear_port_position: 5
   - name: '{module}:23'
     type: lc
     rear_port: '{module}:2'
     label: 12-A
-    rear_port_position: 6
+    rear_port_position: 7
   - name: '{module}:24'
     type: lc
     rear_port: '{module}:2'
     label: 12-B
-    rear_port_position: 7
+    rear_port_position: 6
 rear-ports:
   - name: '{module}:1'
     type: mpo


### PR DESCRIPTION
These Panduit 12x duplex LC MPO Cassettes have 2x MPO 12 fiber rear ports, not a single MPO 24 fiber.
All positions are duplex.


- https://www.panduit.com/en/products/fiber-optic-systems/fiber-optic-panels-cassettes-enclosures/fiber-optic-cassettes/fc2xo-24-10as.html
- https://www.panduit.com/en/products/fiber-optic-systems/fiber-optic-panels-cassettes-enclosures/fiber-optic-cassettes/fc2xo-24-10u.html
- https://www.panduit.com/en/products/fiber-optic-systems/fiber-optic-panels-cassettes-enclosures/fiber-optic-cassettes/fc29n-24-10as.html
- https://www.panduit.com/en/products/fiber-optic-systems/fiber-optic-panels-cassettes-enclosures/fiber-optic-cassettes/fc29n-24-10u.html

