### PR TITLE
Add weight to Cisco Catalyst 9400 modules

### DIFF
--- a/module-types/Cisco/C9400-LC-24XS.yaml
+++ b/module-types/Cisco/C9400-LC-24XS.yaml
@@ -2,7 +2,10 @@
 manufacturer: Cisco
 part_number: C9400-LC-24XS
 model: C9400-LC-24XS
-comments: Cisco Catalyst 9400 Series 24-Port 10 Gigabit Ethernet (SFP+) <br> [Catalyst 9400 Series Data Sheets](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)
+description: Cisco Catalyst 9400 Series 24-Port 10 Gigabit Ethernet (SFP+)
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
+weight: 3.1
+weight_unit: kg
 interfaces:
   - name: TenGigabitEthernet{module}/0/1
     type: 10gbase-x-sfpp

--- a/module-types/Cisco/C9400-LC-48S.yaml
+++ b/module-types/Cisco/C9400-LC-48S.yaml
@@ -2,7 +2,10 @@
 manufacturer: Cisco
 part_number: C9400-LC-48S
 model: C9400-LC-48S
-comments: Cisco Catalyst 9400 Series 48-Port 1 Gigabit Ethernet (SFP)
+description: Cisco Catalyst 9400 Series 48-Port 1 Gigabit Ethernet (SFP)
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
+weight: 2.94
+weight_unit: kg
 interfaces:
   - name: GigabitEthernet{module}/0/1
     type: 1000base-t

--- a/module-types/Cisco/C9400-LC-48U.yaml
+++ b/module-types/Cisco/C9400-LC-48U.yaml
@@ -2,7 +2,10 @@
 manufacturer: Cisco
 part_number: C9400-LC-48U
 model: C9400-LC-48U
-comments: Cisco Catalyst 9400 Series 48-Port UPOE 10/100/1000 (RJ-45) <br> [Catalyst 9400 Series Data Sheets](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)
+description: Cisco Catalyst 9400 Series 48-Port UPOE 10/100/1000 (RJ-45)
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
+weight: 3.0
+weight_unit: kg
 interfaces:
   - name: GigabitEthernet{module}/0/1
     type: 1000base-t

--- a/module-types/Cisco/C9400-LC-48UX.yaml
+++ b/module-types/Cisco/C9400-LC-48UX.yaml
@@ -2,7 +2,10 @@
 manufacturer: Cisco
 part_number: C9400-LC-48UX
 model: C9400-LC-48UX
-comments: Cisco Catalyst 9400 Series 48-Port UPOE w/ 24p mGig 24p RJ-45
+description: Cisco Catalyst 9400 Series 48-Port UPOE w/ 24p mGig 24p RJ-45
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
+weight: 3.8
+weight_unit: kg
 interfaces:
   - name: GigabitEthernet{module}/0/1
     type: 1000base-t

--- a/module-types/Cisco/C9400-LC-48XS.yaml
+++ b/module-types/Cisco/C9400-LC-48XS.yaml
@@ -2,7 +2,10 @@
 manufacturer: Cisco
 part_number: C9400-LC-48XS
 model: C9400-LC-48XS
-comments: Cisco Catalyst 9400 Series 48-Port 10 Gigabit Ethernet (SFP+) <br> [Catalyst 9400 Series Data Sheets](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)
+description: Cisco Catalyst 9400 Series 48-Port 10 Gigabit Ethernet (SFP+)
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
+weight: 3.67
+weight_unit: kg
 interfaces:
   - name: TenGigabitEthernet{module}/0/1
     type: 10gbase-x-sfpp

--- a/module-types/Cisco/C9400-PWR-2100AC.yaml
+++ b/module-types/Cisco/C9400-PWR-2100AC.yaml
@@ -2,7 +2,8 @@
 manufacturer: Cisco
 model: C9400-PWR-2100AC
 part_number: C9400-PWR-2100AC
-comments: Cisco Catalyst 9400 Series 2100W AC Power Supply <br> [Catalyst 9400 Series Data Sheets](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)
+description: Cisco Catalyst 9400 Series 2100W AC Power Supply
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
 power-ports:
   - name: PSU{module}
     type: iec-60320-c20

--- a/module-types/Cisco/C9400-PWR-3200AC.yaml
+++ b/module-types/Cisco/C9400-PWR-3200AC.yaml
@@ -2,7 +2,8 @@
 manufacturer: Cisco
 model: C9400-PWR-3200AC
 part_number: C9400-PWR-3200AC
-comments: Cisco Catalyst 9400 Series 3200W AC Power Supply <br> [Catalyst 9400 Series Data Sheets](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)
+description: Cisco Catalyst 9400 Series 3200W AC Power Supply
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
 power-ports:
   - name: PSU{module}
     type: iec-60320-c20

--- a/module-types/Cisco/C9400-SUP-1.yaml
+++ b/module-types/Cisco/C9400-SUP-1.yaml
@@ -2,7 +2,10 @@
 manufacturer: Cisco
 part_number: C9400-SUP-1
 model: C9400-SUP-1
-comments: Cisco Catalyst 9400 Series Supervisor 1 Module
+description: Cisco Catalyst 9400 Series Supervisor 1 Module
+comments: '[Catalyst 9400 Supervisor Engine Modules Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-ser-sup-eng-data-sheet-cte-en.html)'
+weight: 4.5
+weight_unit: kg
 interfaces:
   - name: TenGigabitEthernet{module}/0/1
     type: 10gbase-x-sfpp

--- a/module-types/Cisco/C9400-SUP-1XL-Y.yaml
+++ b/module-types/Cisco/C9400-SUP-1XL-Y.yaml
@@ -2,7 +2,10 @@
 manufacturer: Cisco
 part_number: C9400-SUP-1XL-Y
 model: C9400-SUP-1XL-Y
-comments: Cisco Catalyst 9400 Series Supervisor 1 XL Module with 25G <br> [C9400 Supervisor Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-ser-sup-eng-data-sheet-cte-en.html)
+description: Cisco Catalyst 9400 Series Supervisor 1 XL Module with 25G
+comments: '[Catalyst 9400 Supervisor Engine Modules Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-ser-sup-eng-data-sheet-cte-en.html)'
+weight: 4.5
+weight_unit: kg
 console-ports:
   - name: con 0
     type: rj-45


### PR DESCRIPTION
Add weight data to Cisco Catalyst 9400 Series modules.
Also split existing comment into `description` and `comments` fields to improve clarity and maintain consistency with other module entries.

Source: [Cisco Catalyst 9400 Series Switches Hardware Installation Guide](https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9400/hardware/install/b_c9400_hig/b_c9400_hig_chapter_0110.html)