### PR TITLE
Add new Cisco Catalyst 9400 Series modules

### DIFF
--- a/module-types/Cisco/C9400-LC-48HN.yaml
+++ b/module-types/Cisco/C9400-LC-48HN.yaml
@@ -1,0 +1,201 @@
+---
+manufacturer: Cisco
+part_number: C9400-LC-48HN
+model: C9400-LC-48HN
+description: Cisco Catalyst 9400 Series 48-Port 5G multigigabit (RJ-45) UPOE+ Line Card
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
+weight: 3.85
+weight_unit: kg
+interfaces:
+  - name: FiveGigabitEthernet{module}/0/1
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/2
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/3
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/4
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/5
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/6
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/7
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/8
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/9
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/10
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/11
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/12
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/13
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/14
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/15
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/16
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/17
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/18
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/19
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/20
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/21
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/22
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/23
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/24
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/25
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/26
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/27
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/28
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/29
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/30
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/31
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/32
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/33
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/34
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/35
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/36
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/37
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/38
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/39
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/40
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/41
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/42
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/43
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/44
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/45
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/46
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/47
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: FiveGigabitEthernet{module}/0/48
+    type: 5gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt

--- a/module-types/Cisco/C9400-LC-48HX.yaml
+++ b/module-types/Cisco/C9400-LC-48HX.yaml
@@ -1,0 +1,201 @@
+---
+manufacturer: Cisco
+part_number: C9400-LC-48HX
+model: C9400-LC-48HX
+description: Cisco Catalyst 9400 Series 48-Port 10G mGig (RJ-45) UPOE+ Line Card
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'
+weight: 3.81
+weight_unit: kg
+interfaces:
+  - name: TenGigabitEthernet{module}/0/1
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/2
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/3
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/4
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/5
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/6
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/7
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/8
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/9
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/10
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/11
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/12
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/13
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/14
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/15
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/16
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/17
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/18
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/19
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/20
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/21
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/22
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/23
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/24
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/25
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/26
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/27
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/28
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/29
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/30
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/31
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/32
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/33
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/34
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/35
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/36
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/37
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/38
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/39
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/40
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/41
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/42
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/43
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/44
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/45
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/46
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/47
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: TenGigabitEthernet{module}/0/48
+    type: 10gbase-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt

--- a/module-types/Cisco/C9400X-SUP-2.yaml
+++ b/module-types/Cisco/C9400X-SUP-2.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Cisco
+part_number: C9400X-SUP-2
+model: C9400X-SUP-2
+description: Cisco Catalyst 9400 Series Supervisor 2 Module
+comments: '[Catalyst 9400 Supervisor Engine Modules Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-ser-sup-eng-data-sheet-cte-en.html)'
+weight: 4.78
+weight_unit: kg
+interfaces:
+  - name: TwentyFiveGigE{module}/0/1
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/2
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/3
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/4
+    type: 25gbase-x-sfp28
+  - name: HundredGigE{module}/0/5
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/6
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/7
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/8
+    type: 100gbase-x-qsfp28

--- a/module-types/Cisco/C9400X-SUP-2XL.yaml
+++ b/module-types/Cisco/C9400X-SUP-2XL.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Cisco
+part_number: C9400X-SUP-2XL
+model: C9400X-SUP-2XL
+description: Cisco Catalyst 9400 Series Supervisor 2 XL Module
+comments: '[Catalyst 9400 Supervisor Engine Modules Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-ser-sup-eng-data-sheet-cte-en.html)'
+weight: 4.78
+weight_unit: kg
+interfaces:
+  - name: TwentyFiveGigE{module}/0/1
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/2
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/3
+    type: 25gbase-x-sfp28
+  - name: TwentyFiveGigE{module}/0/4
+    type: 25gbase-x-sfp28
+  - name: HundredGigE{module}/0/5
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/6
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/7
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/8
+    type: 100gbase-x-qsfp28

--- a/module-types/Cisco/C9404-FAN.yaml
+++ b/module-types/Cisco/C9404-FAN.yaml
@@ -1,0 +1,6 @@
+---
+manufacturer: Cisco
+model: C9404-FAN
+part_number: C9404-FAN
+description: Cisco Catalyst 9400 Series 4 slot chassis Fan Tray
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'

--- a/module-types/Cisco/C9407-FAN.yaml
+++ b/module-types/Cisco/C9407-FAN.yaml
@@ -1,0 +1,6 @@
+---
+manufacturer: Cisco
+model: C9407-FAN
+part_number: C9407-FAN
+description: Cisco Catalyst 9400 Series 7 slot chassis Fan Tray
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'

--- a/module-types/Cisco/C9410-FAN.yaml
+++ b/module-types/Cisco/C9410-FAN.yaml
@@ -1,0 +1,6 @@
+---
+manufacturer: Cisco
+model: C9410-FAN
+part_number: C9410-FAN
+description: Cisco Catalyst 9400 Series 10 slot chassis Fan Tray
+comments: '[Catalyst 9400 Series Switch Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/nb-06-cat9400-series-line-data-sheet-cte-en.html)'


### PR DESCRIPTION
Add support for the following Cisco Catalyst 9400 Series modules:
- C9400-LC-48HN
- C9400-LC-48HX
- C9400X-SUP-2
- C9400X-SUP-2XL
- C9404-FAN
- C9407-FAN
- C9410-FAN

These modules include supervisor engines, line cards, and fan trays, enhancing coverage of the Catalyst 9400 Series in the device type library.