### PR TITLE
Move Bachmann-107686 device to correct vendor directory

### DIFF
--- a/device-types/Bachmann/Bachmann-107686.yaml
+++ b/device-types/Bachmann/Bachmann-107686.yaml
@@ -1,7 +1,7 @@
 ---
-manufacturer: Max Hauri
+manufacturer: Bachmann
 model: Bachmann 107686
-slug: max-hauri-bachmann-107686
+slug: bachmann-107686
 part_number: '107686'
 u_height: 1.0
 is_full_depth: false


### PR DESCRIPTION
Bachmann is an independent vendor, I mistakenly thought they were part of Max Hauri. 
Moving device-type into the correct vendor directory.