### PR TITLE
D link dws 3160 24tc

### DIFF
--- a/device-types/D-Link/DWS-3160-24TC.yaml
+++ b/device-types/D-Link/DWS-3160-24TC.yaml
@@ -59,7 +59,7 @@ interfaces:
   - name: 22T
     type: 1000base-t
   - name: 23T
-    type: 1000base-t    
+    type: 1000base-t
   - name: 24T
     type: 1000base-t
   - name: 21F
@@ -67,6 +67,6 @@ interfaces:
   - name: 22F
     type: 1000base-x-sfp
   - name: 23F
-    type: 1000base-x-sfp    
+    type: 1000base-x-sfp
   - name: 24F
     type: 1000base-x-sfp

--- a/device-types/D-Link/DWS-3160-24TC.yaml
+++ b/device-types/D-Link/DWS-3160-24TC.yaml
@@ -1,0 +1,72 @@
+---
+manufacturer: D-Link
+model: DWS-3160-24TC
+slug: d-link-dws-3160-24tc
+part_number: DWS-3160-24TC
+comments: '[D-Link DWS-3160 Series](https://www.dlink.com/uk/en/products/dws-3160-series-gigabit-l2plus-unified-managed-switches)'
+is_full_depth: false
+airflow: left-to-right
+weight: 2.55
+weight_unit: kg
+u_height: 1
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 38
+interfaces:
+  - name: '1'
+    type: 1000base-t
+  - name: '2'
+    type: 1000base-t
+  - name: '3'
+    type: 1000base-t
+  - name: '4'
+    type: 1000base-t
+  - name: '5'
+    type: 1000base-t
+  - name: '6'
+    type: 1000base-t
+  - name: '7'
+    type: 1000base-t
+  - name: '8'
+    type: 1000base-t
+  - name: '9'
+    type: 1000base-t
+  - name: '10'
+    type: 1000base-t
+  - name: '11'
+    type: 1000base-t
+  - name: '12'
+    type: 1000base-t
+  - name: '13'
+    type: 1000base-t
+  - name: '14'
+    type: 1000base-t
+  - name: '15'
+    type: 1000base-t
+  - name: '16'
+    type: 1000base-t
+  - name: '17'
+    type: 1000base-t
+  - name: '18'
+    type: 1000base-t
+  - name: '19'
+    type: 1000base-t
+  - name: '20'
+    type: 1000base-t
+  - name: '21T'
+    type: 1000base-t
+  - name: '22T'
+    type: 1000base-t
+  - name: '23T'
+    type: 1000base-t    
+  - name: '24T'
+    type: 1000base-t
+  - name: 21F
+    type: 1000base-x-sfp
+  - name: 22F
+    type: 1000base-x-sfp
+  - name: 23F
+    type: 1000base-x-sfp    
+  - name: 24F
+    type: 1000base-x-sfp

--- a/device-types/D-Link/DWS-3160-24TC.yaml
+++ b/device-types/D-Link/DWS-3160-24TC.yaml
@@ -14,53 +14,53 @@ power-ports:
     type: iec-60320-c14
     maximum_draw: 38
 interfaces:
-  - name: '1'
+  - name: 1
     type: 1000base-t
-  - name: '2'
+  - name: 2
     type: 1000base-t
-  - name: '3'
+  - name: 3
     type: 1000base-t
-  - name: '4'
+  - name: 4
     type: 1000base-t
-  - name: '5'
+  - name: 5
     type: 1000base-t
-  - name: '6'
+  - name: 6
     type: 1000base-t
-  - name: '7'
+  - name: 7
     type: 1000base-t
-  - name: '8'
+  - name: 8
     type: 1000base-t
-  - name: '9'
+  - name: 9
     type: 1000base-t
-  - name: '10'
+  - name: 10
     type: 1000base-t
-  - name: '11'
+  - name: 11
     type: 1000base-t
-  - name: '12'
+  - name: 12
     type: 1000base-t
-  - name: '13'
+  - name: 13
     type: 1000base-t
-  - name: '14'
+  - name: 14
     type: 1000base-t
-  - name: '15'
+  - name: 15
     type: 1000base-t
-  - name: '16'
+  - name: 16
     type: 1000base-t
-  - name: '17'
+  - name: 17
     type: 1000base-t
-  - name: '18'
+  - name: 18
     type: 1000base-t
-  - name: '19'
+  - name: 19
     type: 1000base-t
-  - name: '20'
+  - name: 20
     type: 1000base-t
-  - name: '21T'
+  - name: 21T
     type: 1000base-t
-  - name: '22T'
+  - name: 22T
     type: 1000base-t
-  - name: '23T'
+  - name: 23T
     type: 1000base-t    
-  - name: '24T'
+  - name: 24T
     type: 1000base-t
   - name: 21F
     type: 1000base-x-sfp

--- a/device-types/D-Link/DWS-3160-24TC.yaml
+++ b/device-types/D-Link/DWS-3160-24TC.yaml
@@ -14,59 +14,59 @@ power-ports:
     type: iec-60320-c14
     maximum_draw: 38
 interfaces:
-  - name: 1
+  - name: GigabitEthernet1/0/1
     type: 1000base-t
-  - name: 2
+  - name: GigabitEthernet1/0/2
     type: 1000base-t
-  - name: 3
+  - name: GigabitEthernet1/0/3
     type: 1000base-t
-  - name: 4
+  - name: GigabitEthernet1/0/4
     type: 1000base-t
-  - name: 5
+  - name: GigabitEthernet1/0/5
     type: 1000base-t
-  - name: 6
+  - name: GigabitEthernet1/0/6
     type: 1000base-t
-  - name: 7
+  - name: GigabitEthernet1/0/7
     type: 1000base-t
-  - name: 8
+  - name: GigabitEthernet1/0/8
     type: 1000base-t
-  - name: 9
+  - name: GigabitEthernet1/0/9
     type: 1000base-t
-  - name: 10
+  - name: GigabitEthernet1/0/10
     type: 1000base-t
-  - name: 11
+  - name: GigabitEthernet1/0/11
     type: 1000base-t
-  - name: 12
+  - name: GigabitEthernet1/0/12
     type: 1000base-t
-  - name: 13
+  - name: GigabitEthernet1/0/13
     type: 1000base-t
-  - name: 14
+  - name: GigabitEthernet1/0/14
     type: 1000base-t
-  - name: 15
+  - name: GigabitEthernet1/0/15
     type: 1000base-t
-  - name: 16
+  - name: GigabitEthernet1/0/16
     type: 1000base-t
-  - name: 17
+  - name: GigabitEthernet1/0/17
     type: 1000base-t
-  - name: 18
+  - name: GigabitEthernet1/0/18
     type: 1000base-t
-  - name: 19
+  - name: GigabitEthernet1/0/19
     type: 1000base-t
-  - name: 20
+  - name: GigabitEthernet1/0/20
     type: 1000base-t
-  - name: 21T
+  - name: GigabitEthernet1/0/21T
     type: 1000base-t
-  - name: 22T
+  - name: GigabitEthernet1/0/22T
     type: 1000base-t
-  - name: 23T
+  - name: GigabitEthernet1/0/23T
     type: 1000base-t
-  - name: 24T
+  - name: GigabitEthernet1/0/24T
     type: 1000base-t
-  - name: 21F
+  - name: GigabitEthernet1/0/21F
     type: 1000base-x-sfp
-  - name: 22F
+  - name: GigabitEthernet1/0/22F
     type: 1000base-x-sfp
-  - name: 23F
+  - name: GigabitEthernet1/0/23F
     type: 1000base-x-sfp
-  - name: 24F
+  - name: GigabitEthernet1/0/24F
     type: 1000base-x-sfp


### PR DESCRIPTION
Added DWS-3160-24TC
Official specs: https://www.dlink.com/uk/en/products/dws-3160-series-gigabit-l2plus-unified-managed-switches