### PR TITLE
HPE 865414 b21 (HPE 800W power supply module) update comment, power draw and weight

### DIFF
--- a/module-types/HPE/865414-B21.yaml
+++ b/module-types/HPE/865414-B21.yaml
@@ -6,4 +6,4 @@ comments: '[HPE 800W Flex Slot Platinum Hot Plug Low Halogen Power Supply Kit | 
 power-ports:
   - name: Power {module}
     type: iec-60320-c16
-    maximum_draw: 899
+    maximum_draw: 800

--- a/module-types/HPE/865414-B21.yaml
+++ b/module-types/HPE/865414-B21.yaml
@@ -2,7 +2,7 @@
 manufacturer: HPE
 model: 865414-B21
 part_number: 865414-B21
-comments: '[HPE 800W Flex Slot Platinum Hot Plug Low Halogen Power Supply Kit | Hardware Specs | HPE]https://www.hpe.com/psnow/doc/c04346217.html'
+comments: '[HPE 800W Flex Slot Platinum Hot Plug Low Halogen Power Supply Kit | Hardware Specs | HPE](https://www.hpe.com/psnow/doc/PSN1009449980BEEN.pdf)'
 power-ports:
   - name: Power {module}
     type: iec-60320-c16

--- a/module-types/HPE/865414-B21.yaml
+++ b/module-types/HPE/865414-B21.yaml
@@ -2,6 +2,8 @@
 manufacturer: HPE
 model: 865414-B21
 part_number: 865414-B21
+weight: 3.99
+weight_unit: lb
 comments: '[HPE 800W Flex Slot Platinum Hot Plug Low Halogen Power Supply Kit | Hardware Specs | HPE](https://www.hpe.com/psnow/doc/PSN1009449980BEEN.pdf)'
 power-ports:
   - name: Power {module}


### PR DESCRIPTION
I have checked the **HPE 800W Flex Slot Platinum Hot Plug Low Halogen Power Supply Kit** module definition, and found some updates for that module. See official [hardware specs](https://www.hpe.com/psnow/doc/PSN1009449980BEEN.pdf)

Changes implemented:

- added `weight` and `weight_unit`
- corrected typo in maximum power draw from `899` to `800`
- corrected markdown link in the comment - missing brackets and updated the link to the specific document for that module