### PR TITLE
Added TP-Link SG-3424, power consumption fix for TP-Link SG-3424P

### DIFF
--- a/device-types/TP-Link/TL-SG3424.yaml
+++ b/device-types/TP-Link/TL-SG3424.yaml
@@ -1,0 +1,80 @@
+---
+manufacturer: TP-Link
+model: TL-SG3424
+slug: tp-link-tl-sg3424
+part_number: TL-SG3424
+comments: '[TP-Link tl-sg3424](https://www.tp-link.com/us/business-networking/managed-switch/tl-sg3424/#specifications)'
+is_full_depth: false
+u_height: 1
+console-ports:
+  - name: console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 23
+interfaces:
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21'
+    label: combo
+    type: 1000base-t
+  - name: '22'
+    label: combo
+    type: 1000base-t
+  - name: '23'
+    label: combo
+    type: 1000base-t
+  - name: '24'
+    label: combo
+    type: 1000base-t
+  - name: 21F
+    type: 1000base-x-sfp
+    label: combo
+  - name: 22F
+    label: combo
+    type: 1000base-x-sfp
+  - name: 23F
+    label: combo
+    type: 1000base-x-sfp
+  - name: 24F
+    label: combo
+    type: 1000base-x-sfp

--- a/device-types/TP-Link/TL-SG3424P.yaml
+++ b/device-types/TP-Link/TL-SG3424P.yaml
@@ -12,7 +12,7 @@ console-ports:
 power-ports:
   - name: PS1
     type: iec-60320-c14
-    maximum_draw: 47
+    maximum_draw: 358
 interfaces:
   - name: '1'
     type: 1000base-t


### PR DESCRIPTION
This pull request contains two commits with following changes:

- adding SG-3424, which is pretty much the same as SG-3424P (but without PoE)
- fixed SG-3424P power consumption