### PR TITLE
Fix: Add height to Firewall

### DIFF
--- a/device-types/Cisco/FPR1010-NGFW-K9.yaml
+++ b/device-types/Cisco/FPR1010-NGFW-K9.yaml
@@ -3,7 +3,7 @@ manufacturer: Cisco
 model: FPR1010-NGFW-K9
 slug: cisco-fpr1010-ngfw-k9
 part_number: FPR1010-NGFW-K9
-u_height: 0
+u_height: 1
 weight: 3
 weight_unit: lb
 is_full_depth: false


### PR DESCRIPTION
Hey,

I've found one of the Firepowers I use has a U_Height of 0.

Unless I'm mistaken this should be 1. Fixed it in this merge request