### PR TITLE
Add MikroTik CRS520-4XS-16XQ, CRS510-8XS-2XQ-IN, CRS320-8P-8B-4S+RM, CRS326-4C+20G+2Q+RM & 5 MikroTik module-types

### DIFF
--- a/device-types/MikroTik/CCR1072-1G-8S-Plus.yaml
+++ b/device-types/MikroTik/CCR1072-1G-8S-Plus.yaml
@@ -4,6 +4,11 @@ model: CCR1072-1G-8S+
 slug: mikrotik-ccr1072-1g-8s-plus
 is_full_depth: false
 u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/CCR1072-1G-8Splus)
+front_image: false
+rear_image: false
+is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t
@@ -26,10 +31,10 @@ interfaces:
 console-ports:
   - name: serial0
     type: rj-45
-power-ports:
+module-bays:
   - name: power1
-    type: iec-60320-c14
-    maximum_draw: 125
+    position: power1
+    description: Power module
   - name: power2
-    type: iec-60320-c14
-    maximum_draw: 125
+    position: power2
+    description: Power module

--- a/device-types/MikroTik/CCR2004-16G-2S-Plus.yaml
+++ b/device-types/MikroTik/CCR2004-16G-2S-Plus.yaml
@@ -5,6 +5,11 @@ slug: mikrotik-ccr2004-16g-2s-plus
 part_number: CCR2004-16G-2S+
 is_full_depth: false
 u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/ccr2004_16g_2splus)
+front_image: false
+rear_image: false
+is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t
@@ -45,10 +50,10 @@ interfaces:
 console-ports:
   - name: serial0
     type: rj-45
-power-ports:
+module-bays:
   - name: power1
-    type: iec-60320-c14
-    maximum_draw: 48
+    position: power1
+    description: Power module
   - name: power2
-    type: iec-60320-c14
-    maximum_draw: 48
+    position: power2
+    description: Power module

--- a/device-types/MikroTik/CCR2004-1G-12S-Plus-2XS.yaml
+++ b/device-types/MikroTik/CCR2004-1G-12S-Plus-2XS.yaml
@@ -5,6 +5,11 @@ slug: mikrotik-ccr2004-1g-12s-plus-2xs
 part_number: CCR2004-1G-12S+2XS
 is_full_depth: false
 u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/ccr2004_1g_12s_2xs)
+front_image: false
+rear_image: false
+is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CCR2116-12G-4S-Plus.yaml
+++ b/device-types/MikroTik/CCR2116-12G-4S-Plus.yaml
@@ -5,6 +5,11 @@ slug: mikrotik-ccr2116-12g-4s-plus
 part_number: CCR2116-12G-4S+
 is_full_depth: false
 u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/ccr2116_12g_4splus)
+front_image: false
+rear_image: false
+is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CCR2216-1G-12XS-2XQ.yaml
+++ b/device-types/MikroTik/CCR2216-1G-12XS-2XQ.yaml
@@ -3,9 +3,13 @@ manufacturer: MikroTik
 model: CCR2216-1G-12XS-2XQ
 slug: mikrotik-ccr2216-1g-12xs-2xq
 part_number: CCR2216-1G-12XS-2XQ
-comments: '[Mikrotik CCR2216-1G-12XS-2XQ ](https://mikrotik.com/product/ccr2216_1g_12xs_2xq)'
 is_full_depth: false
 u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/ccr2216_1g_12xs_2xq)
+front_image: false
+rear_image: false
+is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t
@@ -40,10 +44,22 @@ interfaces:
 console-ports:
   - name: serial0
     type: rj-45
-power-ports:
+module-bays:
   - name: power1
-    type: iec-60320-c14
-    maximum_draw: 128
+    position: power1
+    description: Power module
   - name: power2
-    type: iec-60320-c14
-    maximum_draw: 128
+    position: power2
+    description: Power module
+  - name: fan1
+    position: '1'
+    description: Fan tray
+  - name: fan2
+    position: '2'
+    description: Fan tray
+  - name: fan3
+    position: '3'
+    description: Fan tray
+  - name: fan4
+    position: '4'
+    description: Fan tray

--- a/device-types/MikroTik/CRS320-8P-8B-4S-Plus-RM.yaml
+++ b/device-types/MikroTik/CRS320-8P-8B-4S-Plus-RM.yaml
@@ -1,0 +1,99 @@
+---
+manufacturer: MikroTik
+model: CRS320-8P-8B-4S+RM
+slug: mikrotik-crs320-8p-8b-4s-plus-rm
+part_number: CRS320-8P-8B-4S+RM
+is_full_depth: false
+airflow: side-to-rear
+u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/crs320_8p_8b_4s_rm)
+front_image: false
+rear_image: false
+is_powered: true
+interfaces:
+  - name: ether1
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: ether2
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: ether3
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: ether4
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: ether5
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: ether6
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: ether7
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: ether8
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: ether9
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: ether10
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: ether11
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: ether12
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: ether13
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: ether14
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: ether15
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: ether16
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: ether17
+    type: 1000base-t
+    mgmt_only: true
+  - name: sfp-sfpplus1
+    type: 10gbase-x-sfpp
+  - name: sfp-sfpplus2
+    type: 10gbase-x-sfpp
+  - name: sfp-sfpplus3
+    type: 10gbase-x-sfpp
+  - name: sfp-sfpplus4
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: serial0
+    type: rj-45
+module-bays:
+  - name: power1
+    position: power1
+    description: Power module
+  - name: power2
+    position: power2
+    description: Power module

--- a/device-types/MikroTik/CRS326-4C-Plus-20G-Plus-2Q-Plus-RM.yaml
+++ b/device-types/MikroTik/CRS326-4C-Plus-20G-Plus-2Q-Plus-RM.yaml
@@ -1,0 +1,88 @@
+---
+manufacturer: MikroTik
+model: CRS326-4C+20G+2Q+RM
+slug: mikrotik-crs326-4c-plus-20g-plus-2q-plus-rm
+part_number: CRS326-4C+20G+2Q+RM
+is_full_depth: false
+airflow: mixed
+u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/crs326_4c_20g_2q_rm)
+
+  Our top-of-the-line switch with incredible 2.5 Gigabit port density,
+  combo ports, and even a pair of 40 Gbps QSFP+ cages. Enterprise-level
+  gamechanger… for the price of a smartphone!
+
+  Note: The combo ports can run in either mode of (F) 10G (SFP+) or
+  (T) 2.5GBASE-T (2.5GE) mode.
+front_image: false
+rear_image: false
+is_powered: true
+interfaces:
+  - name: combo1
+    type: 10gbase-x-sfpp
+  - name: combo2
+    type: 10gbase-x-sfpp
+  - name: combo3
+    type: 10gbase-x-sfpp
+  - name: combo4
+    type: 10gbase-x-sfpp
+  - name: ether1
+    type: 2.5gbase-t
+  - name: ether2
+    type: 2.5gbase-t
+  - name: ether3
+    type: 2.5gbase-t
+  - name: ether4
+    type: 2.5gbase-t
+  - name: ether5
+    type: 2.5gbase-t
+  - name: ether6
+    type: 2.5gbase-t
+  - name: ether7
+    type: 2.5gbase-t
+  - name: ether8
+    type: 2.5gbase-t
+  - name: ether9
+    type: 2.5gbase-t
+  - name: ether10
+    type: 2.5gbase-t
+  - name: ether11
+    type: 2.5gbase-t
+  - name: ether12
+    type: 2.5gbase-t
+  - name: ether13
+    type: 2.5gbase-t
+  - name: ether14
+    type: 2.5gbase-t
+  - name: ether15
+    type: 2.5gbase-t
+  - name: ether16
+    type: 2.5gbase-t
+  - name: ether17
+    type: 2.5gbase-t
+  - name: ether18
+    type: 2.5gbase-t
+  - name: ether19
+    type: 2.5gbase-t
+  - name: ether20
+    type: 2.5gbase-t
+  - name: ether21
+    type: 100base-t1
+    mgmt_only: true
+  - name: qsfp-qsfpplus1
+    type: 40gbase-x-qsfpp
+  - name: qsfp-qsfpplus2
+    type: 40gbase-x-qsfpp
+console-ports:
+  - name: serial0
+    type: rj-45
+power-ports:
+  - name: power1
+    label: POWER 1
+    type: iec-60320-c14
+    maximum_draw: 70
+  - name: power2
+    label: POWER 2
+    type: iec-60320-c14
+    maximum_draw: 70

--- a/device-types/MikroTik/CRS504-4XQ-IN.yaml
+++ b/device-types/MikroTik/CRS504-4XQ-IN.yaml
@@ -5,9 +5,15 @@ slug: mikrotik-crs504-4xq-in
 part_number: CRS504-4XQ-IN
 is_full_depth: false
 airflow: front-to-rear
-comments: Careful, there is only qsfp28-1-1, qsfp28-2-1, qsfp28-3-1 and qsfp28-4-1 interfaces for 100Gb, don't forget to add the other if you use breakout
-  cables.
 u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/crs504_4xq_in)
+
+  Careful, there is only qsfp28-1-1, qsfp28-2-1, qsfp28-3-1 and qsfp28-4-1 interfaces for 100Gb, don't
+  forget to add the other if you use breakout cables.
+front_image: false
+rear_image: false
+is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t
@@ -23,13 +29,19 @@ interfaces:
 console-ports:
   - name: serial0
     type: rj-45
-power-ports:
+module-bays:
   - name: power1
-    type: iec-60320-c14
-    maximum_draw: 41
+    position: power1
+    description: Power module
   - name: power2
-    type: iec-60320-c14
-    maximum_draw: 41
+    position: power2
+    description: Power module
+power-ports:
   - name: power3
+    label: DC 36-57V
+    type: dc-terminal
+    maximum_draw: 41
+  - name: power4
+    label: DC 36-57V
     type: dc-terminal
     maximum_draw: 41

--- a/device-types/MikroTik/CRS510-8XS-2XQ-IN.yaml
+++ b/device-types/MikroTik/CRS510-8XS-2XQ-IN.yaml
@@ -1,16 +1,13 @@
 ---
 manufacturer: MikroTik
-model: CRS518-16XS-2XQ
-slug: mikrotik-crs518-16xs-2xq
-part_number: CRS518-16XS-2XQ
+model: CRS510-8XS-2XQ-IN
+slug: mikrotik-crs510-8xs-2xq-in
+part_number: CRS510-8XS-2XQ-IN
 is_full_depth: false
 airflow: front-to-rear
 u_height: 1
 comments: |
-  [Product Page](https://mikrotik.com/product/crs518_16xs_2xq).
-
-  Careful, there is only qsfp28-1-1 and qsfp28-2-1 interfaces for 100Gb,
-  don't forget to add the other if you use breakout cables.
+  [Product Page](https://mikrotik.com/product/crs510_8xs_2xq_in)
 front_image: false
 rear_image: false
 is_powered: true
@@ -34,22 +31,6 @@ interfaces:
     type: 25gbase-x-sfp28
   - name: sfp28-8
     type: 25gbase-x-sfp28
-  - name: sfp28-9
-    type: 25gbase-x-sfp28
-  - name: sfp28-10
-    type: 25gbase-x-sfp28
-  - name: sfp28-11
-    type: 25gbase-x-sfp28
-  - name: sfp28-12
-    type: 25gbase-x-sfp28
-  - name: sfp28-13
-    type: 25gbase-x-sfp28
-  - name: sfp28-14
-    type: 25gbase-x-sfp28
-  - name: sfp28-15
-    type: 25gbase-x-sfp28
-  - name: sfp28-16
-    type: 25gbase-x-sfp28
   - name: qsfp28-1-1
     type: 100gbase-x-qsfp28
   - name: qsfp28-2-1
@@ -66,15 +47,12 @@ module-bays:
   - name: power2
     position: power2
     description: Power module
-  - name: fan1
-    position: '1'
-    description: Fan tray
-  - name: fan2
-    position: '2'
-    description: Fan tray
-  - name: fan3
-    position: '3'
-    description: Fan tray
-  - name: fan4
-    position: '4'
-    description: Fan tray
+power-ports:
+  - name: power3
+    label: DC 36-57V
+    type: dc-terminal
+    maximum_draw: 45
+  - name: power4
+    label: DC 36-57V
+    type: dc-terminal
+    maximum_draw: 45

--- a/device-types/MikroTik/CRS520-4XS-16XQ.yaml
+++ b/device-types/MikroTik/CRS520-4XS-16XQ.yaml
@@ -1,0 +1,86 @@
+---
+manufacturer: MikroTik
+model: CRS520-4XS-16XQ
+slug: mikrotik-crs520-4xs-16xq
+part_number: CRS520-4XS-16XQ
+is_full_depth: false
+airflow: front-to-rear
+u_height: 1
+comments: |
+  [Product Page](https://mikrotik.com/product/crs520_4xs_16xq_rm).
+
+  Careful, there is only qsfp28-1-[1..16] interfaces for 100Gb,
+  don't forget to add the other if you use breakout cables.
+front_image: false
+rear_image: false
+is_powered: true
+interfaces:
+  - name: ether1
+    type: 1000base-t
+    mgmt_only: true
+  - name: qsfp28-1-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-2-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-3-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-4-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-5-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-6-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-7-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-8-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-9-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-10-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-11-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-12-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-13-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-14-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-15-1
+    type: 100gbase-x-qsfp28
+  - name: qsfp28-16-1
+    type: 100gbase-x-qsfp28
+  - name: sfp28-1
+    type: 25gbase-x-sfp28
+  - name: sfp28-2
+    type: 25gbase-x-sfp28
+  - name: sfp28-3
+    type: 25gbase-x-sfp28
+  - name: sfp28-4
+    type: 25gbase-x-sfp28
+  - name: sfp-sfpplus1
+    type: 10gbase-x-sfpp
+  - name: sfp-sfpplus2
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: serial0
+    type: rj-45
+module-bays:
+  - name: power1
+    position: power1
+    description: Power module
+  - name: power2
+    position: power2
+    description: Power module
+  - name: fan1
+    position: '1'
+    description: Fan tray
+  - name: fan2
+    position: '2'
+    description: Fan tray
+  - name: fan3
+    position: '3'
+    description: Fan tray
+  - name: fan4
+    position: '4'
+    description: Fan tray

--- a/module-types/MikroTik/12POW150.yaml
+++ b/module-types/MikroTik/12POW150.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: MikroTik
+model: 12POW150
+part_number: 12POW150
+comments: |
+  Hot Swap power supply for CCR1072/2216 and CRS518/CRS520.
+
+  CCR1072-1G-8S+, CR2216-1G-12XS-2XQ, CRS518-16XS-2XQ-RM and CRS520-4XS-16XQ-RM units
+  are equipped with two redundant Hot Swap 12v 150W AC/DC power supplies. If one
+  of them goes out of order, second one will take over.
+
+  Hot Swap 12v 150W AC/DC power supplies for CCR1072-1G-8, CCR2216-1G-12XS-2XQ,
+  CRS518-16XS-2XQ-RM, and CRS520-4XS-16XQ-RM are now available for purchase
+  separately. You can replace them on the go to ensure zero downtime, no need to
+  even restart the router.
+
+  [Product Page](https://mikrotik.com/product/12pow150)
+power-ports:
+  - name: power{module}
+    type: iec-60320-c14
+    maximum_draw: 150

--- a/module-types/MikroTik/G1040A-60WF.yaml
+++ b/module-types/MikroTik/G1040A-60WF.yaml
@@ -1,0 +1,18 @@
+---
+manufacturer: MikroTik
+model: G1040A-60WF
+part_number: G1040A-60WF
+comments: |
+  Hot-swap power supply: replace the CCR2004, CRS510 or CRS504 power supply without
+  having to turn off or even restart the router. Zero downtime!
+
+  CCR2004-16G-2S+, CRS510-8XS-2XQ-IN+ and CRS504-4XQ-IN units come with two hot-swap
+  dual redundant power supplies. If one of them goes out of order at some point, the
+  other one will take over. Then you can use this kit to replace the old power supply
+  and you don’t even have to restart the router!
+
+  [Product Page](https://mikrotik.com/product/g1040a_60wf)
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c14
+    maximum_draw: 60

--- a/module-types/MikroTik/G1483-0600WNB.yaml
+++ b/module-types/MikroTik/G1483-0600WNB.yaml
@@ -1,0 +1,18 @@
+---
+manufacturer: MikroTik
+model: G1483-0600WNB
+part_number: G1483-0600WNB
+comments: |
+  Hot-swap 54.5V 10.35A 600W power supply for the CRS320-8P-8B-4S+RM PoE++
+  switch.
+
+  Hot-swap 54.5V 10.35A 600W power supply for the CRS320-8P-8B-4S+RM PoE++
+  switch. The switch comes with a single 600W PSU and an expansion slot for
+  a second PSU that can raise the total power output all the way to 1150
+  Watts, up to 90 Watts per PoE++ port.
+
+  [Product Page](https://mikrotik.com/product/g1483_0600wnb)
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c14
+    maximum_draw: 600

--- a/module-types/MikroTik/MT-HotSwapFan.yaml
+++ b/module-types/MikroTik/MT-HotSwapFan.yaml
@@ -1,0 +1,16 @@
+---
+manufacturer: MikroTik
+model: MT-HOTSWAPFAN
+part_number: MT-HotSwapFan
+comments: |
+  Be prepared for the unexpected with the backup hot-swappable fans for our newest
+  devices, such as
+
+  * CCR2216
+  * CRS518
+  * CRS520
+
+  If your fans go out of order at some point, you can swap them without unnecessary
+  downtime, as there is no need to turn the router off.
+
+  [Product Page](https://mikrotik.com/product/hotswapfan)

--- a/module-types/MikroTik/PW48V-12V150W.yaml
+++ b/module-types/MikroTik/PW48V-12V150W.yaml
@@ -1,0 +1,19 @@
+---
+manufacturer: MikroTik
+model: PW48V-12V150W
+part_number: PW48V-12V150W
+comments: |
+  PW48V-12V150W
+
+  Hot Swap -48V DC telecom power supply for CCR1072, CCR2216 and CRS518. Supported input Voltage -36..-57V..
+
+  We are now offering a Hot Swap -48V DC telecom power supply (product code PW48V-12V150W), available to
+  purchase separately for use with CCR1072, our newest flagship CCR2216 or even the CRS518. Simply
+  remove one of the current power supplies and replace with the new PW48V-12V150W for -48V installations
+  simple and easy. You don't even need to turn off the device. Supports Voltage -36..-57V.
+
+  [Product Page](https://mikrotik.com/product/hot_swap__48v_dc_telecom_power_supply_for_ccr1072)
+power-ports:
+  - name: power{module}
+    type: hardwired
+    maximum_draw: 150


### PR DESCRIPTION
The udpated device definitions relate to the modules being added, where the devices uses swapable power supplies. And some swapable fan modules as well.

- Update CCR1072-1G-8S+
- Update CCR2004-16G-2S+
- Update CCR2216-1G-12XS-2XQ
- Add CRS320-8P-8B-4S+RM
- Add CRS326-4C+20G+2Q+RM
- Update CRS504-4XQ-IN
- Add CRS510-8XS-2XQ-IN
- Update CRS518-16XS-2XQ
- Add CRS520-4XS-16XQ

Add additional Power Modules and Fans for module bays

- Add 12POW150
- Add G1040-60WF
- Add G1483-0600WNB
- Add MT-HotSwapFan
- Add PW48V-12POW150
