### PR TITLE
fix N9K-X9788TC-FX linecard with 10gbase-t ports

### DIFF
--- a/module-types/Cisco/N9K-X9788TC-FX.yaml
+++ b/module-types/Cisco/N9K-X9788TC-FX.yaml
@@ -8,74 +8,106 @@ weight: 5.9
 weight_unit: kg
 interfaces:
   - name: Ethernet{module}/1
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/2
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/3
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/4
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/5
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/6
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/7
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/8
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/9
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/10
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/11
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/12
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/13
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/14
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/15
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/16
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/17
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/18
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/19
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/20
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/21
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/22
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/23
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/24
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/25
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/26
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/27
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/28
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/29
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/30
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/31
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/32
-    type: 25gbase-x-sfp28
+    type: 10gbase-t
   - name: Ethernet{module}/33
-    type: 100gbase-x-qsfp28
+    type: 10gbase-t
   - name: Ethernet{module}/34
-    type: 100gbase-x-qsfp28
+    type: 10gbase-t
   - name: Ethernet{module}/35
-    type: 100gbase-x-qsfp28
+    type: 10gbase-t
   - name: Ethernet{module}/36
+    type: 10gbase-t
+  - name: Ethernet{module}/37
+    type: 10gbase-t
+  - name: Ethernet{module}/38
+    type: 10gbase-t
+  - name: Ethernet{module}/39
+    type: 10gbase-t
+  - name: Ethernet{module}/40
+    type: 10gbase-t
+  - name: Ethernet{module}/41
+    type: 10gbase-t
+  - name: Ethernet{module}/42
+    type: 10gbase-t
+  - name: Ethernet{module}/43
+    type: 10gbase-t
+  - name: Ethernet{module}/44
+    type: 10gbase-t
+  - name: Ethernet{module}/45
+    type: 10gbase-t
+  - name: Ethernet{module}/46
+    type: 10gbase-t
+  - name: Ethernet{module}/47
+    type: 10gbase-t
+  - name: Ethernet{module}/48
+    type: 10gbase-t
+  - name: Ethernet{module}/49
+    type: 100gbase-x-qsfp28
+  - name: Ethernet{module}/50
+    type: 100gbase-x-qsfp28
+  - name: Ethernet{module}/51
+    type: 100gbase-x-qsfp28
+  - name: Ethernet{module}/52
     type: 100gbase-x-qsfp28


### PR DESCRIPTION
The N9K-X9788TC-FX had the wrong interface type/count

As this module is a 48x10G + 4x100G module, this fixes the port count and change the port type to 10gbase-t for the first 48 ports.