### PR TITLE
Add Supermicro A+ Server 2124BT-HNTR and its servers' motherboard H12DST-B

### DIFF
--- a/device-types/Supermicro/AS-2124BT-HNTR.yaml
+++ b/device-types/Supermicro/AS-2124BT-HNTR.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Supermicro
+model: A+ Server 2124BT-HNTR
+slug: supermicro-as-2124bt-hntr
+part_number: AS-2124BT-HNTR
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+comments: SuperServer SYS-5039MC-H8TRF (https://www.supermicro.com/en/Aplus/system/2U/2124/AS-2124BT-HNTR.cfm)
+subdevice_role: parent
+weight: 24.7
+weight_unit: kg
+power-ports:
+  - name: PSU1
+    type: iec-60320-c14
+    maximum_draw: 2200
+  - name: PSU2
+    type: iec-60320-c14
+    maximum_draw: 2200
+device-bays:
+  - name: Node A
+    label: Compute Node A
+  - name: Node B
+    label: Compute Node B
+  - name: Node C
+    label: Compute Node C
+  - name: Node D
+    label: Compute Node D

--- a/device-types/Supermicro/AS-2124BT-HNTR.yaml
+++ b/device-types/Supermicro/AS-2124BT-HNTR.yaml
@@ -10,12 +10,12 @@ comments: SuperServer SYS-5039MC-H8TRF (https://www.supermicro.com/en/Aplus/syst
 subdevice_role: parent
 weight: 24.7
 weight_unit: kg
-power-ports:
-  - name: PSU1
-    type: iec-60320-c14
+module-bays:
+  - name: PSU0
+    position: PSU 0
     maximum_draw: 2200
-  - name: PSU2
-    type: iec-60320-c14
+  - name: PSU1
+    position: PSU 1
     maximum_draw: 2200
 device-bays:
   - name: Node 1

--- a/device-types/Supermicro/AS-2124BT-HNTR.yaml
+++ b/device-types/Supermicro/AS-2124BT-HNTR.yaml
@@ -18,11 +18,11 @@ power-ports:
     type: iec-60320-c14
     maximum_draw: 2200
 device-bays:
-  - name: Node A
-    label: Compute Node A
-  - name: Node B
-    label: Compute Node B
-  - name: Node C
-    label: Compute Node C
-  - name: Node D
-    label: Compute Node D
+  - name: Node 1
+    label: Compute Node 1
+  - name: Node 2
+    label: Compute Node 2
+  - name: Node 3
+    label: Compute Node 3
+  - name: Node 4
+    label: Compute Node 4

--- a/device-types/Supermicro/MBD-H12DST-B.yaml
+++ b/device-types/Supermicro/MBD-H12DST-B.yaml
@@ -27,7 +27,7 @@ module-bays:
   - name: PCI-E 3
     position: '3'
     description: PCI-E 4.0 x16 (Low profile 6.6")
-  - name: PCI-E 2
+  - name: PCI-E 4
     position: '4'
     description: PCI-E 4.0 x16 (Low profile 6.6")
   - name: PCI-E 5

--- a/device-types/Supermicro/MBD-H12DST-B.yaml
+++ b/device-types/Supermicro/MBD-H12DST-B.yaml
@@ -1,0 +1,38 @@
+---
+manufacturer: Supermicro
+model: Motherboard H12DST-B
+slug: supermicro-mbd-h12dst-b
+part_number: MBD-H12DST-B
+u_height: 0
+is_full_depth: true
+airflow: front-to-rear
+comments: Motherboard H12DST-B for AS-2124BT-HNTR and AS-2124BT-HTR (https://www.supermicro.com/en/products/motherboard/H12DST-B)
+subdevice_role: child
+console-ports:
+  - name: COM1
+    type: de-9
+    label: Rear
+interfaces:
+  - name: BMC
+    type: 1000base-t
+    mgmt_only: true
+    description: Dedicated IPMI LAN port
+module-bays:
+  - name: PCI-E 1
+    position: '1'
+    description: PCI-E 3.0 x16
+  - name: PCI-E 2
+    position: '2'
+    description: PCI-E 4.0 x24
+  - name: PCI-E 3
+    position: '3'
+    description: PCI-E 4.0 x16 (Low profile 6.6")
+  - name: PCI-E 2
+    position: '4'
+    description: PCI-E 4.0 x16 (Low profile 6.6")
+  - name: PCI-E 5
+    position: '5'
+    description: SIOM Slot
+  - name: M.2
+    position: '6'
+    description: Form Factor 2280, 22110 (M-Key)


### PR DESCRIPTION
Add Supermicro A+ Server 2124BT-HNTR and its servers' motherboard H12DST-B:
https://www.supermicro.com/en/Aplus/system/2U/2124/AS-2124BT-HNTR.cfm
https://www.supermicro.com/en/products/motherboard/H12DST-B

To-do: Add optional yet required SIOM cards for H12DST-B