### PR TITLE
Update FMU-1UFMX-N - Correct device bays

### DIFF
--- a/device-types/FS/FMU-1UFMX-N.yaml
+++ b/device-types/FS/FMU-1UFMX-N.yaml
@@ -12,4 +12,3 @@ is_powered: false
 device-bays:
   - name: '1'
   - name: '2'
-  - name: '3'


### PR DESCRIPTION
The device only has two bays:
https://www.fs.com/de/products/30408.html?now_cid=1202