### PR TITLE
changes manufacturer "Tripp Lite" to "Eaton"

### DIFF
--- a/device-types/Eaton/Tripp-Lite-B051-000.yaml
+++ b/device-types/Eaton/Tripp-Lite-B051-000.yaml
@@ -1,5 +1,5 @@
 ---
-manufacturer: Tripp Lite
+manufacturer: Eaton
 model: Tripp Lite B051-000
 slug: tripp-lite-b051-000
 part_number: B051-000

--- a/device-types/Eaton/Tripp-Lite-N054-024.yaml
+++ b/device-types/Eaton/Tripp-Lite-N054-024.yaml
@@ -1,5 +1,5 @@
 ---
-manufacturer: Tripp Lite
+manufacturer: Eaton
 model: Tripp Lite N054-024
 slug: tripp-lite-n054-024
 part_number: N054-024


### PR DESCRIPTION
Tripp Lite is a brand of Eaton, files are in the Eaton directory