### PR TITLE
Fixed the uplink speeds of the FortiNet FS-148F-POE

### DIFF
--- a/device-types/Fortinet/FS-1024E.yaml
+++ b/device-types/Fortinet/FS-1024E.yaml
@@ -1,0 +1,75 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 1024E
+slug: fortinet-fs-1024e
+part_number: FS-1024E
+u_height: 1
+weight: 14.5
+weight_unit: lb
+is_full_depth: false
+comments: '[Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Data_Center_Series.pdf)'
+airflow: front-to-rear
+console-ports:
+  - name: Console
+    type: rj-45
+module-bays:
+  - name: PSU1
+    position: '1'
+  - name: PSU2
+    position: '2'
+interfaces:
+  - name: port1
+    type: 10gbase-x-sfpp
+  - name: port2
+    type: 10gbase-x-sfpp
+  - name: port3
+    type: 10gbase-x-sfpp
+  - name: port4
+    type: 10gbase-x-sfpp
+  - name: port5
+    type: 10gbase-x-sfpp
+  - name: port6
+    type: 10gbase-x-sfpp
+  - name: port7
+    type: 10gbase-x-sfpp
+  - name: port8
+    type: 10gbase-x-sfpp
+  - name: port9
+    type: 10gbase-x-sfpp
+  - name: port10
+    type: 10gbase-x-sfpp
+  - name: port11
+    type: 10gbase-x-sfpp
+  - name: port12
+    type: 10gbase-x-sfpp
+  - name: port13
+    type: 10gbase-x-sfpp
+  - name: port14
+    type: 10gbase-x-sfpp
+  - name: port15
+    type: 10gbase-x-sfpp
+  - name: port16
+    type: 10gbase-x-sfpp
+  - name: port17
+    type: 10gbase-x-sfpp
+  - name: port18
+    type: 10gbase-x-sfpp
+  - name: port19
+    type: 10gbase-x-sfpp
+  - name: port20
+    type: 10gbase-x-sfpp
+  - name: port21
+    type: 10gbase-x-sfpp
+  - name: port22
+    type: 10gbase-x-sfpp
+  - name: port23
+    type: 10gbase-x-sfpp
+  - name: port24
+    type: 10gbase-x-sfpp
+  - name: port25
+    type: 100gbase-x-qsfp28
+  - name: port26
+    type: 100gbase-x-qsfp28
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/Fortinet/FS-148F-FPOE.yaml
+++ b/device-types/Fortinet/FS-148F-FPOE.yaml
@@ -1,0 +1,221 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 148F-FPOE
+slug: fortinet-fs-148f-fpoe
+part_number: FS-148F-FPOE
+u_height: 1
+weight: 4.68
+weight_unit: kg
+is_full_depth: false
+airflow: side-to-rear
+comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
+  [FortiSwitch FS-148F-FPOE Series QuickStart Guide](https://fortinetweb.s3.amazonaws.com/docs.fortinet.com/v2/attachments/3f38a8b3-0a5f-11eb-96b9-00505692583a/FortiSwitch-148F-Series-QSG.pdf)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 476
+    allocated_draw: 475
+interfaces:
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port13
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port14
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port15
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port16
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port17
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port18
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port19
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port20
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port21
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port22
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port23
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port24
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port25
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port26
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port27
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port28
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port29
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port30
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port31
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port32
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port33
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port34
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port35
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port36
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port37
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port38
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port39
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port40
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port41
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port42
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port43
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port44
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port45
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port46
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port47
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port48
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port49
+    type: 10gbase-x-sfpp
+  - name: port50
+    type: 10gbase-x-sfpp
+  - name: port51
+    type: 10gbase-x-sfpp
+  - name: port52
+    type: 10gbase-x-sfpp

--- a/device-types/Fortinet/FS-148F-POE.yaml
+++ b/device-types/Fortinet/FS-148F-POE.yaml
@@ -164,10 +164,10 @@ interfaces:
   - name: port48
     type: 1000base-t
   - name: port49
-    type: 1000base-x-sfp
+    type: 10gbase-x-sfpp
   - name: port50
-    type: 1000base-x-sfp
+    type: 10gbase-x-sfpp
   - name: port51
-    type: 1000base-x-sfp
+    type: 10gbase-x-sfpp
   - name: port52
-    type: 1000base-x-sfp
+    type: 10gbase-x-sfpp


### PR DESCRIPTION
The 148F-POE has 10Gbase uplinks, however the device type had only 1Gbase defined. Updated to 10Gbase SFP+