### PR TITLE
Updated Port Names FG-400F.yaml

### DIFF
--- a/device-types/Fortinet/FG-400F.yaml
+++ b/device-types/Fortinet/FG-400F.yaml
@@ -57,35 +57,35 @@ interfaces:
     type: 1000base-t
   - name: port16
     type: 1000base-t
+  - name: portx1
+    type: 10gbase-x-sfpp
+  - name: portx2
+    type: 10gbase-x-sfpp
+  - name: portx3
+    type: 10gbase-x-sfpp
+  - name: portx4
+    type: 10gbase-x-sfpp
+  - name: portx5
+    type: 10gbase-x-sfpp
+  - name: portx6
+    type: 10gbase-x-sfpp
+  - name: portx7
+    type: 10gbase-x-sfpp
+  - name: portx8
+    type: 10gbase-x-sfpp
   - name: port17
-    type: 10gbase-x-sfpp
+    type: 1000base-x-sfp
   - name: port18
-    type: 10gbase-x-sfpp
+    type: 1000base-x-sfp
   - name: port19
-    type: 10gbase-x-sfpp
+    type: 1000base-x-sfp
   - name: port20
-    type: 10gbase-x-sfpp
+    type: 1000base-x-sfp
   - name: port21
-    type: 10gbase-x-sfpp
+    type: 1000base-x-sfp
   - name: port22
-    type: 10gbase-x-sfpp
+    type: 1000base-x-sfp
   - name: port23
-    type: 10gbase-x-sfpp
+    type: 1000base-x-sfp
   - name: port24
-    type: 10gbase-x-sfpp
-  - name: port25
-    type: 1000base-x-sfp
-  - name: port26
-    type: 1000base-x-sfp
-  - name: port27
-    type: 1000base-x-sfp
-  - name: port28
-    type: 1000base-x-sfp
-  - name: port29
-    type: 1000base-x-sfp
-  - name: port30
-    type: 1000base-x-sfp
-  - name: port31
-    type: 1000base-x-sfp
-  - name: port32
     type: 1000base-x-sfp

--- a/device-types/Fortinet/FG-400F.yaml
+++ b/device-types/Fortinet/FG-400F.yaml
@@ -57,21 +57,21 @@ interfaces:
     type: 1000base-t
   - name: port16
     type: 1000base-t
-  - name: portx1
+  - name: x1
     type: 10gbase-x-sfpp
-  - name: portx2
+  - name: x2
     type: 10gbase-x-sfpp
-  - name: portx3
+  - name: x3
     type: 10gbase-x-sfpp
-  - name: portx4
+  - name: x4
     type: 10gbase-x-sfpp
-  - name: portx5
+  - name: x5
     type: 10gbase-x-sfpp
-  - name: portx6
+  - name: x6
     type: 10gbase-x-sfpp
-  - name: portx7
+  - name: x7
     type: 10gbase-x-sfpp
-  - name: portx8
+  - name: x8
     type: 10gbase-x-sfpp
   - name: port17
     type: 1000base-x-sfp


### PR DESCRIPTION
Hi, the 10gbase-x-sfpp Ports are not numbered as they were in the template. 
These Ports have they're own numbers (X1-X8). The last Ports then continue with the previous numbering, see attached image.
The old Port 17 would be a 10GE SFP+ Port. But the actual Port 17 on the Device is a 1GE SFP Port

![400F-Ports](https://github.com/user-attachments/assets/ca647717-64ab-47d3-a824-7450d9ee3572)

Official datasheet with correct naming: https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/fortigate-400f-series.pdf