### PR TITLE
added the weight of NIM-16A

### DIFF
--- a/module-types/Cisco/NIM-16A.yaml
+++ b/module-types/Cisco/NIM-16A.yaml
@@ -3,6 +3,8 @@ manufacturer: Cisco
 model: NIM-16A
 part_number: NIM-16A
 comments: '[Cisco 16-Port Asynchronous Serial NIM](https://www.cisco.com/c/en/us/products/collateral/routers/4000-series-integrated-services-routers-isr/datasheet-c78-739968.html)'
+weight: 620
+weight_unit: g
 console-server-ports:
   - name: Async0/{module}/0
     type: rj-45


### PR DESCRIPTION
I'm adding the Module NIM-24A in PR #2131 with the weight.
I wanted to add weight to NIM-16A too since they are very similar modules and it makes sense for them to have the same fields. the only difference between them is the nim-24a has 8 more console server ports and weighs a bit more.