### PR TITLE
Fix: Remove rear-port declarations from Minisforum MS-01 (#2709)

### DIFF
--- a/device-types/Minisforum/Minisforum-MS-01.yml
+++ b/device-types/Minisforum/Minisforum-MS-01.yml
@@ -19,15 +19,6 @@ interfaces:
     type: 2.5gbase-t
   - name: ethernet-2/2
     type: 2.5gbase-t
-rear-ports:
-  - name: usb-c-1/1
-    type: usb-c
-  - name: usb-c-1/2
-    type: usb-c
-  - name: usb-a-1/1
-    type: usb-a
-  - name: usb-a-1/2
-    type: usb-a
 module-bays:
   - name: PCIe Slot
     position: '1'

--- a/device-types/Minisforum/Minisforum-MS-01.yml
+++ b/device-types/Minisforum/Minisforum-MS-01.yml
@@ -24,6 +24,6 @@ module-bays:
     position: '1'
     description: PCIe 4.0 x16
 power-ports:
-  - name: Barrel Jack
+  - name: External Power Supply
     type: dc-terminal
     maximum-draw: 180


### PR DESCRIPTION
Closes #2709 