### PR TITLE
MOD - adding ACX7024 Juniper device type and ZPE NSR

### DIFF
--- a/device-types/Juniper/ACX7024-AC.yaml
+++ b/device-types/Juniper/ACX7024-AC.yaml
@@ -82,9 +82,3 @@ module-bays:
     maximum_draw: 150
     position: '1'
   - name: Fan Module 0
-  - name: Fan Module 1
-  - name: Fan Module 2
-  - name: Fan Module 3
-  - name: Fan Module 4
-  - name: Fan Module 5
-

--- a/device-types/Juniper/ACX7024-AC.yaml
+++ b/device-types/Juniper/ACX7024-AC.yaml
@@ -1,0 +1,90 @@
+---
+manufacturer: Juniper
+model: ACX7024-AC
+part_number: ACX7024
+slug: juniper-acx7024-ac
+u_height: 1
+weight: 12.5
+weight_unit: lb
+airflow: front-to-rear
+is_full_depth: false
+comments: '[Juniper ACX7024-AC Datasheet](https://www.juniper.net/us/en/products/routers/acx-series/acx7000-family-cloud-metro-routers/acx7000-line/acx7024-acx7024x-cloud-metro-routers-datasheet.html)'
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: re0:mgmt-0
+    type: 1000base-t
+    mgmt_only: true
+  - name: et-0/0/0
+    type: 100gbase-x-qsfp28
+  - name: et-0/0/1
+    type: 100gbase-x-qsfp28
+  - name: et-0/0/2
+    type: 100gbase-x-qsfp28
+  - name: et-0/0/3
+    type: 100gbase-x-qsfp28
+  - name: et-0/0/4
+    type: 25gbase-x-sfp28
+  - name: et-0/0/5
+    type: 25gbase-x-sfp28
+  - name: et-0/0/6
+    type: 25gbase-x-sfp28
+  - name: et-0/0/7
+    type: 25gbase-x-sfp28
+  - name: et-0/0/8
+    type: 25gbase-x-sfp28
+  - name: et-0/0/9
+    type: 25gbase-x-sfp28
+  - name: et-0/0/10
+    type: 25gbase-x-sfp28
+  - name: et-0/0/11
+    type: 25gbase-x-sfp28
+  - name: et-0/0/12
+    type: 25gbase-x-sfp28
+  - name: et-0/0/13
+    type: 25gbase-x-sfp28
+  - name: et-0/0/14
+    type: 25gbase-x-sfp28
+  - name: et-0/0/15
+    type: 25gbase-x-sfp28
+  - name: et-0/0/16
+    type: 25gbase-x-sfp28
+  - name: et-0/0/17
+    type: 25gbase-x-sfp28
+  - name: et-0/0/18
+    type: 25gbase-x-sfp28
+  - name: et-0/0/19
+    type: 25gbase-x-sfp28
+  - name: et-0/0/20
+    type: 25gbase-x-sfp28
+  - name: et-0/0/21
+    type: 25gbase-x-sfp28
+  - name: et-0/0/22
+    type: 25gbase-x-sfp28
+  - name: et-0/0/23
+    type: 25gbase-x-sfp28
+  - name: et-0/0/24
+    type: 25gbase-x-sfp28
+  - name: et-0/0/25
+    type: 25gbase-x-sfp28
+  - name: et-0/0/26
+    type: 25gbase-x-sfp28
+  - name: et-0/0/27
+    type: 25gbase-x-sfp28
+module-bays:
+  - name: PSM 0
+    # Comment: Power Supply Module 0
+    maximum_draw: 150
+    position: '0'
+  - name: PSM 1
+    # Comment: Power Supply Module 1
+    maximum_draw: 150
+    position: '1'
+  - name: Fan Module 0
+  - name: Fan Module 1
+  - name: Fan Module 2
+  - name: Fan Module 3
+  - name: Fan Module 4
+  - name: Fan Module 5
+

--- a/device-types/ZPE/NSR-BASE-DAC.yaml
+++ b/device-types/ZPE/NSR-BASE-DAC.yaml
@@ -1,0 +1,119 @@
+---
+manufacturer: ZPE
+model: NSR-BASE-DAC
+slug: zpe-nsr-base-dac
+part_number: NSR-BASE-DAC
+u_height: 1
+is_full_depth: true
+comments: ZPE Nodegrid Net Services Router. 16X RJ45 Serial, 20X ETH (18 GbE, 2 SFP+), 3X USB
+console-ports:
+  - name: Console
+    type: rj-45
+console-server-ports:
+  - name: ttyS1-1
+    type: rj-45
+  - name: ttyS1-2
+    type: rj-45
+  - name: ttyS1-3
+    type: rj-45
+  - name: ttyS1-4
+    type: rj-45
+  - name: ttyS1-5
+    type: rj-45
+  - name: ttyS1-6
+    type: rj-45
+  - name: ttyS1-7
+    type: rj-45
+  - name: ttyS1-8
+    type: rj-45
+  - name: ttyS1-9
+    type: rj-45
+  - name: ttyS1-10
+    type: rj-45
+  - name: ttyS1-11
+    type: rj-45
+  - name: ttyS1-12
+    type: rj-45
+  - name: ttyS1-13
+    type: rj-45
+  - name: ttyS1-14
+    type: rj-45
+  - name: ttyS1-15
+    type: rj-45
+  - name: ttyS1-16
+    type: rj-45
+  - name: usbS0-1
+    type: usb-a
+  - name: usbS0-2
+    type: usb-a
+  - name: usbS0-3
+    type: usb-a
+power-ports:
+  - name: PSU1
+    type: dc-terminal
+    allocated_draw: 45
+  - name: PSU2
+    type: dc-terminal
+    allocated_draw: 45
+interfaces:
+  - name: ETH0
+    type: 1000base-t
+  - name: ETH1
+    type: 1000base-t
+  - name: SFP0
+    type: 10gbase-x-sfpp
+  - name: SFP1
+    type: 10gbase-x-sfpp
+  - name: netS2-1
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-2
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-3
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-4
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-5
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-6
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-7
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-8
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-9
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-10
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-11
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-12
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-13
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-14
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-15
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+  - name: netS2-16
+    type: 1000base-t
+    poe_type: type2-ieee802.3at
+    # TODO 2xGPIO, 1xDigital Out, 1xRelay Port
+    # 1 x optional WiFi module
+    # SLOTS??? this is a modular device but this yaml file is a first pass
+    # 2 x LTE modem slots
+    # 1 x HDMI


### PR DESCRIPTION
The purpose of this PR is to replace legacy PR1955 which had binary files that were not required and should not have been committed.