### PR TITLE
Update J9805A.yaml

### DIFF
--- a/device-types/HPE/J9805A.yaml
+++ b/device-types/HPE/J9805A.yaml
@@ -14,26 +14,26 @@ module-bays:
     position: '3'
 power-outlets:
   - name: 1A
-    power_port: PS1
+    label: PS1-A
     type: dc-terminal
   - name: 1B
-    power_port: PS1
+    label: PS1-B
     type: dc-terminal
   - name: 1C
-    power_port: PS1
+    label: PS1-C
     type: dc-terminal
   - name: 1D
-    power_port: PS1
+    label: PS1-D
     type: dc-terminal
   - name: 2A
-    power_port: PS2
+    label: PS2-A
     type: dc-terminal
   - name: 2B
-    power_port: PS2
+    label: PS2-B
     type: dc-terminal
   - name: 3A
-    power_port: PS3
+    label: PS3-A
     type: dc-terminal
   - name: 3B
-    power_port: PS3
+    label: PS3-B
     type: dc-terminal


### PR DESCRIPTION
Correct power_port to label due to the transition to modular power supplies