### PR TITLE
Add Supermicro SuperServer SYS-221H-TNR device-type and some related module-types

### DIFF
--- a/device-types/Supermicro/SYS-221H-TNR.yaml
+++ b/device-types/Supermicro/SYS-221H-TNR.yaml
@@ -1,0 +1,39 @@
+---
+manufacturer: Supermicro
+model: SuperServer SYS-221H-TNR
+slug: supermicro-sys-221h-tnr
+part_number: SYS-221H-TNR
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+weight: 18.2
+weight_unit: kg
+comments: '[Supermicro SuperServer SYS-221H-TNR](https://www.supermicro.com/en/products/system/hyper/2u/sys-221h-tnr)'
+interfaces:
+  - name: BMC
+    type: 1000base-t
+    mgmt_only: true
+    description: Dedicated IPMI LAN port
+module-bays:
+  - name: PSU 1
+    position: PSU1
+  - name: PSU 2
+    position: PSU2
+  - name: AIOM 1
+    position: AIOM1
+    description: AIOM / OCP3.0 NIC Slot, PCI-E 5.0 x16
+  - name: AIOM 2
+    position: AIOM2
+    description: AIOM / OCP3.0 NIC Slot, PCI-E 5.0 x16
+  - name: PCI-E 1
+    position: '1'
+    description: PCI-E 5.0 x16, Full Height, 10.5" Length, Double Width
+  - name: PCI-E 3
+    position: '3'
+    description: PCI-E 5.0 x16, Full Height, 10.5" Length, Double Width
+  - name: PCI-E 5
+    position: '5'
+    description: PCI-E 5.0 x16, Full Height, 10.5" Length, Double Width
+  - name: PCI-E 7
+    position: '7'
+    description: PCI-E 5.0 x16, Full Height, 10.5" Length, Double Width

--- a/module-types/Supermicro/AOC-ATG-i2TM.yaml
+++ b/module-types/Supermicro/AOC-ATG-i2TM.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: Supermicro
+model: Add-on Card AOC-ATG-i2TM
+part_number: AOC-ATG-i2TM
+description: Intel X550 10GbE controller - Advanced I/O Module (AIOM) Form Factor
+comments: '[Supermicro AOC-ATG-i2TM](https://www.supermicro.com/manuals/other/datasheet-AOC-ATG-i2T.pdf)'
+interfaces:
+  - name: Gig-E 1
+    type: 10gbase-t
+  - name: Gig-E 2
+    type: 10gbase-t

--- a/module-types/Supermicro/PWS-1K63A-1R.yaml
+++ b/module-types/Supermicro/PWS-1K63A-1R.yaml
@@ -1,0 +1,10 @@
+---
+manufacturer: Supermicro
+model: PWS-1K63A-1R
+part_number: PWS-1K63A-1R
+description: 1000W/1600W 1U Redundant Power Supply
+comments: '[Datasheet](https://store.supermicro.com/media/wysiwyg/productspecs/PWS-1K63A-1R/PWS-1K63A-1R_datasheet_09062022.pdf)'
+power-ports:
+  - name: PSU{module}
+    type: iec-60320-c14
+    maximum_draw: 1600


### PR DESCRIPTION
- Device: <https://www.supermicro.com/en/products/system/hyper/2u/sys-221h-tnr>
  - [NOTE] As described in "Expansion Slots" section, This server has a choice of PCIe expansion slot options A or B. The yaml of this PR is written based on option A (4 PCIe 5.0 x16 FH/10.5"L double-width slots) for now. Therefore, please note that some PCI slot numbers appear to be skipped.
- Related Modules
  - PSU: <https://store.supermicro.com/us_en/1600w-1u-pws-1k63a-1r.html> 
  - AIOM NIC: <https://www.supermicro.com/en/products/accessories/addon/AOC-ATG-i2T.php>