### PR TITLE
ASR-9006: add positions so modules get automatic components

### DIFF
--- a/device-types/Cisco/ASR-9006.yaml
+++ b/device-types/Cisco/ASR-9006.yaml
@@ -9,27 +9,27 @@ comments: '[Cisco ASR 9000 Series Aggregation Services Routers Data Sheet](https
 module-bays:
   - name: Slot 0
     label: RSP 0
-    position: '0'
+    position: RSP0
   - name: Slot 1
     label: RSP 1
-    position: '1'
+    position: RSP1
   - name: Slot 2
     label: Line Card 0
-    position: '0'
+    position: LC0
   - name: Slot 3
     label: Line Card 1
-    position: '1'
+    position: LC1
   - name: Slot 4
     label: Line Card 2
-    position: '2'
+    position: LC2
   - name: Slot 5
     label: Line Card 3
-    position: '3'
+    position: LC3
   - name: Power Slot 0
-    position: '0'
+    position: PSU0
   - name: Power Slot 1
-    position: '1'
+    position: PSU1
   - name: Power Slot 2
-    position: '2'
+    position: PSU2
   - name: Power Slot 3
-    position: '3'
+    position: PSU3

--- a/device-types/Cisco/ASR-9006.yaml
+++ b/device-types/Cisco/ASR-9006.yaml
@@ -6,19 +6,6 @@ part_number: ASR-9006
 u_height: 10
 is_full_depth: true
 comments: '[Cisco ASR 9000 Series Aggregation Services Routers Data Sheet](https://www.cisco.com/c/en/us/products/collateral/routers/asr-9000-series-aggregation-services-routers/data_sheet_c78-501767.html)'
-power-ports:
-  - name: PS0
-    type: iec-60320-c14
-    maximum_draw: 3000
-  - name: PS1
-    type: iec-60320-c14
-    maximum_draw: 3000
-  - name: PS2
-    type: iec-60320-c14
-    maximum_draw: 3000
-  - name: PS3
-    type: iec-60320-c14
-    maximum_draw: 3000
 module-bays:
   - name: Slot 0
     label: RSP 0
@@ -32,3 +19,7 @@ module-bays:
     label: Line Card 2
   - name: Slot 5
     label: Line Card 3
+  - name: Power Slot 0
+  - name: Power Slot 1
+  - name: Power Slot 2
+  - name: Power Slot 3

--- a/device-types/Cisco/ASR-9006.yaml
+++ b/device-types/Cisco/ASR-9006.yaml
@@ -9,17 +9,27 @@ comments: '[Cisco ASR 9000 Series Aggregation Services Routers Data Sheet](https
 module-bays:
   - name: Slot 0
     label: RSP 0
+    position: '0'
   - name: Slot 1
     label: RSP 1
+    position: '1'
   - name: Slot 2
     label: Line Card 0
+    position: '0'
   - name: Slot 3
     label: Line Card 1
+    position: '1'
   - name: Slot 4
     label: Line Card 2
+    position: '2'
   - name: Slot 5
     label: Line Card 3
+    position: '3'
   - name: Power Slot 0
+    position: '0'
   - name: Power Slot 1
+    position: '1'
   - name: Power Slot 2
+    position: '2'
   - name: Power Slot 3
+    position: '3'


### PR DESCRIPTION
There are duplicate positions, but it is on purpose, there is one count for management and one for line cards.
The interfaces are, for example:

first management module, RSP0:
Mg0/RSP**0**/CPU0/0
Mg0/RSP**0**/CPU0/1

second management module, RSP1:
Mg0/RSP**1**/CPU0/0
Mg0/RSP**1**/CPU0/1

first interface line card (with 10G ports), the module is in the second number
Te0/**0**/0/0
Te0/**0**/0/1

second line card (with 10G ports)
Te0/**1**/0/0
Te0/**1**/0/1
