### PR TITLE
Cisco Devices: Replace 'C' with 'Catalyst' in model

### DIFF
--- a/device-types/Cisco/C1000-16FP-2G-L.yaml
+++ b/device-types/Cisco/C1000-16FP-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-16FP-2G-L
+model: Catalyst 1000-16FP-2G-L
 slug: cisco-c1000-16fp-2g-l
 part_number: C1000-16FP-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-16P-2G-L.yaml
+++ b/device-types/Cisco/C1000-16P-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-16P-2G-L
+model: Catalyst 1000-16P-2G-L
 slug: cisco-c1000-16p-2g-l
 part_number: C1000-16P-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-16P-E-2G-L.yaml
+++ b/device-types/Cisco/C1000-16P-E-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-16P-E-2G-L
+model: Catalyst 1000-16P-E-2G-L
 slug: cisco-c1000-16p-e-2g-l
 part_number: C1000-16P-E-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-16T-2G-L.yaml
+++ b/device-types/Cisco/C1000-16T-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-16T-2G-L
+model: Catalyst 1000-16T-2G-L
 slug: cisco-c1000-16t-2g-l
 part_number: C1000-16T-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-16T-E-2G-L.yaml
+++ b/device-types/Cisco/C1000-16T-E-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-16T-E-2G-L
+model: Catalyst 1000-16T-E-2G-L
 slug: cisco-c1000-16t-e-2g-l
 part_number: C1000-16T-E-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-24FP-4G-L.yaml
+++ b/device-types/Cisco/C1000-24FP-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-24FP-4G-L
+model: Catalyst 1000-24FP-4G-L
 slug: cisco-c1000-24fp-4g-l
 part_number: C1000-24FP-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-24FP-4X-L.yaml
+++ b/device-types/Cisco/C1000-24FP-4X-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-24FP-4X-L
+model: Catalyst 1000-24FP-4X-L
 slug: cisco-c1000-24fp-4x-l
 part_number: C1000-24FP-4X-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-24P-4G-L.yaml
+++ b/device-types/Cisco/C1000-24P-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-24P-4G-L
+model: Catalyst 1000-24P-4G-L
 slug: cisco-c1000-24p-4g-l
 part_number: C1000-24P-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-24P-4X-L.yaml
+++ b/device-types/Cisco/C1000-24P-4X-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-24P-4X-L
+model: Catalyst 1000-24P-4X-L
 slug: cisco-c1000-24p-4x-l
 part_number: C1000-24P-4X-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-24T-4G-L.yaml
+++ b/device-types/Cisco/C1000-24T-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-24T-4G-L
+model: Catalyst 1000-24T-4G-L
 slug: cisco-c1000-24t-4g-l
 part_number: C1000-24T-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-24T-4X-L.yaml
+++ b/device-types/Cisco/C1000-24T-4X-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-24T-4X-L
+model: Catalyst 1000-24T-4X-L
 slug: cisco-c1000-24t-4x-l
 part_number: C1000-24T-4X-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-48FP-4G-L.yaml
+++ b/device-types/Cisco/C1000-48FP-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-48FP-4G-L
+model: Catalyst 1000-48FP-4G-L
 slug: cisco-c1000-48fp-4g-l
 part_number: C1000-48FP-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-48FP-4X-L.yaml
+++ b/device-types/Cisco/C1000-48FP-4X-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-48FP-4X-L
+model: Catalyst 1000-48FP-4X-L
 slug: cisco-c1000-48fp-4x-l
 part_number: C1000-48FP-4X-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-48P-4G-L.yaml
+++ b/device-types/Cisco/C1000-48P-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-48P-4G-L
+model: Catalyst 1000-48P-4G-L
 slug: cisco-c1000-48p-4g-l
 part_number: C1000-48P-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-48P-4X-L.yaml
+++ b/device-types/Cisco/C1000-48P-4X-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-48P-4X-L
+model: Catalyst 1000-48P-4X-L
 slug: cisco-c1000-48p-4x-l
 part_number: C1000-48P-4X-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-48T-4G-L.yaml
+++ b/device-types/Cisco/C1000-48T-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-48T-4G-L
+model: Catalyst 1000-48T-4G-L
 slug: cisco-c1000-48t-4g-l
 part_number: C1000-48T-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-48T-4X-L.yaml
+++ b/device-types/Cisco/C1000-48T-4X-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-48T-4X-L
+model: Catalyst 1000-48T-4X-L
 slug: cisco-c1000-48t-4x-l
 part_number: C1000-48T-4X-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-8FP-2G-L.yaml
+++ b/device-types/Cisco/C1000-8FP-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-8FP-2G-L
+model: Catalyst 1000-8FP-2G-L
 slug: cisco-c1000-8fp-2g-l
 part_number: C1000-8FP-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-8FP-E-2G-L.yaml
+++ b/device-types/Cisco/C1000-8FP-E-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-8FP-E-2G-L
+model: Catalyst 1000-8FP-E-2G-L
 slug: cisco-c1000-8fp-e-2g-l
 part_number: C1000-8FP-E-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-8P-2G-L.yaml
+++ b/device-types/Cisco/C1000-8P-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-8P-2G-L
+model: Catalyst 1000-8P-2G-L
 slug: cisco-c1000-8p-2g-l
 part_number: C1000-8P-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-8P-E-2G-L.yaml
+++ b/device-types/Cisco/C1000-8P-E-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-8P-E-2G-L
+model: Catalyst 1000-8P-E-2G-L
 slug: cisco-c1000-8p-e-2g-l
 part_number: C1000-8P-E-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-8T-2G-L.yaml
+++ b/device-types/Cisco/C1000-8T-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-8T-2G-L
+model: Catalyst 1000-8T-2G-L
 slug: cisco-c1000-8t-2g-l
 part_number: C1000-8T-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000-8T-E-2G-L.yaml
+++ b/device-types/Cisco/C1000-8T-E-2G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000-8T-E-2G-L
+model: Catalyst 1000-8T-E-2G-L
 slug: cisco-c1000-8t-e-2g-l
 part_number: C1000-8T-E-2G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000FE-24P-4G-L.yaml
+++ b/device-types/Cisco/C1000FE-24P-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000FE-24P-4G-L
+model: Catalyst 1000FE-24P-4G-L
 slug: cisco-c1000fe-24p-4g-l
 part_number: C1000FE-24P-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000FE-24T-4G-L.yaml
+++ b/device-types/Cisco/C1000FE-24T-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000FE-24T-4G-L
+model: Catalyst 1000FE-24T-4G-L
 slug: cisco-c1000fe-24t-4g-l
 part_number: C1000FE-24T-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000FE-48P-4G-L.yaml
+++ b/device-types/Cisco/C1000FE-48P-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000FE-48P-4G-L
+model: Catalyst 1000FE-48P-4G-L
 slug: cisco-c1000fe-48p-4g-l
 part_number: C1000FE-48P-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C1000FE-48T-4G-L.yaml
+++ b/device-types/Cisco/C1000FE-48T-4G-L.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C1000FE-48T-4G-L
+model: Catalyst 1000FE-48T-4G-L
 slug: cisco-c1000fe-48t-4g-l
 part_number: C1000FE-48T-4G-L
 comments: '[Cisco Catalyst 1000 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1k-ser-switch-ds-cte-en.html)'

--- a/device-types/Cisco/C6816-X-LE.yaml
+++ b/device-types/Cisco/C6816-X-LE.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C6816-X-LE
+model: Catalyst 6816-X-LE
 slug: cisco-c6816-x-le
 part_number: C6816-X-LE
 u_height: 2

--- a/device-types/Cisco/C6832-X-LE.yaml
+++ b/device-types/Cisco/C6832-X-LE.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C6832-X-LE
+model: Catalyst 6832-X-LE
 slug: cisco-c6832-x-le
 part_number: C6832-X-LE
 u_height: 2

--- a/device-types/Cisco/C6840-X-LE-40G.yaml
+++ b/device-types/Cisco/C6840-X-LE-40G.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C6840-X-LE-40G
+model: Catalyst 6840-X-LE-40G
 slug: cisco-c6840-x-le-40g
 part_number: C6840-X-LE-40G
 is_full_depth: false

--- a/device-types/Cisco/C7201.yaml
+++ b/device-types/Cisco/C7201.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Cisco
-model: C7201
-part_number: CISCO7201
+model: Catalyst 7201
+part_number: C7201
 slug: cisco-c7201
 comments: '[Cisco 7201 Data Sheet](https://www.cisco.com/c/en/us/products/collateral/routers/7201-router/product_data_sheet0900aecd80630b58.html)'
 u_height: 1

--- a/device-types/Cisco/C8300-1N1S-6T.yaml
+++ b/device-types/Cisco/C8300-1N1S-6T.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C8300-1N1S-6T
+model: Catalyst 8300-1N1S-6T
 slug: cisco-c8300-1n1s-6t
 part_number: C8300-1N1S-6T
 u_height: 1

--- a/device-types/Cisco/C8300-2N2S-4T2X.yaml
+++ b/device-types/Cisco/C8300-2N2S-4T2X.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C8300-2N2S-4T2X
+model: Catalyst 8300-2N2S-4T2X
 slug: cisco-c8300-2n2s-4t2x
 part_number: C8300-2N2S-4T2X
 u_height: 2

--- a/device-types/Cisco/C881-K9.yaml
+++ b/device-types/Cisco/C881-K9.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C881-K9
+model: Catalyst 881-K9
 part_number: C881-K9
 slug: cisco-c881-k9
 comments: Discontinued and no official datasheet on the Cisco website.

--- a/device-types/Cisco/C887VA-K9.yaml
+++ b/device-types/Cisco/C887VA-K9.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C887VA-K9
+model: Catalyst 887VA-K9
 part_number: C887VA-K9
 slug: cisco-c887va-k9
 comments: Discontinued and no official datasheet on the Cisco website.

--- a/device-types/Cisco/C891F-K9.yml
+++ b/device-types/Cisco/C891F-K9.yml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C891F
+model: Catalyst 891F
 part_number: C891F-K9
 slug: cisco-c891f-k9
 u_height: 1

--- a/device-types/Cisco/C9105AXI-E.yaml
+++ b/device-types/Cisco/C9105AXI-E.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9105AXI-E
+model: Catalyst 9105AXI-E
 slug: cisco-c9105axi-e
 part_number: C9105AXI-E
 u_height: 0

--- a/device-types/Cisco/C9115AXI-E.yaml
+++ b/device-types/Cisco/C9115AXI-E.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9115AXI-E
+model: Catalyst 9115AXI-E
 slug: cisco-c9115axi-e
 part_number: C9115AXI-E
 u_height: 0

--- a/device-types/Cisco/C9124AXI-E.yaml
+++ b/device-types/Cisco/C9124AXI-E.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9124AXI-E
+model: Catalyst 9124AXI-E
 slug: cisco-c9124axi-e
 part_number: C9124AXI-E
 u_height: 0

--- a/device-types/Cisco/C9200-24P.yaml
+++ b/device-types/Cisco/C9200-24P.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200-24P
+model: Catalyst 9200-24P
 part_number: C9200-24P
 slug: cisco-c9200-24p
 u_height: 1

--- a/device-types/Cisco/C9200-24T.yaml
+++ b/device-types/Cisco/C9200-24T.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200-24T
+model: Catalyst 9200-24T
 part_number: C9200-24T
 slug: cisco-c9200-24t
 u_height: 1

--- a/device-types/Cisco/C9200-48P.yaml
+++ b/device-types/Cisco/C9200-48P.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200-48P
+model: Catalyst 9200-48P
 part_number: C9200-48P
 slug: cisco-c9200-48p
 u_height: 1

--- a/device-types/Cisco/C9200-48T.yaml
+++ b/device-types/Cisco/C9200-48T.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200-48T
+model: Catalyst 9200-48T
 part_number: C9200-48T
 slug: cisco-c9200-48t
 u_height: 1

--- a/device-types/Cisco/C9200L-24P-4G-E.yaml
+++ b/device-types/Cisco/C9200L-24P-4G-E.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-24P-4G-E
+model: Catalyst 9200L-24P-4G-E
 part_number: C9200L-24P-4G-E
 slug: cisco-c9200l-24p-4g-e
 u_height: 1

--- a/device-types/Cisco/C9200L-24P-4G.yaml
+++ b/device-types/Cisco/C9200L-24P-4G.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-24P-4G
+model: Catalyst 9200L-24P-4G
 part_number: C9200L-24P-4G
 slug: cisco-c9200l-24p-4g
 u_height: 1

--- a/device-types/Cisco/C9200L-24P-4X.yaml
+++ b/device-types/Cisco/C9200L-24P-4X.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-24P-4X
+model: Catalyst 9200L-24P-4X
 part_number: C9200L-24P-4X
 slug: cisco-c9200l-24p-4x
 u_height: 1

--- a/device-types/Cisco/C9200L-24PXG-2Y.yaml
+++ b/device-types/Cisco/C9200L-24PXG-2Y.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-24PXG-2Y
+model: Catalyst 9200L-24PXG-2Y
 part_number: C9200L-24PXG-2Y
 slug: cisco-c9200l-24pxg-2y
 u_height: 1

--- a/device-types/Cisco/C9200L-24T-4G.yaml
+++ b/device-types/Cisco/C9200L-24T-4G.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-24T-4G
+model: Catalyst 9200L-24T-4G
 part_number: C9200L-24T-4G
 slug: cisco-c9200l-24t-4g
 u_height: 1

--- a/device-types/Cisco/C9200L-24T-4X.yaml
+++ b/device-types/Cisco/C9200L-24T-4X.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-24T-4X
+model: Catalyst 9200L-24T-4X
 part_number: C9200L-24T-4X
 slug: cisco-c9200l-24t-4x
 u_height: 1

--- a/device-types/Cisco/C9200L-48P-4G-E.yaml
+++ b/device-types/Cisco/C9200L-48P-4G-E.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-48P-4G-E
+model: Catalyst 9200L-48P-4G-E
 part_number: C9200L-48P-4G-E
 slug: cisco-c9200l-48p-4g-e
 u_height: 1

--- a/device-types/Cisco/C9200L-48P-4G.yaml
+++ b/device-types/Cisco/C9200L-48P-4G.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-48P-4G
+model: Catalyst 9200L-48P-4G
 part_number: C9200L-48P-4G
 slug: cisco-c9200l-48p-4g
 u_height: 1

--- a/device-types/Cisco/C9200L-48P-4X.yaml
+++ b/device-types/Cisco/C9200L-48P-4X.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-48P-4X
+model: Catalyst 9200L-48P-4X
 part_number: C9200L-48P-4X
 slug: cisco-c9200l-48p-4x
 u_height: 1

--- a/device-types/Cisco/C9200L-48PL-4G.yaml
+++ b/device-types/Cisco/C9200L-48PL-4G.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-48PL-4G
+model: Catalyst 9200L-48PL-4G
 part_number: C9200L-48PL-4G
 slug: cisco-c9200l-48pl-4g
 u_height: 1

--- a/device-types/Cisco/C9200L-48T-4G.yaml
+++ b/device-types/Cisco/C9200L-48T-4G.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-48T-4G
+model: Catalyst 9200L-48T-4G
 part_number: C9200L-48T-4G
 slug: cisco-c9200l-48t-4g
 u_height: 1

--- a/device-types/Cisco/C9200L-48T-4X.yaml
+++ b/device-types/Cisco/C9200L-48T-4X.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C9200L-48T-4X
+model: Catalyst 9200L-48T-4X
 part_number: C9200L-48T-4X
 slug: cisco-c9200l-48t-4x
 u_height: 1

--- a/device-types/Cisco/C921-4PLTEGB.yaml
+++ b/device-types/Cisco/C921-4PLTEGB.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Cisco
-model: C921-4PLTEGB
+model: Catalyst 921-4PLTEGB
 part_number: C921-4PLTEGB
 slug: cisco-c921-4pltegb
 comments: (Cisco 900 Series Integrated Services Routers Data Sheet)[https://www.cisco.com/c/en/us/products/collateral/routers/900-series-integrated-services-routers-isr/datasheet-c78-741615.html]


### PR DESCRIPTION
Counting models using Catalyst (215'ish) vs C (55'ish) this change proposes changing 'C' with 'Catalyst' in the model name field for the Cisco devices.

Resolve a validation error in C7201.yaml