### PR TITLE
Update BCM957508-P2100G.yaml

### DIFF
--- a/module-types/Broadcom Corporation/BCM957508-P2100G.yaml
+++ b/module-types/Broadcom Corporation/BCM957508-P2100G.yaml
@@ -1,5 +1,5 @@
 ---
-manufacturer: Broadcom
+manufacturer: Broadcom Corporation
 model: BCM957508-P2100G
 part_number: BCM957508-P2100G
 description: Dual-Port 100 Gb/s QSFP56 Ethernet PCI Express 4.0 x16 Network Interface Card


### PR DESCRIPTION
Fixed incorrect manufacturer name for BCM957508-P2100G from "Broadcom" to "Broadcom Corporation". This is causing the script to fail to import the device because the manufacturer "Broadcom" does not exist.