### PR TITLE
APC interface and module bay fixes

### DIFF
--- a/device-types/APC/SMC3000RMI2U.yml
+++ b/device-types/APC/SMC3000RMI2U.yml
@@ -48,4 +48,4 @@ power-outlets:
     power_port: Inlet
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'

--- a/device-types/APC/SMC3000RMI2U.yml
+++ b/device-types/APC/SMC3000RMI2U.yml
@@ -48,4 +48,4 @@ power-outlets:
     power_port: Inlet
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT1000.yaml
+++ b/device-types/APC/SMT1000.yaml
@@ -30,3 +30,4 @@ power-outlets:
     type: nema-5-15r
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMT1000.yaml
+++ b/device-types/APC/SMT1000.yaml
@@ -30,4 +30,4 @@ power-outlets:
     type: nema-5-15r
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT1500.yaml
+++ b/device-types/APC/SMT1500.yaml
@@ -32,4 +32,4 @@ power-outlets:
     type: nema-5-15r
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT1500.yaml
+++ b/device-types/APC/SMT1500.yaml
@@ -32,4 +32,4 @@ power-outlets:
     type: nema-5-15r
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'

--- a/device-types/APC/SMT1500RM2U.yaml
+++ b/device-types/APC/SMT1500RM2U.yaml
@@ -28,4 +28,4 @@ power-outlets:
     type: nema-5-15r
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT1500RM2U.yaml
+++ b/device-types/APC/SMT1500RM2U.yaml
@@ -28,4 +28,4 @@ power-outlets:
     type: nema-5-15r
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'

--- a/device-types/APC/SMT1500RM2UC.yaml
+++ b/device-types/APC/SMT1500RM2UC.yaml
@@ -27,6 +27,6 @@ power-outlets:
   - name: Group 2 Outlet 3
     type: nema-5-15r
 interfaces:
-  - name: Ethernet
+  - name: SmartConnect
     type: 1000base-t
     mgmt_only: true

--- a/device-types/APC/SMT1500RMI2U.yaml
+++ b/device-types/APC/SMT1500RMI2U.yaml
@@ -31,3 +31,4 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMT1500RMI2U.yaml
+++ b/device-types/APC/SMT1500RMI2U.yaml
@@ -31,4 +31,4 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT1500RMI2UC.yaml
+++ b/device-types/APC/SMT1500RMI2UC.yaml
@@ -39,3 +39,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMT1500RMI2UC.yaml
+++ b/device-types/APC/SMT1500RMI2UC.yaml
@@ -34,7 +34,7 @@ power-outlets:
     type: iec-60320-c13
     power_port: Source
 interfaces:
-  - name: Ethernet
+  - name: SmartConnect
     type: 1000base-t
     mgmt_only: true
 module-bays:

--- a/device-types/APC/SMT1500RMI2UC.yaml
+++ b/device-types/APC/SMT1500RMI2UC.yaml
@@ -39,4 +39,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT1500RMI2UNC.yaml
+++ b/device-types/APC/SMT1500RMI2UNC.yaml
@@ -31,7 +31,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SMT1500RMI2UNC.yaml
+++ b/device-types/APC/SMT1500RMI2UNC.yaml
@@ -32,7 +32,3 @@ power-outlets:
 module-bays:
   - name: SmartSlot
     position: SmartSlot
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true

--- a/device-types/APC/SMT1500RMI2UNC.yaml
+++ b/device-types/APC/SMT1500RMI2UNC.yaml
@@ -31,6 +31,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SMT2200RM2UNC.yaml
+++ b/device-types/APC/SMT2200RM2UNC.yaml
@@ -46,3 +46,4 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMT2200RM2UNC.yaml
+++ b/device-types/APC/SMT2200RM2UNC.yaml
@@ -46,4 +46,4 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT2200RM2UNC.yaml
+++ b/device-types/APC/SMT2200RM2UNC.yaml
@@ -46,7 +46,3 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true

--- a/device-types/APC/SMT2200RMI2UNC.yaml
+++ b/device-types/APC/SMT2200RMI2UNC.yaml
@@ -45,6 +45,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SMT2200RMI2UNC.yaml
+++ b/device-types/APC/SMT2200RMI2UNC.yaml
@@ -45,7 +45,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SMT2200RMI2UNC.yaml
+++ b/device-types/APC/SMT2200RMI2UNC.yaml
@@ -46,7 +46,3 @@ power-outlets:
 module-bays:
   - name: SmartSlot
     position: SmartSlot
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true

--- a/device-types/APC/SMT3000RMI2U.yaml
+++ b/device-types/APC/SMT3000RMI2U.yaml
@@ -50,3 +50,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMT3000RMI2U.yaml
+++ b/device-types/APC/SMT3000RMI2U.yaml
@@ -50,4 +50,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT3000RMI2U.yaml
+++ b/device-types/APC/SMT3000RMI2U.yaml
@@ -44,10 +44,6 @@ power-outlets:
   - name: Group 3 Outlet 1
     type: iec-60320-c19
     power_port: Source
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true
 module-bays:
   - name: SmartSlot
     position: SmartSlot

--- a/device-types/APC/SMT3000RMI2UC.yaml
+++ b/device-types/APC/SMT3000RMI2UC.yaml
@@ -52,4 +52,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT3000RMI2UC.yaml
+++ b/device-types/APC/SMT3000RMI2UC.yaml
@@ -52,3 +52,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMT3000RMI2UC.yaml
+++ b/device-types/APC/SMT3000RMI2UC.yaml
@@ -47,7 +47,7 @@ power-outlets:
     type: iec-60320-c19
     power_port: Source
 interfaces:
-  - name: Ethernet
+  - name: SmartConnect
     type: 1000base-t
     mgmt_only: true
 module-bays:

--- a/device-types/APC/SMT3000RMI2UNC.yaml
+++ b/device-types/APC/SMT3000RMI2UNC.yaml
@@ -50,3 +50,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMT3000RMI2UNC.yaml
+++ b/device-types/APC/SMT3000RMI2UNC.yaml
@@ -50,4 +50,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMT3000RMI2UNC.yaml
+++ b/device-types/APC/SMT3000RMI2UNC.yaml
@@ -44,10 +44,6 @@ power-outlets:
   - name: Group 3 Outlet 1
     type: iec-60320-c19
     power_port: Source
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true
 module-bays:
   - name: SmartSlot
     position: SmartSlot

--- a/device-types/APC/SMT750IC.yaml
+++ b/device-types/APC/SMT750IC.yaml
@@ -31,5 +31,6 @@ console-ports:
   - name: Serial
     type: rj-45
 interfaces:
-  - name: Network
+  - name: SmartConnect
     type: 1000base-t
+    mgmt_only: true

--- a/device-types/APC/SMX1000I.yaml
+++ b/device-types/APC/SMX1000I.yaml
@@ -26,7 +26,6 @@ power-outlets:
     type: nema-5-15r
   - name: Group 2 Outlet 3
     type: nema-5-15r
-interfaces:
-  - name: Ethernet
-    type: 100base-tx
-    mgmt_only: true
+module-bays:
+  - name: SmartSlot
+    position: SmartSlot

--- a/device-types/APC/SMX1500RMI2U.yaml
+++ b/device-types/APC/SMX1500RMI2U.yaml
@@ -37,3 +37,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMX1500RMI2U.yaml
+++ b/device-types/APC/SMX1500RMI2U.yaml
@@ -31,10 +31,6 @@ power-outlets:
     type: iec-60320-c19
   - name: Group 2 Outlet 4
     type: iec-60320-c13
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true
 module-bays:
   - name: SmartSlot
     position: SmartSlot

--- a/device-types/APC/SMX1500RMI2U.yaml
+++ b/device-types/APC/SMX1500RMI2U.yaml
@@ -37,4 +37,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMX2200HV.yaml
+++ b/device-types/APC/SMX2200HV.yaml
@@ -40,4 +40,4 @@ power-outlets:
     type: iec-60320-c19
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMX2200HV.yaml
+++ b/device-types/APC/SMX2200HV.yaml
@@ -40,3 +40,4 @@ power-outlets:
     type: iec-60320-c19
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMX3000HVNC.yaml
+++ b/device-types/APC/SMX3000HVNC.yaml
@@ -39,4 +39,4 @@ power-outlets:
     type: iec-60320-c19
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMX3000HVNC.yaml
+++ b/device-types/APC/SMX3000HVNC.yaml
@@ -39,3 +39,4 @@ power-outlets:
     type: iec-60320-c19
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMX3000RMHV2UNC.yaml
+++ b/device-types/APC/SMX3000RMHV2UNC.yaml
@@ -35,4 +35,4 @@ power-outlets:
     type: iec-60320-c19
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMX3000RMHV2UNC.yaml
+++ b/device-types/APC/SMX3000RMHV2UNC.yaml
@@ -35,3 +35,4 @@ power-outlets:
     type: iec-60320-c19
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SMX3000RMLV2U.yaml
+++ b/device-types/APC/SMX3000RMLV2U.yaml
@@ -44,4 +44,4 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SMX3000RMLV2U.yaml
+++ b/device-types/APC/SMX3000RMLV2U.yaml
@@ -44,3 +44,4 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SRT1000UXI-NCLI.yaml
+++ b/device-types/APC/SRT1000UXI-NCLI.yaml
@@ -35,7 +35,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SRT1000UXI-NCLI.yaml
+++ b/device-types/APC/SRT1000UXI-NCLI.yaml
@@ -36,7 +36,3 @@ power-outlets:
 module-bays:
   - name: SmartSlot
     position: SmartSlot
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true

--- a/device-types/APC/SRT1000UXI-NCLI.yaml
+++ b/device-types/APC/SRT1000UXI-NCLI.yaml
@@ -35,7 +35,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SRT1500RMXLI-NC.yaml
+++ b/device-types/APC/SRT1500RMXLI-NC.yaml
@@ -35,7 +35,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SRT1500RMXLI-NC.yaml
+++ b/device-types/APC/SRT1500RMXLI-NC.yaml
@@ -36,7 +36,3 @@ power-outlets:
 module-bays:
   - name: SmartSlot
     position: SmartSlot
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true

--- a/device-types/APC/SRT1500RMXLI-NC.yaml
+++ b/device-types/APC/SRT1500RMXLI-NC.yaml
@@ -35,7 +35,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SRT1500UXI-NCLI.yaml
+++ b/device-types/APC/SRT1500UXI-NCLI.yaml
@@ -42,7 +42,3 @@ power-outlets:
 module-bays:
   - name: SmartSlot
     position: SmartSlot
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true

--- a/device-types/APC/SRT1500UXI-NCLI.yaml
+++ b/device-types/APC/SRT1500UXI-NCLI.yaml
@@ -41,7 +41,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SRT1500UXI-NCLI.yaml
+++ b/device-types/APC/SRT1500UXI-NCLI.yaml
@@ -41,7 +41,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SRT2200RMXLI-NC.yaml
+++ b/device-types/APC/SRT2200RMXLI-NC.yaml
@@ -51,4 +51,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SRT2200RMXLI-NC.yaml
+++ b/device-types/APC/SRT2200RMXLI-NC.yaml
@@ -45,10 +45,6 @@ power-outlets:
   - name: 16A Outlet 2
     type: iec-60320-c19
     power_port: Inlet
-interfaces:
-  - name: Ethernet
-    type: 100base-tx
-    mgmt_only: true
 module-bays:
   - name: SmartSlot
     position: SmartSlot

--- a/device-types/APC/SRT2200RMXLI-NC.yaml
+++ b/device-types/APC/SRT2200RMXLI-NC.yaml
@@ -51,4 +51,4 @@ interfaces:
     mgmt_only: true
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'

--- a/device-types/APC/SRT3000RMXLT.yaml
+++ b/device-types/APC/SRT3000RMXLT.yaml
@@ -24,4 +24,4 @@ power-outlets:
     type: nema-l6-20r
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SRT3000RMXLT.yaml
+++ b/device-types/APC/SRT3000RMXLT.yaml
@@ -24,4 +24,4 @@ power-outlets:
     type: nema-l6-20r
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'

--- a/device-types/APC/SRT3000UXI-NCLI.yaml
+++ b/device-types/APC/SRT3000UXI-NCLI.yaml
@@ -42,7 +42,3 @@ power-outlets:
 module-bays:
   - name: SmartSlot
     position: SmartSlot
-interfaces:
-  - name: Ethernet
-    type: 1000base-t
-    mgmt_only: true

--- a/device-types/APC/SRT3000UXI-NCLI.yaml
+++ b/device-types/APC/SRT3000UXI-NCLI.yaml
@@ -41,7 +41,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SRT3000UXI-NCLI.yaml
+++ b/device-types/APC/SRT3000UXI-NCLI.yaml
@@ -41,7 +41,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot
 interfaces:
   - name: Ethernet
     type: 1000base-t

--- a/device-types/APC/SRT5KRMXLI.yaml
+++ b/device-types/APC/SRT5KRMXLI.yaml
@@ -37,3 +37,6 @@ interfaces:
   - name: Ethernet
     type: 100base-tx
     mgmt_only: true
+module-bays:
+  - name: SmartSlot
+    position: SmartSlot

--- a/device-types/APC/SRT5KRMXLT-IEC.yaml
+++ b/device-types/APC/SRT5KRMXLT-IEC.yaml
@@ -40,3 +40,6 @@ interfaces:
   - name: Ethernet
     type: 100base-tx
     mgmt_only: true
+module-bays:
+  - name: SmartSlot
+    position: SmartSlot

--- a/device-types/APC/SRT5KRMXLT.yaml
+++ b/device-types/APC/SRT5KRMXLT.yaml
@@ -29,7 +29,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot
 interfaces:
   - name: Ethernet
     type: 100base-tx

--- a/device-types/APC/SRT5KRMXLT.yaml
+++ b/device-types/APC/SRT5KRMXLT.yaml
@@ -29,7 +29,7 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'
 interfaces:
   - name: Ethernet
     type: 100base-tx

--- a/device-types/APC/SRT5KRMXLW-HW.yaml
+++ b/device-types/APC/SRT5KRMXLW-HW.yaml
@@ -16,3 +16,6 @@ interfaces:
   - name: Ethernet
     type: 100base-tx
     mgmt_only: true
+module-bays:
+  - name: SmartSlot
+    position: SmartSlot

--- a/device-types/APC/SRT5KXLJ.yaml
+++ b/device-types/APC/SRT5KXLJ.yaml
@@ -29,3 +29,6 @@ interfaces:
   - name: Ethernet
     type: 100base-tx
     mgmt_only: true
+module-bays:
+  - name: SmartSlot
+    position: SmartSlot

--- a/device-types/APC/SUA1500RMI2U.yaml
+++ b/device-types/APC/SUA1500RMI2U.yaml
@@ -31,3 +31,4 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SUA1500RMI2U.yaml
+++ b/device-types/APC/SUA1500RMI2U.yaml
@@ -31,4 +31,4 @@ power-outlets:
     power_port: Source
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SURT2000RMXLI.yaml
+++ b/device-types/APC/SURT2000RMXLI.yaml
@@ -30,7 +30,6 @@ power-outlets:
   - name: Outlet 6
     type: iec-60320-c13
     power_port: Inlet
-interfaces:
-  - name: Ethernet
-    type: 100base-tx
-    mgmt_only: true
+module-bays:
+  - name: SmartSlot
+    position: SmartSlot

--- a/device-types/APC/SURT20KRMXLT.yaml
+++ b/device-types/APC/SURT20KRMXLT.yaml
@@ -32,3 +32,4 @@ power-outlets:
     type: nema-l6-20r
 module-bays:
   - name: SmartSlot
+    position: 'SmartSlot'

--- a/device-types/APC/SURT20KRMXLT.yaml
+++ b/device-types/APC/SURT20KRMXLT.yaml
@@ -32,4 +32,4 @@ power-outlets:
     type: nema-l6-20r
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SURTD3000XLI.yml
+++ b/device-types/APC/SURTD3000XLI.yml
@@ -49,4 +49,4 @@ power-outlets:
     power_port: Inlet
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'

--- a/device-types/APC/SURTD3000XLI.yml
+++ b/device-types/APC/SURTD3000XLI.yml
@@ -49,4 +49,4 @@ power-outlets:
     power_port: Inlet
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot

--- a/device-types/APC/SURTD5000XLI.yml
+++ b/device-types/APC/SURTD5000XLI.yml
@@ -49,4 +49,4 @@ power-outlets:
     power_port: Inlet
 module-bays:
   - name: SmartSlot
-    position: Rear
+    position: 'SmartSlot'

--- a/device-types/APC/SURTD5000XLI.yml
+++ b/device-types/APC/SURTD5000XLI.yml
@@ -49,4 +49,4 @@ power-outlets:
     power_port: Inlet
 module-bays:
   - name: SmartSlot
-    position: 'SmartSlot'
+    position: SmartSlot


### PR DESCRIPTION
Add "position: SmartSlot" to many UPS models.  Then when a module such as an AP9640 is added the network interface on it will be shown with the name "Network [SmartSlot]".  This will distinguish it nicely from built-in network interfaces.

Also I fixed some built-in interfaces.  Some remain with name=Ethernet but ones that are the limited SmartConnect cloud-only type I set name=SmartConnect.  Some just had interfaces removed as none exist unless a SmartSlot module is added with one.