### PR TITLE
Intel NICs: Add full series of Intel NICs

### DIFF
--- a/module-types/Intel/E810-2CQDA2.yaml
+++ b/module-types/Intel/E810-2CQDA2.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: E810-2CQDA2
+part_number: E810-2CQDA2
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/210969/intel-ethernet-network-adapter-e8102cqda2.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 100gbase-x-qsfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 100gbase-x-qsfp28
+    mgmt_only: false

--- a/module-types/Intel/E810-CQDA1.yaml
+++ b/module-types/Intel/E810-CQDA1.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Intel
+model: E810-CQDA1
+part_number: E810-CQDA1
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/192561/intel-ethernet-network-adapter-e810cqda1.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 100gbase-x-qsfp28
+    mgmt_only: false

--- a/module-types/Intel/E810-CQDA2.yaml
+++ b/module-types/Intel/E810-CQDA2.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: E810-CQDA2
+part_number: E810-CQDA2
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/192558/intel-ethernet-network-adapter-e810cqda2.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 100gbase-x-qsfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 100gbase-x-qsfp28
+    mgmt_only: false

--- a/module-types/Intel/E810-CQDA2T.yaml
+++ b/module-types/Intel/E810-CQDA2T.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: E810-CQDA2T
+part_number: E810-CQDA2T
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/218110/intel-ethernet-network-adapter-e810cqda2t.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 100gbase-x-qsfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 100gbase-x-qsfp28
+    mgmt_only: false

--- a/module-types/Intel/E810-XXVDA2.yaml
+++ b/module-types/Intel/E810-XXVDA2.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: E810-XXVDA2
+part_number: E810-XXVDA2
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/189760/intel-ethernet-network-adapter-e810xxvda2.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 25gbase-x-sfp28
+    mgmt_only: false

--- a/module-types/Intel/E810-XXVDA4.yaml
+++ b/module-types/Intel/E810-XXVDA4.yaml
@@ -1,0 +1,18 @@
+---
+manufacturer: Intel
+model: E810-XXVDA4
+part_number: E810-XXVDA4
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/192560/intel-ethernet-network-adapter-e810xxvda4.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/3
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/4
+    type: 25gbase-x-sfp28
+    mgmt_only: false

--- a/module-types/Intel/E810-XXVDA4T.yaml
+++ b/module-types/Intel/E810-XXVDA4T.yaml
@@ -1,0 +1,18 @@
+---
+manufacturer: Intel
+model: E810-XXVDA4T
+part_number: E810-XXVDA4T
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/211608/intel-ethernet-network-adapter-e810xxvda4t.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/3
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/4
+    type: 25gbase-x-sfp28
+    mgmt_only: false

--- a/module-types/Intel/I350-T2.yaml
+++ b/module-types/Intel/I350-T2.yaml
@@ -3,9 +3,9 @@ manufacturer: Intel
 model: I350-T2
 part_number: I350-T2
 interfaces:
-  - name: 1ge{module}-1
+  - name: Ethernet/{module}/1
     type: 1000base-t
     mgmt_only: false
-  - name: 1ge{module}-2
+  - name: Ethernet/{module}/2
     type: 1000base-t
     mgmt_only: false

--- a/module-types/Intel/I710-T4L.yaml
+++ b/module-types/Intel/I710-T4L.yaml
@@ -1,8 +1,8 @@
 ---
 manufacturer: Intel
-model: I350-T4
-part_number: I350-T4
-comments: '[Datasheet](https://www.intel.com.au/content/www/au/en/products/sku/184824/intel-ethernet-network-adapter-i350t4-for-ocp-3-0/specifications.html)'
+model: I710-T4L
+part_number: I710-T4L
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/225772/intel-ethernet-network-adapter-i710t4l.html)'
 interfaces:
   - name: Ethernet/{module}/1
     type: 1000base-t

--- a/module-types/Intel/X520-DA1.yaml
+++ b/module-types/Intel/X520-DA1.yaml
@@ -4,6 +4,6 @@ model: X520-DA1
 part_number: X520-DA1
 comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/68669/intel-ethernet-converged-network-adapter-x520da1.html)'
 interfaces:
-  - name: '{module} SFP+ 10Gb Port 1'
+  - name: Ethernet/{module}/1
     type: 10gbase-x-sfpp
     mgmt_only: false

--- a/module-types/Intel/X520-DA2.yaml
+++ b/module-types/Intel/X520-DA2.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: X520-DA2
+part_number: X520-DA2
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/39776/intel-ethernet-converged-network-adapter-x520-da2.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-x-sfpp
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 10gbase-x-sfpp
+    mgmt_only: false

--- a/module-types/Intel/X540-T1.yaml
+++ b/module-types/Intel/X540-T1.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Intel
+model: X540-T1
+part_number: X540-T1
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/58953/intel-ethernet-converged-network-adapter-x540t1.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-t
+    mgmt_only: false

--- a/module-types/Intel/X540-T2.yaml
+++ b/module-types/Intel/X540-T2.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: X540-T2
+part_number: X540-T2
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/58954/intel-ethernet-converged-network-adapter-x540t2.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-t
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 10gbase-t
+    mgmt_only: false

--- a/module-types/Intel/X550-T1.yaml
+++ b/module-types/Intel/X550-T1.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Intel
+model: X550-T1
+part_number: X550-T1
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/88208/intel-ethernet-converged-network-adapter-x550t1.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-t
+    mgmt_only: false

--- a/module-types/Intel/X550-T2.yaml
+++ b/module-types/Intel/X550-T2.yaml
@@ -4,9 +4,9 @@ model: X550-T2
 part_number: X550-T2
 comments: '[Datasheet](https://www.intel.com.au/content/www/au/en/products/sku/88209/intel-ethernet-converged-network-adapter-x550t2/specifications.html)'
 interfaces:
-  - name: 10ge{module}-1
+  - name: Ethernet/{module}/1
     type: 10gbase-t
     mgmt_only: false
-  - name: 10ge{module}-2
+  - name: Ethernet/{module}/2
     type: 10gbase-t
     mgmt_only: false

--- a/module-types/Intel/X710-DA2.yaml
+++ b/module-types/Intel/X710-DA2.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: X710-DA2
+part_number: X710-DA2
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/83964/intel-ethernet-converged-network-adapter-x710da2.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-x-sfpp
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 10gbase-x-sfpp
+    mgmt_only: false

--- a/module-types/Intel/X710-DA4.yaml
+++ b/module-types/Intel/X710-DA4.yaml
@@ -1,0 +1,18 @@
+---
+manufacturer: Intel
+model: X710-DA4
+part_number: X710-DA4
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/83965/intel-ethernet-converged-network-adapter-x710da4.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-x-sfpp
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 10gbase-x-sfpp
+    mgmt_only: false
+  - name: Ethernet/{module}/3
+    type: 10gbase-x-sfpp
+    mgmt_only: false
+  - name: Ethernet/{module}/4
+    type: 10gbase-x-sfpp
+    mgmt_only: false

--- a/module-types/Intel/X710-T2L.yaml
+++ b/module-types/Intel/X710-T2L.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: X710-T2L
+part_number: X710-T2L
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/189463/intel-ethernet-network-adapter-x710t2l.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-t
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 10gbase-t
+    mgmt_only: false

--- a/module-types/Intel/X710-T4.yaml
+++ b/module-types/Intel/X710-T4.yaml
@@ -1,0 +1,18 @@
+---
+manufacturer: Intel
+model: X710-T4
+part_number: X710-T4
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/93428/intel-ethernet-converged-network-adapter-x710t4.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-t
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 10gbase-t
+    mgmt_only: false
+  - name: Ethernet/{module}/3
+    type: 10gbase-t
+    mgmt_only: false
+  - name: Ethernet/{module}/4
+    type: 10gbase-t
+    mgmt_only: false

--- a/module-types/Intel/X710-T4L.yaml
+++ b/module-types/Intel/X710-T4L.yaml
@@ -1,0 +1,18 @@
+---
+manufacturer: Intel
+model: X710-T4L
+part_number: X710-T4L
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/189464/intel-ethernet-network-adapter-x710t4l.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 10gbase-t
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 10gbase-t
+    mgmt_only: false
+  - name: Ethernet/{module}/3
+    type: 10gbase-t
+    mgmt_only: false
+  - name: Ethernet/{module}/4
+    type: 10gbase-t
+    mgmt_only: false

--- a/module-types/Intel/XL710-QDA1.yaml
+++ b/module-types/Intel/XL710-QDA1.yaml
@@ -2,7 +2,7 @@
 manufacturer: Intel
 model: XL710-QDA1
 part_number: XL710-QDA1
-comments: '[Intel Ethernet Converged Network Adapter XL710-QDA1](https://www.intel.com/content/www/us/en/products/sku/83966/intel-ethernet-converged-network-adapter-xl710qda1/specifications.html)'
+comments: '[Datasheet](https://www.intel.com/content/www/us/en/products/sku/83966/intel-ethernet-converged-network-adapter-xl710qda1/specifications.html)'
 interfaces:
   - name: Ethernet/{module}/1
     type: 40gbase-x-qsfpp

--- a/module-types/Intel/XL710-QDA2.yaml
+++ b/module-types/Intel/XL710-QDA2.yaml
@@ -2,7 +2,7 @@
 manufacturer: Intel
 model: XL710-QDA2
 part_number: XL710-QDA2
-comments: '[Intel Ethernet Converged Network Adapter XL710-QDA2](https://www.intel.com/content/www/us/en/products/sku/83967/intel-ethernet-converged-network-adapter-xl710qda2/specifications.html)'
+comments: '[Datasheet](https://www.intel.com/content/www/us/en/products/sku/83967/intel-ethernet-converged-network-adapter-xl710qda2/specifications.html)'
 interfaces:
   - name: Ethernet/{module}/1
     type: 40gbase-x-qsfpp

--- a/module-types/Intel/XXV710-DA1.yaml
+++ b/module-types/Intel/XXV710-DA1.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Intel
+model: XXV710-DA1
+part_number: XXV710-DA1
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/95261/intel-ethernet-network-adapter-xxv710da1.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 25gbase-x-sfp28
+    mgmt_only: false

--- a/module-types/Intel/XXV710-DA2.yaml
+++ b/module-types/Intel/XXV710-DA2.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: XXV710-DA2
+part_number: XXV710-DA2
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/95260/intel-ethernet-network-adapter-xxv710da2.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 25gbase-x-sfp28
+    mgmt_only: false

--- a/module-types/Intel/XXV710-DA2T.yaml
+++ b/module-types/Intel/XXV710-DA2T.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: Intel
+model: XXV710-DA2T
+part_number: XXV710-DA2T
+comments: '[Datasheet](https://ark.intel.com/content/www/us/en/ark/products/204979/intel-ethernet-network-adapter-xxv710da2t.html)'
+interfaces:
+  - name: Ethernet/{module}/1
+    type: 25gbase-x-sfp28
+    mgmt_only: false
+  - name: Ethernet/{module}/2
+    type: 25gbase-x-sfp28
+    mgmt_only: false


### PR DESCRIPTION
to the module library folder.

Alligned all interface naming to the method of "Ethernet/{module}/[1-4]"