### PR TITLE
Add a handful of new devices

### DIFF
--- a/device-types/Generic/shelf-1he-full-depth.yaml
+++ b/device-types/Generic/shelf-1he-full-depth.yaml
@@ -1,0 +1,8 @@
+---
+manufacturer: Generic
+model: shelf-1he-full-depth
+slug: generic-shelf-1he-full-depth
+u_height: 1
+is_full_depth: true
+airflow: passive
+is_powered: false

--- a/device-types/Supermicro/SYS-5019S-M.yaml
+++ b/device-types/Supermicro/SYS-5019S-M.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: Supermicro
+model: SuperServer 5019S-M
+slug: supermicro-sys-5019s-m
+part_number: SYS-5019S-M
+u_height: 1
+is_full_depth: true
+airflow: front-to-rear
+comments: SuperServer SYS-5019S-M (https://www.supermicro.com/en/products/system/1u/5019/sys-5019s-m.cfm)
+weight: 13.8
+weight_unit: kg
+console-ports:
+  - name: Serial-1
+    type: de-9
+    label: Front
+  - name: Serial-2
+    type: de-9
+    label: Rear
+interfaces:
+  - name: BMC
+    type: 1000base-t
+    mgmt_only: true
+    description: Dedicated IPMI LAN port
+  - name: Gig-E 1
+    type: 1000base-t
+  - name: Gig-E 2
+    type: 1000base-t
+module-bays:
+  - name: PSU
+    position: PSU
+    maximum_draw: 400
+  - name: PCI-E 1
+    position: '1'
+    description: PCI-E 3.0 x16 slot
+  - name: M.2 1
+    position: '2'
+    description: Form-factors 2280, 22110

--- a/device-types/Supermicro/SYS-6028TR-HTR.yaml
+++ b/device-types/Supermicro/SYS-6028TR-HTR.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Supermicro
+model: SuperServer 6028TR-HTR
+slug: supermicro-sys-6028tr-htr
+part_number: SYS-6028TR-HTR
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+comments: SuperServer 6028TR-HTR (https://www.supermicro.com/en/products/system/2u/6028/sys-6028tr-htr.cfm)
+subdevice_role: parent
+weight: 38.6
+weight_unit: kg
+module-bays:
+  - name: PSU0
+    position: PSU 0
+    maximum_draw: 2200
+  - name: PSU1
+    position: PSU 1
+    maximum_draw: 2200
+device-bays:
+  - name: Node 1
+    label: Compute Node 1
+  - name: Node 2
+    label: Compute Node 2
+  - name: Node 3
+    label: Compute Node 3
+  - name: Node 4
+    label: Compute Node 4

--- a/device-types/Supermicro/SYS-6029U-TR4TP.yaml
+++ b/device-types/Supermicro/SYS-6029U-TR4TP.yaml
@@ -1,0 +1,45 @@
+---
+manufacturer: Supermicro
+model: SuperServer 6029U-TR4T+
+slug: supermicro-sys-6029u-tr4t-plus
+part_number: SYS-6029U-TR4T+
+u_height: 2
+is_full_depth: true
+comments: '[Supermicro SuperServer 6029U-TR4T+] (https://www.supermicro.com/en/products/system/2U/6028/SYS-6028U-TR4T_.cfm)'
+weight: 16.4
+weight_unit: kg
+airflow: front-to-rear
+console-ports:
+  - name: Serial
+    type: de-9
+    description: Rear port
+interfaces:
+  - name: BMC
+    type: 1000base-t
+    mgmt_only: true
+    description: Dedicated IPMI port
+  - name: Gig-E 1
+    type: 10gbase-t
+  - name: Gig-E 2
+    type: 10gbase-t
+  - name: Gig-E 3
+    type: 10gbase-t
+  - name: Gig-E 4
+    type: 10gbase-t
+module-bays:
+  - name: PSU1
+    position: PSU1
+  - name: PSU2
+    position: PSU2
+  - name: PCI-E 1
+    position: '1'
+    description: PCI-E 3.0x 16-slot
+  - name: PCI-E 2
+    position: '2'
+    description: PCI-E 3.0x 16-slot
+  - name: PCI-E 3
+    position: '3'
+    description: PCI-E 3.0x 16-slot
+  - name: PCI-E 4
+    position: '4'
+    description: PCI-E 3.0x 8-slot

--- a/device-types/Supermicro/SuperChassis-826-BE1C4.yaml
+++ b/device-types/Supermicro/SuperChassis-826-BE1C4.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Supermicro
+model: SuperChassis 826BE1C4
+slug: supermicro-superchassis-628be1c4
+part_number: SuperChassis 826BE1C4-R1K23LPB
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+comments: SuperChassis 628BE1C4 (https://www.supermicro.com/en/products/chassis/2u/826/sc826be1c4-r1k23lpb)
+subdevice_role: parent
+weight: 18.1
+weight_unit: kg
+module-bays:
+  - name: PSU0
+    position: PSU 0
+    maximum_draw: 2200
+  - name: PSU1
+    position: PSU 1
+    maximum_draw: 2200
+device-bays:
+  - name: System Board
+    label: System Board

--- a/device-types/Ubiquiti/ER-8-XG.yaml
+++ b/device-types/Ubiquiti/ER-8-XG.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: Ubiquiti
+model: EdgeRouter Infinity
+slug: ubiquiti-edgerouter-infinity
+part_number: ER-8-XG
+u_height: 1
+is_full_depth: false
+comments: '[EdgeRouter Infinity](https://dl.ubnt.com/datasheets/edgemax/EdgeRouter_ER-8-XG_DS.pdf)'
+power-ports:
+  - name: PSU 1
+    type: iec-60320-c6
+    maximum_draw: 40
+  - name: PSU 2
+    type: iec-60320-c6
+    maximum_draw: 40
+interfaces:
+  - name: eth0
+    type: 1000base-t
+  - name: eth1
+    type: 10gbase-x-sfpp
+  - name: eth2
+    type: 10gbase-x-sfpp
+  - name: eth3
+    type: 10gbase-x-sfpp
+  - name: eth4
+    type: 10gbase-x-sfpp
+  - name: eth5
+    type: 10gbase-x-sfpp
+  - name: eth6
+    type: 10gbase-x-sfpp
+  - name: eth7
+    type: 10gbase-x-sfpp
+  - name: eth8
+    type: 10gbase-x-sfpp
+console-ports:
+  - name: Console
+    type: rj-45


### PR DESCRIPTION
Add new devices for:
 - Ubiquiti EdgeRouter Infinity, their 10GbE 1U version
 - Supermicro Superserver 6028U-TR4T+
 - Supermicro SuperServer 6028TR-HTR (4-node system)
 - SuperChassis 826BE1C4 (empty chassis)
 - Supermicro SuperServer 5019S-M (1U system)

+ a full-depth version of a generic 1U shelf.