### PR TITLE
Create N55-M16P module used in Nexus switches

### DIFF
--- a/module-types/Cisco/N55-M16P.yaml
+++ b/module-types/Cisco/N55-M16P.yaml
@@ -4,35 +4,35 @@ model: N55-M16P
 description: N55 M16P Generic Expansion Module
 comments: '[Cisco Nexus 5500 Platform Overview](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/hw/installation/guide/nexus_5000_hig/overview5500.html)'
 interfaces:
-    - name: Ethernet2/1
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/2
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/3
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/4
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/5
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/6
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/7
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/8
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/9
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/10
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/11
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/12
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/13
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/14
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/15
-      type: 10gbase-x-sfpp
-    - name: Ethernet2/16
-      type: 10gbase-x-sfpp
+  - name: Ethernet2/1
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/2
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/3
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/4
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/5
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/6
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/7
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/8
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/9
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/10
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/11
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/12
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/13
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/14
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/15
+    type: 10gbase-x-sfpp
+  - name: Ethernet2/16
+    type: 10gbase-x-sfpp

--- a/module-types/Cisco/N55-M16P.yaml
+++ b/module-types/Cisco/N55-M16P.yaml
@@ -4,35 +4,35 @@ model: N55-M16P
 description: N55 M16P Generic Expansion Module
 comments: '[Cisco Nexus 5500 Platform Overview](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/hw/installation/guide/nexus_5000_hig/overview5500.html)'
 interfaces:
-- name: Ethernet2/1
-  type: 10gbase-x-sfpp
-- name: Ethernet2/2
-  type: 10gbase-x-sfpp
-- name: Ethernet2/3
-  type: 10gbase-x-sfpp
-- name: Ethernet2/4
-  type: 10gbase-x-sfpp
-- name: Ethernet2/5
-  type: 10gbase-x-sfpp
-- name: Ethernet2/6
-  type: 10gbase-x-sfpp
-- name: Ethernet2/7
-  type: 10gbase-x-sfpp
-- name: Ethernet2/8
-  type: 10gbase-x-sfpp
-- name: Ethernet2/9
-  type: 10gbase-x-sfpp
-- name: Ethernet2/10
-  type: 10gbase-x-sfpp
-- name: Ethernet2/11
-  type: 10gbase-x-sfpp
-- name: Ethernet2/12
-  type: 10gbase-x-sfpp
-- name: Ethernet2/13
-  type: 10gbase-x-sfpp
-- name: Ethernet2/14
-  type: 10gbase-x-sfpp
-- name: Ethernet2/15
-  type: 10gbase-x-sfpp
-- name: Ethernet2/16
-  type: 10gbase-x-sfpp
+    - name: Ethernet2/1
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/2
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/3
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/4
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/5
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/6
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/7
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/8
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/9
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/10
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/11
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/12
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/13
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/14
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/15
+      type: 10gbase-x-sfpp
+    - name: Ethernet2/16
+      type: 10gbase-x-sfpp

--- a/module-types/Cisco/N55-M16P.yaml
+++ b/module-types/Cisco/N55-M16P.yaml
@@ -1,3 +1,4 @@
+---
 manufacturer: Cisco
 model: N55-M16P
 description: N55 M16P Generic Expansion Module

--- a/module-types/Cisco/N55-M16P.yaml
+++ b/module-types/Cisco/N55-M16P.yaml
@@ -1,0 +1,37 @@
+manufacturer: Cisco
+model: N55-M16P
+description: N55 M16P Generic Expansion Module
+comments: '[Cisco Nexus 5500 Platform Overview](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/hw/installation/guide/nexus_5000_hig/overview5500.html)'
+interfaces:
+- name: Ethernet2/1
+  type: 10gbase-x-sfpp
+- name: Ethernet2/2
+  type: 10gbase-x-sfpp
+- name: Ethernet2/3
+  type: 10gbase-x-sfpp
+- name: Ethernet2/4
+  type: 10gbase-x-sfpp
+- name: Ethernet2/5
+  type: 10gbase-x-sfpp
+- name: Ethernet2/6
+  type: 10gbase-x-sfpp
+- name: Ethernet2/7
+  type: 10gbase-x-sfpp
+- name: Ethernet2/8
+  type: 10gbase-x-sfpp
+- name: Ethernet2/9
+  type: 10gbase-x-sfpp
+- name: Ethernet2/10
+  type: 10gbase-x-sfpp
+- name: Ethernet2/11
+  type: 10gbase-x-sfpp
+- name: Ethernet2/12
+  type: 10gbase-x-sfpp
+- name: Ethernet2/13
+  type: 10gbase-x-sfpp
+- name: Ethernet2/14
+  type: 10gbase-x-sfpp
+- name: Ethernet2/15
+  type: 10gbase-x-sfpp
+- name: Ethernet2/16
+  type: 10gbase-x-sfpp


### PR DESCRIPTION
Create N55-M16P module used in Nexus switches (Nexus 5548UP for example).