### PR TITLE
Take2/add uptime compute blade

### DIFF
--- a/device-types/Uptime Industries/Bladerunner-1.0-20-blade.yaml
+++ b/device-types/Uptime Industries/Bladerunner-1.0-20-blade.yaml
@@ -15,6 +15,7 @@ weight: 1.5
 weight_unit: kg
 airflow: passive
 subdevice_role: parent
+is_powered: false
 # Can fit 20 Compute Blades
 device-bays:
   - name: '1'

--- a/device-types/Uptime Industries/Bladerunner-1.0-20-blade.yaml
+++ b/device-types/Uptime Industries/Bladerunner-1.0-20-blade.yaml
@@ -1,0 +1,59 @@
+---
+manufacturer: Uptime Industries
+# There are 20 bay, 4 bay and 2 bay versions
+model: BladeRunner 1.0 20 blade
+slug: uptime-industries-bladerunner-20
+# There is no official part number that I can find
+# https://docs.computeblade.com/bladerunner/19inch
+part_number: bladerunner-20
+comments: |
+  [Datasheet](https://docs.computeblade.com/bladerunner/19inch)
+u_height: 1
+# 377 mm deep
+is_full_depth: false
+weight: 1.5
+weight_unit: kg
+airflow: passive
+subdevice_role: parent
+# Can fit 20 Compute Blades
+device-bays:
+  - name: '1'
+    position: '1'
+  - name: '2'
+    position: '2'
+  - name: '3'
+    position: '3'
+  - name: '4'
+    position: '4'
+  - name: '5'
+    position: '5'
+  - name: '6'
+    position: '6'
+  - name: '7'
+    position: '7'
+  - name: '8'
+    position: '8'
+  - name: '9'
+    position: '9'
+  - name: '10'
+    position: '10'
+  - name: '11'
+    position: '11'
+  - name: '12'
+    position: '12'
+  - name: '13'
+    position: '13'
+  - name: '14'
+    position: '14'
+  - name: '15'
+    position: '15'
+  - name: '16'
+    position: '16'
+  - name: '17'
+    position: '17'
+  - name: '18'
+    position: '18'
+  - name: '19'
+    position: '19'
+  - name: '20'
+    position: '20'

--- a/device-types/Uptime Industries/Compute-Blade-1.0-Dev.yaml
+++ b/device-types/Uptime Industries/Compute-Blade-1.0-Dev.yaml
@@ -1,0 +1,48 @@
+---
+manufacturer: Uptime Industries
+# First generation has 3 SKUs: dev, tpm, basic
+model: Compute Blade 1.0 Dev
+slug: uptime-industries-compute-blade-1.0-dev
+# Part number pulled off of sticker on shipping box seen here
+# https://docs.computeblade.com/blade
+part_number: BladeDev-V1-0
+comments: |
+  [Docs](https://docs.computeblade.com/blade)
+
+is_full_depth: false
+weight: 1.5
+weight_unit: kg
+airflow: passive
+# Fits inside a BladeRunner chassis
+subdevice_role: child
+
+interfaces:
+  - name: eth0
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type1-ieee802.3at
+
+# USB A, C (exclusive, switchable), HDMI and 2 UARTs
+console-ports:
+  - name: HDMI 4K60
+    type: other
+  - name: USB-A
+    type: usb-a
+  - name: USB-C
+    type: usb-c
+
+  - name: UART REAR
+    type: other
+  - name: UART FRONT
+    type: other
+
+# Really only supports a M2 NVMe SSD, microSD and a rPi CM4/5 module
+module-bays:
+  - name: Raspberry Pi CM4/5 Connector
+    position: '1'
+    # 2230, 2242, 2260, 2280, 22110
+  - name: M.2 NVMe SSD
+    position: '2'
+    # Optional, can boot off of the m2 SSD
+  - name: microSD Card
+    position: '3'

--- a/device-types/Uptime Industries/Compute-Blade-v1-Dev.yaml
+++ b/device-types/Uptime Industries/Compute-Blade-v1-Dev.yaml
@@ -1,11 +1,11 @@
 ---
 manufacturer: Uptime Industries
 # First generation has 3 SKUs: dev, tpm, basic
-model: Compute Blade 1.0 Dev
-slug: uptime-industries-compute-blade-1.0-dev
+model: Compute Blade v1 Dev
+slug: uptime-industries-compute-blade-v1-dev
 # Part number pulled off of sticker on shipping box seen here
 # https://docs.computeblade.com/blade
-part_number: BladeDev-V1-0
+part_number: BladeDev-v1-0
 comments: |
   [Docs](https://docs.computeblade.com/blade)
 
@@ -13,14 +13,16 @@ is_full_depth: false
 weight: 1.5
 weight_unit: kg
 airflow: passive
-# Fits inside a BladeRunner chassis
+# Meant to be inserted into a BladeRunner chassis which _is_ 1U
+u_height: 0
 subdevice_role: child
 
 interfaces:
   - name: eth0
     type: 1000base-t
     poe_mode: pd
-    poe_type: type1-ieee802.3at
+    # Up to 30w, normal operation is 2-8w
+    poe_type: type2-ieee802.3at
 
 # USB A, C (exclusive, switchable), HDMI and 2 UARTs
 console-ports:
@@ -30,13 +32,12 @@ console-ports:
     type: usb-a
   - name: USB-C
     type: usb-c
-
   - name: UART REAR
     type: other
   - name: UART FRONT
     type: other
 
-# Really only supports a M2 NVMe SSD, microSD and a rPi CM4/5 module
+# Only supports a M2 NVMe SSD, microSD and a rPi CM4/5 module
 module-bays:
   - name: Raspberry Pi CM4/5 Connector
     position: '1'

--- a/module-types/Raspberry Pi/compute-module-4008000.yaml
+++ b/module-types/Raspberry Pi/compute-module-4008000.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Raspberry Pi
+model: Compute Module 4008000
+##
+# Compute Module 4 comes in one of _many_ flavors
+# RAM: 1/2/4/8 gig
+# eMMC: 0/8/16/32 gig  (0 = "lite" version)
+# Wireless: yes/no
+# There are also extended temperatures versions, not included here as they're custom order for industrial use.
+#
+# The part number is in the format:
+#     CM4WWRRFF where
+#    WW = Wireless (00 = no, 10 = wifi)
+#    RR = RAM (01 = 1 gig, 02 = 2 gig, 04 = 4 gig, 08 = 8 gig)
+#    FF = Flash (00 = no flash, 08 = 8 gig, 16 = 16 gig, 32 = 32 gig)
+# So a module with no flash, no wifi and 8 gig ram would be CM4008000
+# As far as I can tell, the number does not change to account for the various PCB revisions.
+# See: https://datasheets.raspberrypi.com/cm4/cm4-product-brief.pdf
+##
+part_number: CM4008000
+
+comments: |
+  Raspberry Pi Compute Module 4
+  * WiFi: No
+  * RAM: 8 GB
+  * Flash: 0 GB (Lite version, no eMMC)
+  [Product Family](https://www.raspberrypi.com/products/compute-module-4/?variant=raspberry-pi-cm4008000)

--- a/module-types/Raspberry Pi/compute-module-4108000.yaml
+++ b/module-types/Raspberry Pi/compute-module-4108000.yaml
@@ -1,0 +1,15 @@
+---
+manufacturer: Raspberry Pi
+model: Compute Module 4108000
+# See note in compute-module-4008000.yaml about the part number format
+part_number: '4108000'
+comments: |
+  Raspberry Pi Compute Module 4
+  * WiFi: Yes
+  * RAM: 8 GB
+  * Flash: 0 GB (Lite version, no eMMC)
+  [Product Family](https://www.raspberrypi.com/products/compute-module-4/?variant=raspberry-pi-cm4108000)
+
+interfaces:
+  - name: wlan0
+    type: ieee802.11ac


### PR DESCRIPTION
This adds the uptime-industries rPi compute module blade chassis, blade-host as well as two different types of raspberry pi compute modules.