### PR TITLE
Cisco: Modify C6807-XL and add 2 different modules

### DIFF
--- a/device-types/Cisco/C6807-XL.yaml
+++ b/device-types/Cisco/C6807-XL.yaml
@@ -4,10 +4,26 @@ model: Catalyst 6807-XL
 part_number: C6807-XL
 slug: cisco-catalyst-6807-xl
 u_height: 10
+weight: 62
+weight_unit: lb
+airflow: right-to-left
 is_full_depth: false
-console-ports:
-  - name: con 0
-    type: rj-45
+comments: '[Cisco Catalyst 6807-XL Modular Switch Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-6807-xl-switch/datasheet-c78-728229.html)'
+module-bays:
+  - name: Slot 1
+    position: '1'
+  - name: Slot 2
+    position: '2'
+  - name: Slot 3
+    position: '3'
+  - name: Slot 4
+    position: '4'
+  - name: Slot 5
+    position: '5'
+  - name: Slot 6
+    position: '6'
+  - name: Slot 7
+    position: '7'
 power-ports:
   - name: PS-1
     type: iec-60320-c14

--- a/module-types/Cisco/VS-S2T-10G.yaml
+++ b/module-types/Cisco/VS-S2T-10G.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Cisco
+model: VS-S2T-10G
+part_number: VS-S2T-10G
+weight: 12.0
+weight_unit: lb
+comments: '[Cisco Catalyst 6500 Series Supervisor Engine 2T Data Sheet](https://www.cisco.com/c/en/us/products/collateral/interfaces-modules/catalyst-6500-series-supervisor-engine-2t/data_sheet_c78-648214.html)'
+console-ports:
+  - name: con{module}
+    type: rj-45
+interfaces:
+  - name: GigabitEthernet{module}/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/2
+    type: 1000base-x-sfp
+  - name: GigabitEthernet{module}/3
+    type: 1000base-x-sfp
+  - name: TenGigabitEthernet{module}/4
+    type: 10gbase-x-x2
+  - name: TenGigabitEthernet{module}/5
+    type: 10gbase-x-x2
+  - name: Mgmt{module}/0
+    type: 1000base-t
+    mgmt_only: true

--- a/module-types/Cisco/WS-X6904-40G.yaml
+++ b/module-types/Cisco/WS-X6904-40G.yaml
@@ -1,0 +1,49 @@
+---
+manufacturer: Cisco
+model: WS-X6904-40G
+part_number: WS-X6904-40G
+weight: 12.0
+weight_unit: lb
+comments: '[Cisco Catalyst 6900 Series 40 Gigabit Ethernet Interface Module for Cisco Catalyst 6500 Series Switches Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-6500-series-switches/data_sheet_c78-696623.html)'
+interfaces:
+# Two possible optical modes for 4 optical slots (40GE using a CFP-40G or 10GE using a CVR-CFP-4SFP10G):
+#  - name: FortyGigabitEthernet{module}/1
+#    type: 40gbase-x-qsfpp
+  - name: TenGigabitEthernet{module}/5
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/6
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/7
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/8
+    type: 10gbase-x-sfpp
+#  - name: FortyGigabitEthernet{module}/2
+#    type: 40gbase-x-qsfpp
+  - name: TenGigabitEthernet{module}/9
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/10
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/11
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/12
+    type: 10gbase-x-sfpp
+#  - name: FortyGigabitEthernet{module}/3
+#    type: 40gbase-x-qsfpp
+  - name: TenGigabitEthernet{module}/13
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/14
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/15
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/16
+    type: 10gbase-x-sfpp
+#  - name: FortyGigabitEthernet{module}/4
+#    type: 40gbase-x-qsfpp
+  - name: TenGigabitEthernet{module}/17
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/18
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/19
+    type: 10gbase-x-sfpp
+  - name: TenGigabitEthernet{module}/20
+    type: 10gbase-x-sfpp


### PR DESCRIPTION
## Description/Rationale

C6807-XL and VS-S2T-10G should be self-explanatory, but regarding WS-X6904-40G, there are three possible setups depending on the transceiver used:

- 4 40GE ports
- 16 10GE ports
- Mixed 40GE/10GE ports

I'm not sure how to properly handle this, but seeing precedent from [FWB-2000E](https://github.com/netbox-community/devicetype-library/blob/1b261daa6bb33a28dc663c4042b090c9ed597116/device-types/Fortinet/FWB-2000E.yaml#L35), I decided to use this approach. I put the interfaces and numbers in the appropriate position (e.g. if it's 40G then the if number is Fo{module}/1, but if it's 10G ten they'll be Te{module}/[5-8] and so on, see datasheet for more info).