### PR TITLE
Update SEL-587-Current-Differential-Relay.yaml

### DIFF
--- a/device-types/Schweitzer Engineering Laboratories/SEL-587-Current-Differential-Relay.yaml
+++ b/device-types/Schweitzer Engineering Laboratories/SEL-587-Current-Differential-Relay.yaml
@@ -17,6 +17,6 @@ power-ports:
 console-server-ports:
   # Serial Ports
   - name: Port F
-    label: Communications with Modbus RTU-Slave, ASCII terminals, local HMI, SCADA, or DCS systems
+    label: Modbus RTU-Slave, ASCII terminals, HMI, SCADA, or DCS systems
     type: de-9
     speed: 38400


### PR DESCRIPTION
Fix Error '[{"label":["Ensure this field has no more than 64 characters."]}]' creating Console Server Port