### PR TITLE
added N9K-C93108TC-EX weight

### DIFF
--- a/device-types/Cisco/N9K-C93108TC-EX.yaml
+++ b/device-types/Cisco/N9K-C93108TC-EX.yaml
@@ -7,6 +7,8 @@ front_image: true
 rear_image: true
 u_height: 1
 is_full_depth: true
+weight: 8
+weight_unit: kg
 console-ports:
   - name: Console
     type: rj-45


### PR DESCRIPTION
added missing weight for Cisco N9K-C93108TC-EX (without fans, without PSUs)