### PR TITLE
Master

### DIFF
--- a/device-types/Cisco/ASR-9904.yaml
+++ b/device-types/Cisco/ASR-9904.yaml
@@ -20,12 +20,14 @@ power-ports:
   - name: PS3
     type: iec-60320-c22
     maximum_draw: 3000
-device-bays:
+module-bays:
   - name: Slot 0
     label: LC 0
   - name: Slot 1
+    position: 0/RP0
     label: RSP 0
   - name: Slot 2
     label: RSP 1
+    position: 0/RP1
   - name: Slot 3
     label: LC 1

--- a/device-types/Cisco/ASR-9906.yaml
+++ b/device-types/Cisco/ASR-9906.yaml
@@ -26,8 +26,9 @@ power-ports:
   - name: PS5
     type: iec-60320-c22
     maximum_draw: 6000
-device-bays:
+module-bays:
   - name: Slot 0
+    position: 0/RP0
     label: RSP 0
   - name: Slot 1
     label: Line Card 0
@@ -39,3 +40,4 @@ device-bays:
     label: Line Card 3
   - name: Slot 5
     label: RSP 1
+    position: 0/RP1

--- a/device-types/Cisco/ASR-9910.yaml
+++ b/device-types/Cisco/ASR-9910.yaml
@@ -44,9 +44,10 @@ power-ports:
   - name: PS11
     type: iec-60320-c22
     maximum_draw: 6000
-device-bays:
+module-bays:
   - name: Slot 0
     label: RSP 0
+    position: 0/RP0
   - name: Slot 1
     label: Line Card 0
   - name: Slot 2
@@ -65,3 +66,4 @@ device-bays:
     label: Line Card 7
   - name: Slot 9
     label: RSP 1
+    position: 0/RP1


### PR DESCRIPTION
Change ASR99k's to use module bays instead of device bays to bring all the 9k's into the same standard.