### PR TITLE
Update PTX10002-36QDD.yaml

### DIFF
--- a/device-types/Juniper/PTX10002-36QDD.yaml
+++ b/device-types/Juniper/PTX10002-36QDD.yaml
@@ -36,19 +36,19 @@ interfaces:
     enabled: true
     mgmt_only: false
   - name: et-0/0/4
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/5
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/6
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/7
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/8
@@ -84,19 +84,19 @@ interfaces:
     enabled: true
     mgmt_only: false
   - name: et-0/0/16
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/17
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/18
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/19
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/20
@@ -132,19 +132,19 @@ interfaces:
     enabled: true
     mgmt_only: false
   - name: et-0/0/28
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/29
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/30
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/31
-    type: 100gbase-x-qsfp28
+    type: 800gbase-x-qsfpdd
     enabled: true
     mgmt_only: false
   - name: et-0/0/32


### PR DESCRIPTION
This chassis is 36x800G capable. The default template should reflect that.

Can be validated on Juniper Port Checker:
https://apps.juniper.net/port-checker/ptx10002-36qdd/