### PR TITLE
Incorrect rear_port ST-24-port-fiber-patch-panel-rear-splice

### DIFF
--- a/device-types/Generic/ST-24-port-fiber-patch-panel-rear-splice.yaml
+++ b/device-types/Generic/ST-24-port-fiber-patch-panel-rear-splice.yaml
@@ -155,7 +155,7 @@ rear-ports:
   - name: Port/17
     type: splice
     positions: 1
-  - name: Port/28
+  - name: Port/18
     type: splice
     positions: 1
   - name: Port/19


### PR DESCRIPTION
Rear port 18 was incorrectly named port 28. Causing the netbox-community/Device-Type-Library-Import to complain about the nonexistant port.

https://github.com/netbox-community/Device-Type-Library-Import/issues/123#issuecomment-2009982136