### PR TITLE
adding 2 network ports to Dell R750xs

### DIFF
--- a/device-types/Dell/PowerEdge-R750xs.yaml
+++ b/device-types/Dell/PowerEdge-R750xs.yaml
@@ -16,6 +16,10 @@ interfaces:
     label: iDRAC
     type: 1000base-t
     mgmt_only: true
+  - name: eth1
+    type: 1000base-t
+  - name: eth2
+    type: 1000base-t
 module-bays:
   - name: PSU-1
     label: '1'


### PR DESCRIPTION
as per https://i.dell.com/sites/csdocuments/Product_Docs/en/R750xs-specsheet.pdf, the Dell R750xs always has two built-in ethernet ports