### PR TITLE
fix eth0 type of RPI3-MODBP

### DIFF
--- a/device-types/Raspberry Pi/RPI3-MODBP.yaml
+++ b/device-types/Raspberry Pi/RPI3-MODBP.yaml
@@ -7,7 +7,7 @@ u_height: 0
 is_full_depth: false
 interfaces:
   - name: eth0
-    type: 1000base-t
+    type: 100base-t
   - name: wlan0
     type: ieee802.11ac
 power-ports:


### PR DESCRIPTION
Raspberry Pi 3 Model B+ eth0 is 100BaseT not 1000BaseT
See :
```
root@berryship:~# ethtool eth0
Settings for eth0:
	Supported ports: [ TP	MII ]
	Supported link modes:   10baseT/Half 10baseT/Full
	                       100baseT/Half 100baseT/Full
	Supported pause frame use: Symmetric Receive-only
	Supports auto-negotiation: Yes
	Supported FEC modes: Not reported
	Advertised link modes:  10baseT/Half 10baseT/Full
	                       100baseT/Half 100baseT/Full
	Advertised pause frame use: No
	Advertised auto-negotiation: Yes
	Advertised FEC modes: Not reported
	Speed: Unknown!
	Duplex: Unknown! (255)
	Auto-negotiation: on
	Port: Twisted Pair
	PHYAD: 1
	Transceiver: internal
	MDI-X: Unknown
	Supports Wake-on: pumbag
	Wake-on: d
        Current message level: 0x00000007 (7)
                               drv probe link
	Link detected: no
	```