### PR TITLE
fix: correct QuickSpecs link

### DIFF
--- a/device-types/HPE/ProLiant-DL360e-Gen8.yaml
+++ b/device-types/HPE/ProLiant-DL360e-Gen8.yaml
@@ -5,7 +5,7 @@ slug: hpe-proliant-dl360e-gen8
 u_height: 1.0
 is_full_depth: true
 part_number: 661189-B21
-comments: '[HP ProLiant DL360e Gen8 QuickSpecs](https://www.hpe.com/psnow/doc/c04284501)'
+comments: '[HP ProLiant DL360e Gen8 QuickSpecs](https://www.hpe.com/psnow/doc/c04123219)'
 weight: 17.92
 weight_unit: kg
 console-ports:


### PR DESCRIPTION
previously the link opened HP ProLiant DL360 Generation 7 QuickSpecs