### PR TITLE
Adds D-Link DGS-1100-18 device type

### DIFF
--- a/device-types/D-Link/DGS-1100-18.yaml
+++ b/device-types/D-Link/DGS-1100-18.yaml
@@ -1,0 +1,54 @@
+---
+manufacturer: D-Link
+model: DGS-1100-18
+slug: d-link-dgs-1100-18
+part_number: DGS-1100-18
+comments: |
+  ## Manufacturer information
+  - [D-Link DGS-1100-18](https://ftp.dlink.de/dgs/dgs-1100/documentation/dgs-1100-1618242624P_man_revb_Manual_en.pdf)
+is_full_depth: false
+airflow: passive
+weight: 1.5
+weight_unit: kg
+u_height: 1
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 15
+interfaces:
+  - name: GigabitEthernet1/0/1
+    type: 1000base-t
+  - name: GigabitEthernet1/0/2
+    type: 1000base-t
+  - name: GigabitEthernet1/0/3
+    type: 1000base-t
+  - name: GigabitEthernet1/0/4
+    type: 1000base-t
+  - name: GigabitEthernet1/0/5
+    type: 1000base-t
+  - name: GigabitEthernet1/0/6
+    type: 1000base-t
+  - name: GigabitEthernet1/0/7
+    type: 1000base-t
+  - name: GigabitEthernet1/0/8
+    type: 1000base-t
+  - name: GigabitEthernet1/0/9
+    type: 1000base-t
+  - name: GigabitEthernet1/0/10
+    type: 1000base-t
+  - name: GigabitEthernet1/0/11
+    type: 1000base-t
+  - name: GigabitEthernet1/0/12
+    type: 1000base-t
+  - name: GigabitEthernet1/0/13
+    type: 1000base-t
+  - name: GigabitEthernet1/0/14
+    type: 1000base-t
+  - name: GigabitEthernet1/0/15
+    type: 1000base-t
+  - name: GigabitEthernet1/0/16
+    type: 1000base-t
+  - name: GigabitEthernet1/0/17
+    type: 1000base-x-sfp
+  - name: GigabitEthernet1/0/18
+    type: 1000base-x-sfp


### PR DESCRIPTION
Introduces support for the D-Link DGS-1100-18 switch model by defining its specifications, interfaces, and power port details.

Includes 18 gigabit interfaces and relevant manufacturer details.
