### PR TITLE
Add the `SMX1500RM2UNC` UPS and expansion battery

### DIFF
--- a/device-types/APC/SMX1500RM2UNC.yaml
+++ b/device-types/APC/SMX1500RM2UNC.yaml
@@ -1,0 +1,37 @@
+---
+manufacturer: APC
+model: SMX1500RM2UNC
+slug: apc-smx1500rm2unc
+part_number: SMX1500RM2UNC
+comments: |
+  APC Smart-UPS X, Line Interactive, 1500VA, Rack/Tower LCD 120V with Network Card
+u_height: 2
+is_full_depth: true
+console-ports:
+  - name: Serial
+    type: rj-45
+  - name: USB
+    type: usb-b
+power-ports:
+  - name: Source
+    type: nema-5-15r
+power-outlets:
+  - name: Group 1 Outlet 1
+    type: nema-5-15r
+  - name: Group 1 Outlet 2
+    type: nema-5-15r
+  - name: Group 1 Outlet 3
+    type: nema-5-15r
+  - name: Group 1 Outlet 4
+    type: nema-5-15r
+  - name: Group 2 Outlet 1
+    type: nema-5-15r
+  - name: Group 2 Outlet 2
+    type: nema-5-15r
+  - name: Group 3 Outlet 1
+    type: nema-5-15r
+  - name: Group 3 Outlet 2
+    type: nema-5-15r
+module-bays:
+  - name: SmartSlot
+    position: SmartSlot

--- a/device-types/APC/SMX48RMBP2U.yaml
+++ b/device-types/APC/SMX48RMBP2U.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: APC
+model: SMX48RMBP2U
+slug: apc-smx48rmbp2u
+part_number: SMX48RMBP2U
+comments: APC Smart-UPS X-Series External Battery Pack Rack/Tower 48V, 864VAh, rackmount, 2U
+u_height: 2
+is_full_depth: true
+power-ports:
+  - name: UPS Input
+    type: other


### PR DESCRIPTION
Similar to an existing UPS model (outlets are the primary differentiation?) and the expansion battery that is common to this entire generation / family of UPS