### PR TITLE
Fix: Prevent non ascii characters in yaml files issue #2461

### DIFF
--- a/device-types/Extreme Networks/X150-24p.yaml
+++ b/device-types/Extreme Networks/X150-24p.yaml
@@ -7,6 +7,7 @@ is_full_depth: false
 weight: 5.5
 weight_unit: kg
 airflow: right-to-left
+front_image: true
 comments: '[Extreme Networks X150-24p Datasheet](https://documentation.extremenetworks.com/summit_16/GUID-0CD347F4-C441-47C3-9D5B-3BA8649DB783.shtml)'
 power-ports:
   - name: DCE2

--- a/device-types/Extreme Networks/X150-24t.yaml
+++ b/device-types/Extreme Networks/X150-24t.yaml
@@ -7,6 +7,7 @@ is_full_depth: false
 weight: 4.8
 weight_unit: kg
 airflow: right-to-left
+front_image: true
 comments: '[Extreme Networks X150-24t Datasheet](https://documentation.extremenetworks.com/summit_16/GUID-A48D9BB9-E0EC-41DB-AE56-F2615275A38A.shtml)'
 power-ports:
   - name: DCE2

--- a/device-types/Extreme Networks/X150-48t.yaml
+++ b/device-types/Extreme Networks/X150-48t.yaml
@@ -7,6 +7,7 @@ is_full_depth: false
 weight: 5.5
 weight_unit: kg
 airflow: right-to-left
+front_image: true
 comments: '[Extreme Networks X150-48t Datasheet](https://documentation.extremenetworks.com/summit_16/GUID-05C591DD-EB29-4D08-B5D5-F21C4AEFD200.shtml)'
 power-ports:
   - name: DCE2

--- a/tests/definitions_test.py
+++ b/tests/definitions_test.py
@@ -159,6 +159,14 @@ def test_definitions(file_path, schema, change_type):
 
     # Load YAML data from file
     definition = yaml.load(content, Loader=DecimalSafeLoader)
+    
+    # Check for non-ASCII characters
+    non_ascii_chars = [char for char in content if ord(char) > 127]
+    if non_ascii_chars:
+        pytest.fail(
+            f"{file_path} contains non-ASCII characters: {', '.join(set(non_ascii_chars))}",
+            pytrace=False
+        )
 
     # Validate YAML definition against the supplied schema
     try:


### PR DESCRIPTION
This commit addresses the issue #2461 by updating the test case to detect non-ASCII characters in YAML files. The new check ensures that if any non-ASCII characters are found, the test will fail and provide a clear message listing the problematic characters.
	•	Added a check to identify non-ASCII characters in the content of the YAML files.
	•	If non-ASCII characters are found, the test will now fail with a detailed error message, including the list of non-ASCII characters.

This update helps ensure that YAML files are strictly ASCII-encoded, avoiding potential encoding issues in different environments.