### PR TITLE
Cisco Nexus 9300-GX2

### DIFF
--- a/device-types/Cisco/N9K-C9332D-GX2B.yaml
+++ b/device-types/Cisco/N9K-C9332D-GX2B.yaml
@@ -1,0 +1,87 @@
+---
+manufacturer: Cisco
+model: Nexus 9332D-GX2b
+part_number: N9K-C9332D-GX2B
+slug: cisco-n9k-c9332d-gx2b
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: console
+    type: rj-45
+interfaces:
+  - name: Ethernet1/1
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/2
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/3
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/4
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/5
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/6
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/7
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/8
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/9
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/10
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/11
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/12
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/13
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/14
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/15
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/16
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/17
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/18
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/19
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/20
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/21
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/22
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/23
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/24
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/25
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/26
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/27
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/28
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/29
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/30
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/31
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/32
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/33
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/34
+    type: 10gbase-x-sfpp
+  - name: mgmt0
+    type: 1000base-t
+    mgmt_only: true
+module-bays:
+  - name: PS1
+    position: '1'
+  - name: PS2
+    position: '2'

--- a/device-types/Cisco/N9K-C9348D-GX2A.yaml
+++ b/device-types/Cisco/N9K-C9348D-GX2A.yaml
@@ -1,0 +1,119 @@
+---
+manufacturer: Cisco
+model: Nexus 9348D-GX2A
+part_number: N9K-C9348D-GX2A
+slug: cisco-n9k-c9348d-gx2a
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: console
+    type: rj-45
+interfaces:
+  - name: Ethernet1/1
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/2
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/3
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/4
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/5
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/6
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/7
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/8
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/9
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/10
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/11
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/12
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/13
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/14
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/15
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/16
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/17
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/18
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/19
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/20
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/21
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/22
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/23
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/24
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/25
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/26
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/27
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/28
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/29
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/30
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/31
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/32
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/33
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/34
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/35
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/36
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/37
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/38
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/39
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/40
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/41
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/42
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/43
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/44
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/45
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/46
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/47
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/48
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/49
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/50
+    type: 10gbase-x-sfpp
+  - name: mgmt0
+    type: 1000base-t
+    mgmt_only: true
+module-bays:
+  - name: PS1
+    position: '1'
+  - name: PS2
+    position: '2'

--- a/device-types/Cisco/N9K-C9364D-GX2A.yaml
+++ b/device-types/Cisco/N9K-C9364D-GX2A.yaml
@@ -1,0 +1,151 @@
+---
+manufacturer: Cisco
+model: Nexus 9364D-GX2A
+part_number: N9K-C9364D-GX2A
+slug: cisco-n9k-c9364d-gx2a
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: console
+    type: rj-45
+interfaces:
+  - name: Ethernet1/1
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/2
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/3
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/4
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/5
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/6
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/7
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/8
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/9
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/10
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/11
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/12
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/13
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/14
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/15
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/16
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/17
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/18
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/19
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/20
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/21
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/22
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/23
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/24
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/25
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/26
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/27
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/28
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/29
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/30
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/31
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/32
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/33
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/34
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/35
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/36
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/37
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/38
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/39
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/40
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/41
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/42
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/43
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/44
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/45
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/46
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/47
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/48
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/49
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/50
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/51
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/52
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/53
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/54
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/55
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/56
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/57
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/58
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/59
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/60
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/61
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/62
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/63
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/64
+    type: 400gbase-x-qsfpdd
+  - name: Ethernet1/65
+    type: 10gbase-x-sfpp
+  - name: Ethernet1/66
+    type: 10gbase-x-sfpp
+  - name: mgmt0
+    type: 1000base-t
+    mgmt_only: true
+module-bays:
+  - name: PS1
+    position: '1'
+  - name: PS2
+    position: '2'


### PR DESCRIPTION
Cisco Nexus 9300-GX2:

Model | Description
-- | --
Cisco Nexus 9364D-GX2A | 64 x 400-Gbps QSFP-DD and 2x 1/10 -Gbps SFP+ ports
Cisco Nexus 9348D-GX2A | 48 x 400-Gbps QSFP-DD and 2x 1/10 -Gbps SFP+ ports
Cisco Nexus 9332D-GX2B | 32 x 400-Gbps QSFP-DD and 2x 1/10 -Gbps SFP+ ports

https://www.cisco.com/c/en/us/products/collateral/switches/nexus-9000-series-switches/datasheet-c78-743854.html