### PR TITLE
Add module types for Cisco UCS-X 9508 chassis

### DIFF
--- a/module-types/Cisco/UCSX-9508-FAN.yaml
+++ b/module-types/Cisco/UCSX-9508-FAN.yaml
@@ -3,4 +3,3 @@ manufacturer: Cisco
 model: UCSX-9508-FAN
 part_number: UCSX-9508-FAN
 description: UCSX-9508 Chassis Fan Module
-

--- a/module-types/Cisco/UCSX-9508-FAN.yaml
+++ b/module-types/Cisco/UCSX-9508-FAN.yaml
@@ -1,0 +1,6 @@
+---
+manufacturer: Cisco
+model: UCSX-9508-FAN
+part_number: UCSX-9508-FAN
+description: UCSX-9508 Chassis Fan Module
+

--- a/module-types/Cisco/UCSX-9508-RBLK.yaml
+++ b/module-types/Cisco/UCSX-9508-RBLK.yaml
@@ -3,4 +3,3 @@ manufacturer: Cisco
 model: UCSX-9508-RBLK
 part_number: UCSX-9508-RBLK
 description: UCSX-9508 Chassis X-Fabric Module Blank
-

--- a/module-types/Cisco/UCSX-9508-RBLK.yaml
+++ b/module-types/Cisco/UCSX-9508-RBLK.yaml
@@ -1,0 +1,6 @@
+---
+manufacturer: Cisco
+model: UCSX-9508-RBLK
+part_number: UCSX-9508-RBLK
+description: UCSX-9508 Chassis X-Fabric Module Blank
+

--- a/module-types/Cisco/UCSX-I-9108-100G.yaml
+++ b/module-types/Cisco/UCSX-I-9108-100G.yaml
@@ -21,4 +21,3 @@ interfaces:
     type: 100gbase-x-qsfp28
   - name: Fabric port {module}/8
     type: 100gbase-x-qsfp28
-

--- a/module-types/Cisco/UCSX-I-9108-100G.yaml
+++ b/module-types/Cisco/UCSX-I-9108-100G.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Cisco
+model: UCSX-I-9108-100G
+part_number: UCSX-I-9108-100G
+description: Cisco UCS 9108 100G Intelligent Fabric Module
+comments: '[Cisco UCS 9108 100G IFM Data Sheet](https://www.cisco.com/c/dam/en/us/products/collateral/servers-unified-computing/ucs-x-series-modular-system/cisco-ucs-9108-100g-intelligent-fabric-module-spec-sheet.pdf)'
+interfaces:
+  - name: Fabric port {module}/1
+    type: 100gbase-x-qsfp28
+  - name: Fabric port {module}/2
+    type: 100gbase-x-qsfp28
+  - name: Fabric port {module}/3
+    type: 100gbase-x-qsfp28
+  - name: Fabric port {module}/4
+    type: 100gbase-x-qsfp28
+  - name: Fabric port {module}/5
+    type: 100gbase-x-qsfp28
+  - name: Fabric port {module}/6
+    type: 100gbase-x-qsfp28
+  - name: Fabric port {module}/7
+    type: 100gbase-x-qsfp28
+  - name: Fabric port {module}/8
+    type: 100gbase-x-qsfp28
+

--- a/module-types/Cisco/UCSX-PSU-2800AC.yaml
+++ b/module-types/Cisco/UCSX-PSU-2800AC.yaml
@@ -1,0 +1,10 @@
+---
+manufacturer: Cisco
+model: UCSX-PSU-2800AC
+part_number: UCSX-PSU-2800AC
+description: UCSX-9508 Chassis 2800 VAC Dual Voltage PSU
+power-ports:
+  - name: 'PSU{module}'
+    type: iec-60320-c20
+    maximum_draw: 2800
+

--- a/module-types/Cisco/UCSX-PSU-2800AC.yaml
+++ b/module-types/Cisco/UCSX-PSU-2800AC.yaml
@@ -4,6 +4,6 @@ model: UCSX-PSU-2800AC
 part_number: UCSX-PSU-2800AC
 description: UCSX-9508 Chassis 2800 VAC Dual Voltage PSU
 power-ports:
-  - name: 'PSU{module}'
+  - name: PSU{module}
     type: iec-60320-c20
     maximum_draw: 2800

--- a/module-types/Cisco/UCSX-PSU-2800AC.yaml
+++ b/module-types/Cisco/UCSX-PSU-2800AC.yaml
@@ -7,4 +7,3 @@ power-ports:
   - name: 'PSU{module}'
     type: iec-60320-c20
     maximum_draw: 2800
-


### PR DESCRIPTION
The Cisco UCS-X 9508 chassis has module slots defined, but no modules.  This PR adds some of them to the repo.