### PR TITLE
yamllint: Add empty-values

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -27,3 +27,7 @@ rules:
   octal-values: disable
   quoted-strings: disable
   trailing-spaces: enable
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+    forbid-in-block-sequences: true


### PR DESCRIPTION
Enable
- forbid-in-block-mappings
- forbid-in-flow-mappings
- forbid-in-block-sequences

https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.empty_values