### PR TITLE
Please add APC SMT1000RMI2UC to device type library

### DIFF
--- a/device-types/APC/SMT1000RMI2UC.yaml
+++ b/device-types/APC/SMT1000RMI2UC.yaml
@@ -1,0 +1,42 @@
+---
+manufacturer: APC
+model: SMT1000RMI2UC
+slug: apc-smt1000rmi2uc
+part_number: SMT1000RMI2UC
+u_height: 2
+is_full_depth: true
+weight: 22.5
+weight_unit: kg
+airflow: front-to-rear
+front_image: false
+rear_image: false
+comments: APC Smart-UPS, Line Interactive, 1000VA, Rackmount 2U, 230V, 4x IEC C13 Outlets, SmartSlot, AVR, LCD, Battery SKU RBC133
+console-ports:
+  - name: Serial
+    type: rj-45
+  - name: USB
+    type: usb-b
+power-ports:
+  - name: Source
+    type: iec-60320-c14
+    maximum_draw: 700
+power-outlets:
+  - name: Group 1 Outlet 1
+    type: iec-60320-c13
+    power_port: Source
+  - name: Group 1 Outlet 2
+    type: iec-60320-c13
+    power_port: Source
+  - name: Group 2 Outlet 1
+    type: iec-60320-c13
+    power_port: Source
+  - name: Group 2 Outlet 2
+    type: iec-60320-c13
+    power_port: Source
+interfaces:
+  - name: SmartConnect
+    type: 1000base-t
+    mgmt_only: true
+module-bays:
+  - name: SmartSlot
+    position: SmartSlot


### PR DESCRIPTION
Please add APC SMT1000RMI2UC to device type library.
Link to specs: https://www.se.com/de/de/product/SMT1000RMI2UC/apc-smartups-line-interactive-1000va-rackmontage-2he-230v-4-iec-c13stecker-smartconnect-port+smartslot-avr-lcd/
Thank you.