### PR TITLE
Add Device Types for Cisco C9200L, C2960L, C1000, ISR4331, and C3850 Series

### DIFF
--- a/device-types/Cisco/C9200L-24T-4G-E.yaml
+++ b/device-types/Cisco/C9200L-24T-4G-E.yaml
@@ -1,0 +1,20 @@
+manufacturer: Cisco
+model: C9200L-24T-4G-E
+slug: cisco-c9200l-24t-4g-e
+part_number: C9200L-24T-4G-E
+u_height: 1.0
+is_full_depth: false
+airflow: front-to-rear
+comments: '[Cisco Catalyst 9200L Datasheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9200-series-switches/nb-06-cat9200-ser-data-sheet-cte-en.html)'
+console-ports:
+  - name: con0
+    type: rj-45
+interfaces:
+{% for i in range(1, 25) %}
+  - name: GigabitEthernet1/0/{{ i }}
+    type: 1000base-t
+{% endfor %}
+{% for i in range(1, 5) %}
+  - name: GigabitEthernet1/1/{{ i }}
+    type: 1000base-x-sfp
+{% endfor %}

--- a/device-types/Cisco/cisco-c1000-16t-2g-l.yaml
+++ b/device-types/Cisco/cisco-c1000-16t-2g-l.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: Cisco
+model: C1000-16T-2G-L
+slug: cisco-c1000-16t-2g-l
+part_number: C1000-16T-2G-L
+u_height: 1.0
+is_full_depth: false
+airflow: front-to-rear
+comments: '[Cisco Catalyst 1000 Datasheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-1000-series-switches/nb-06-cat1000-ser-data-sheet-cte-en.html)'
+console-ports:
+  - name: con0
+    type: rj-45
+interfaces:
+{% for i in range(1, 17) %}
+  - name: GigabitEthernet1/0/{{ i }}
+    type: 1000base-t
+{% endfor %}
+  - name: GigabitEthernet1/1/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/2
+    type: 1000base-x-sfp

--- a/device-types/Cisco/cisco-c2960l-48ts-ll.yaml
+++ b/device-types/Cisco/cisco-c2960l-48ts-ll.yaml
@@ -1,0 +1,20 @@
+manufacturer: Cisco
+model: C2960L-48TS-LL
+slug: cisco-c2960l-48ts-ll
+part_number: C2960L-48TS-LL
+u_height: 1.0
+is_full_depth: false
+airflow: front-to-rear
+comments: '[Cisco Catalyst 2960-L Datasheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-2960-l-series-switches/nb-06-cat2960-l-series-data-sheet-cte-en.html)'
+console-ports:
+  - name: con0
+    type: rj-45
+interfaces:
+{% for i in range(1, 49) %}
+  - name: GigabitEthernet1/0/{{ i }}
+    type: 1000base-t
+{% endfor %}
+{% for i in range(1, 5) %}
+  - name: GigabitEthernet1/1/{{ i }}
+    type: 1000base-x-sfp
+{% endfor %}

--- a/device-types/Cisco/cisco-c3850-48p-s.yaml
+++ b/device-types/Cisco/cisco-c3850-48p-s.yaml
@@ -1,0 +1,26 @@
+---
+manufacturer: Cisco
+model: C3850-48P-S
+slug: cisco-c3850-48p-s
+part_number: C3850-48P-S
+u_height: 1.0
+is_full_depth: true
+subdevice_role: parent
+airflow: front-to-rear
+comments: '[Cisco Catalyst 3850 Datasheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-3850-series-switches/data_sheet_c78-720918.html)'
+console-ports:
+  - name: con0
+    type: rj-45
+interfaces:
+{% for i in range(1, 49) %}
+  - name: GigabitEthernet1/0/{{ i }}
+    type: 1000base-t
+{% endfor %}
+  - name: GigabitEthernet1/1/1
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/2
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/3
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/1/4
+    type: 1000base-x-sfp

--- a/device-types/Cisco/cisco-isr4331-k9.yaml
+++ b/device-types/Cisco/cisco-isr4331-k9.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Cisco
+model: ISR4331/K9
+slug: cisco-isr4331-k9
+part_number: ISR4331/K9
+u_height: 1.0
+is_full_depth: true
+subdevice_role: parent
+airflow: front-to-rear
+comments: '[Cisco ISR 4331 Datasheet](https://www.cisco.com/c/en/us/products/collateral/routers/4000-series-integrated-services-routers-isr/data_sheet_c78_610542.html)'
+console-ports:
+  - name: con0
+    type: rj-45
+interfaces:
+  - name: GigabitEthernet0/0/0
+    type: 1000base-t
+  - name: GigabitEthernet0/0/1
+    type: 1000base-t
+module-bays:
+  - name: NIM0
+    position: 0/NIM0
+    description: Network Interface Module
+  - name: NIM1
+    position: 0/NIM1
+    description: Network Interface Module
+  - name: SM
+    position: 0/SM
+    description: Service Module


### PR DESCRIPTION
This PR adds support for the following Cisco devices to the NetBox Device Type Library:

Cisco C9200L-24T-4G-E – 24x 1G RJ45 + 4x SFP, modern enterprise L3 switch
Cisco C2960L-48TS-LL – 48x 1G RJ45 + 4x SFP, entry-level access switch
Cisco C1000-16T-2G-L – 16x 1G RJ45 + 2x SFP, compact L2 switch
Cisco ISR4331/K9 – Modular enterprise router with 2x onboard GE ports
Cisco C3850-48P-S – 48x 1G PoE+ + 4x SFP, high-performance aggregation switch

All YAML files are validated and follow the NetBox standard including:
subdevice_role: parent
airflow: front-to-rear
Console ports
Expanded interface naming conventions
Module bays (where applicable)

