### PR TITLE
Add Virtual Connect SE 40Gb F8 Module for Synergy

### DIFF
--- a/device-types/HPE/Virtual-Connect-SE-40Gb-F8-Module-for-Synergy.yaml
+++ b/device-types/HPE/Virtual-Connect-SE-40Gb-F8-Module-for-Synergy.yaml
@@ -1,0 +1,41 @@
+---
+manufacturer: HPE
+model: Virtual Connect SE 40Gb F8 Module for Synergy
+slug: hpe-virtual-connect-se-40gb-f8-module-for-synergy
+comments: '[QuickSpecs](https://www.hpe.com/psnow/doc/c04815258)'
+part_number: 794502-B23
+weight: 5
+weight_unit: kg
+u_height: 0
+subdevice_role: child
+interfaces:
+  - name: interconnect {module}, L1
+    description: CXP (120 Gb/s Interconnect Link)
+    type: other
+  - name: interconnect {module}, L2
+    description: CXP (120 Gb/s Interconnect Link)
+    type: other
+  - name: interconnect {module}, L3
+    description: CXP (120 Gb/s Interconnect Link)
+    type: other
+  - name: interconnect {module}, L4
+    description: CXP (120 Gb/s Interconnect Link)
+    type: other
+  - name: interconnect {module}, Q1
+    type: 40gbase-x-qsfpp
+  - name: interconnect {module}, Q2
+    type: 40gbase-x-qsfpp
+  - name: interconnect {module}, Q3
+    type: 40gbase-x-qsfpp
+  - name: interconnect {module}, Q4
+    type: 40gbase-x-qsfpp
+  - name: interconnect {module}, Q5
+    type: 40gbase-x-qsfpp
+  - name: interconnect {module}, Q6
+    type: 40gbase-x-qsfpp
+  - name: interconnect {module}, Q7
+    type: 40gbase-x-qsfpp
+    comments: ICM Clustering or Uplink
+  - name: interconnect {module}, Q8
+    type: 40gbase-x-qsfpp
+    comments: ICM Clustring or Uplink


### PR DESCRIPTION
In this PR, I have added a single configuration file to define the Virtual Connect SE 40Gb F8 Module for HPE Synergy. While this product is marked as obsolete by HPE, it is still leveraged in active deployments.