### PR TITLE
Fix missing u_height for Mellanox/SX6012*

### DIFF
--- a/device-types/Mellanox/SX6012F-1BFS.yaml
+++ b/device-types/Mellanox/SX6012F-1BFS.yaml
@@ -6,6 +6,7 @@ part_number: MSX6012F-1BFS
 airflow: rear-to-front
 weight: 2.98
 weight_unit: kg
+u_height: 0
 subdevice_role: child
 console-ports:
   - name: Serial Console

--- a/device-types/Mellanox/SX6012F-1BRS.yaml
+++ b/device-types/Mellanox/SX6012F-1BRS.yaml
@@ -6,6 +6,7 @@ part_number: MSX6012F-1BRS
 airflow: front-to-rear
 weight: 2.98
 weight_unit: kg
+u_height: 0
 subdevice_role: child
 console-ports:
   - name: Serial Console

--- a/device-types/Mellanox/SX6012F-2BFS.yaml
+++ b/device-types/Mellanox/SX6012F-2BFS.yaml
@@ -6,6 +6,7 @@ part_number: MSX6012F-2BFS
 airflow: rear-to-front
 weight: 2.98
 weight_unit: kg
+u_height: 0
 subdevice_role: child
 console-ports:
   - name: Serial Console

--- a/device-types/Mellanox/SX6012F-2BRS.yaml
+++ b/device-types/Mellanox/SX6012F-2BRS.yaml
@@ -6,6 +6,7 @@ part_number: MSX6012F-2BRS
 airflow: front-to-rear
 weight: 2.98
 weight_unit: kg
+u_height: 0
 subdevice_role: child
 console-ports:
   - name: Serial Console

--- a/device-types/Mellanox/SX6012T-1BFS.yaml
+++ b/device-types/Mellanox/SX6012T-1BFS.yaml
@@ -6,6 +6,7 @@ part_number: MSX6012T-1BFS
 airflow: rear-to-front
 weight: 2.98
 weight_unit: kg
+u_height: 0
 subdevice_role: child
 console-ports:
   - name: Serial Console

--- a/device-types/Mellanox/SX6012T-2BFS.yaml
+++ b/device-types/Mellanox/SX6012T-2BFS.yaml
@@ -6,6 +6,7 @@ part_number: MSX6012T-2BFS
 airflow: rear-to-front
 weight: 2.98
 weight_unit: kg
+u_height: 0
 subdevice_role: child
 console-ports:
   - name: Serial Console


### PR DESCRIPTION
Add missing u_height field for child modules.

- Mellanox SX6012F-1BFS
- Mellanox SX6012F-1BRS
- Mellanox SX6012F-2BFS
- Mellanox SX6012F-2BRS
- Mellanox SX6012T-1BFS
- Mellanox SX6012T-2BFS

https://github.com/netbox-community/Device-Type-Library-Import/issues/123#issuecomment-2009982136