### PR TITLE
Fix HPE Aruba 6400 module bay positions

### DIFF
--- a/device-types/HPE/Aruba-6405-v2.yaml
+++ b/device-types/HPE/Aruba-6405-v2.yaml
@@ -27,14 +27,14 @@ module-bays:
   - name: '7'
     position: '7'
   - name: PS1
-    position: PS1
+    position: '1'
   - name: PS2
-    position: PS2
+    position: '2'
   - name: PS3
-    position: PS3
+    position: '3'
   - name: PS4
-    position: PS4
+    position: '4'
   - name: Fan1
-    position: Fan1
+    position: '1'
   - name: Fan2
-    position: Fan2
+    position: '2'

--- a/device-types/HPE/Aruba-6405.yaml
+++ b/device-types/HPE/Aruba-6405.yaml
@@ -27,14 +27,14 @@ module-bays:
   - name: '7'
     position: '7'
   - name: PS1
-    position: PS1
+    position: '1'
   - name: PS2
-    position: PS2
+    position: '2'
   - name: PS3
-    position: PS3
+    position: '3'
   - name: PS4
-    position: PS4
+    position: '4'
   - name: Fan1
-    position: Fan1
+    position: '1'
   - name: Fan2
-    position: Fan2
+    position: '2'

--- a/device-types/HPE/Aruba-6410-v2.yaml
+++ b/device-types/HPE/Aruba-6410-v2.yaml
@@ -37,18 +37,18 @@ module-bays:
   - name: '12'
     position: '12'
   - name: PS1
-    position: PS1
+    position: '1'
   - name: PS2
-    position: PS2
+    position: '2'
   - name: PS3
-    position: PS3
+    position: '3'
   - name: PS4
-    position: PS4
+    position: '4'
   - name: Fan1
-    position: Fan1
+    position: '1'
   - name: Fan2
-    position: Fan2
+    position: '2'
   - name: Fan3
-    position: Fan3
+    position: '3'
   - name: Fan4
-    position: Fan4
+    position: '4'

--- a/device-types/HPE/Aruba-6410.yaml
+++ b/device-types/HPE/Aruba-6410.yaml
@@ -37,18 +37,18 @@ module-bays:
   - name: '12'
     position: '12'
   - name: PS1
-    position: PS1
+    position: '1'
   - name: PS2
-    position: PS2
+    position: '2'
   - name: PS3
-    position: PS3
+    position: '3'
   - name: PS4
-    position: PS4
+    position: '4'
   - name: Fan1
-    position: Fan1
+    position: '1'
   - name: Fan2
-    position: Fan2
+    position: '2'
   - name: Fan3
-    position: Fan3
+    position: '3'
   - name: Fan4
-    position: Fan4
+    position: '4'


### PR DESCRIPTION
Fixed the position naming of the PSU and fan module bays
```
6410# show environment fan 

Fan tray information
------------------------------------------------------------------------------
Name  Description                           Status        Serial Number  Fans
------------------------------------------------------------------------------
1/1   R0X32A Aruba 6400 Fan Tray            ready         XXXXXXXXXX     4  
1/2   R0X32A Aruba 6400 Fan Tray            ready         XXXXXXXXXX     4  
1/3   R0X32A Aruba 6400 Fan Tray            ready         XXXXXXXXXX     4  
1/4   R0X32A Aruba 6400 Fan Tray            ready         XXXXXXXXXX     4  
```

```
6410# show environment power-supply 
------------------------------------------------------------------------------
         Product  Serial            PSU            Input   Voltage    Wattage
Mbr/PSU  Number   Number            Status         Type    Range      Maximum
------------------------------------------------------------------------------
1/1      R0X35A   XXXXXXXXXX        OK             AC      110V-240V  1800
1/2      R0X35A   XXXXXXXXXX        OK             AC      110V-240V  1764
1/3      R0X35A   XXXXXXXXXX        OK             AC      110V-240V  1764
1/4      R0X35A   XXXXXXXXXX        OK             AC      110V-240V  1764
```
