### PR TITLE
Updates to Juniper EX4300-32F

### DIFF
--- a/device-types/Juniper/EX4300-32F-DC-TAA.yaml
+++ b/device-types/Juniper/EX4300-32F-DC-TAA.yaml
@@ -102,7 +102,3 @@ interfaces:
     type: 40gbase-x-qsfpp
   - name: et-0/1/1
     type: 40gbase-x-qsfpp
-  - name: et-0/1/2
-    type: 40gbase-x-qsfpp
-  - name: et-0/1/3
-    type: 40gbase-x-qsfpp

--- a/device-types/Juniper/EX4300-32F-DC.yaml
+++ b/device-types/Juniper/EX4300-32F-DC.yaml
@@ -102,7 +102,3 @@ interfaces:
     type: 40gbase-x-qsfpp
   - name: et-0/1/1
     type: 40gbase-x-qsfpp
-  - name: et-0/1/2
-    type: 40gbase-x-qsfpp
-  - name: et-0/1/3
-    type: 40gbase-x-qsfpp

--- a/device-types/Juniper/EX4300-32F-TAA.yaml
+++ b/device-types/Juniper/EX4300-32F-TAA.yaml
@@ -102,7 +102,3 @@ interfaces:
     type: 40gbase-x-qsfpp
   - name: et-0/1/1
     type: 40gbase-x-qsfpp
-  - name: et-0/1/2
-    type: 40gbase-x-qsfpp
-  - name: et-0/1/3
-    type: 40gbase-x-qsfpp

--- a/device-types/Juniper/EX4300-32F.yaml
+++ b/device-types/Juniper/EX4300-32F.yaml
@@ -102,7 +102,3 @@ interfaces:
     type: 40gbase-x-qsfpp
   - name: et-0/1/1
     type: 40gbase-x-qsfpp
-  - name: et-0/1/2
-    type: 40gbase-x-qsfpp
-  - name: et-0/1/3
-    type: 40gbase-x-qsfpp

--- a/module-types/Juniper/EX-UM-8X8SFP.yaml
+++ b/module-types/Juniper/EX-UM-8X8SFP.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: Juniper
+model: EX-UM-8X8SFP
+part_number: EX-UM-8X8SFP
+interfaces:
+  - name: ge-0/2/0
+    type: 10gbase-x-sfpp
+  - name: ge-0/2/1
+    type: 10gbase-x-sfpp
+  - name: ge-0/2/2
+    type: 10gbase-x-sfpp
+  - name: ge-0/2/3
+    type: 10gbase-x-sfpp
+  - name: xe-0/2/4
+    type: 10gbase-x-sfpp
+  - name: xe-0/2/5
+    type: 10gbase-x-sfpp
+  - name: xe-0/2/6
+    type: 10gbase-x-sfpp
+  - name: xe-0/2/7
+    type: 10gbase-x-sfpp


### PR DESCRIPTION
The EX4300-32F has some differences to the other EX4300-{24,48}{T,P} models.  It has fewer built-in QSFP+ ports but supports an eight SFP+ port uplink module.  These changes reflect those more accurately.