### PR TITLE
Addition of all AC common slot PSUs for HPE ProLiant G6, G7 and Gen8

### DIFF
--- a/module-types/HPE/500172-B21.yaml
+++ b/module-types/HPE/500172-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 1200W Common Slot Silver Hot Plug Power Supply
+part_number: 500172-B21
+description: Silver Common Slot PSU on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 1200

--- a/module-types/HPE/503296-B21.yaml
+++ b/module-types/HPE/503296-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 460W Common Slot Gold Hot Plug Power Supply
+part_number: 503296-B21
+description: Gold Common Slot PSU on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 460

--- a/module-types/HPE/512327-B21.yaml
+++ b/module-types/HPE/512327-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 750W Common Slot Gold Hot Plug Power Supply
+part_number: 512327-B21
+description: Gold Common Slot PSU on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 750

--- a/module-types/HPE/578322-B21.yaml
+++ b/module-types/HPE/578322-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 1200W Common Slot Platinum Hot Plug Power Supply
+part_number: 578322-B21
+description: Platinum Common Slot PSU with support for HPE Power Discovery Services on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 1200

--- a/module-types/HPE/656362-B21.yaml
+++ b/module-types/HPE/656362-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 460W Common Slot Platinum Plus Hot Plug Power Supply
+part_number: 656362-B21
+description: Platinum Common Plus Slot PSU with support for HPE Power Discovery Services on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 460

--- a/module-types/HPE/656363-B21.yaml
+++ b/module-types/HPE/656363-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 750W Common Slot Platinum Plus Hot Plug Power Supply
+part_number: 656363-B21
+description: Platinum Plus Common Slot PSU with support for HPE Power Discovery Services on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 750

--- a/module-types/HPE/656364-B21.yaml
+++ b/module-types/HPE/656364-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 1200W Common Slot Platinum Plus Hot Plug Power Supply
+part_number: 656364-B21
+description: Platinum Plus Common Slot PSU with support for HPE Power Discovery Services on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 1200

--- a/module-types/HPE/684532-B21.yaml
+++ b/module-types/HPE/684532-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 1500W Common Slot Platinum Plus Hot Plug Power Supply
+part_number: 684532-B21
+description: Platinum Plus Common Slot PSU with support for HPE Power Discovery Services on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 1500

--- a/module-types/HPE/697581-B21.yaml
+++ b/module-types/HPE/697581-B21.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: HPE
 model: HPE 750W Common Slot Titanium Hot Plug Power Supply
-part_number: 656363-B21
+part_number: 697581-B21
 description: Titanium Common Slot PSU with support for HPE Power Discovery Services on various HPE Proliant G6, G7 and Gen8 servers
 comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
 weight: 1.13

--- a/module-types/HPE/697581-B21.yaml
+++ b/module-types/HPE/697581-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 750W Common Slot Titanium Hot Plug Power Supply
+part_number: 656363-B21
+description: Titanium Common Slot PSU with support for HPE Power Discovery Services on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 750

--- a/module-types/HPE/739252-B21.yaml
+++ b/module-types/HPE/739252-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 460W Common Slot Platinum Hot Plug Power Supply
+part_number: 739252-B21
+description: Platinum Common Slot PSU on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 460

--- a/module-types/HPE/739254-B21.yaml
+++ b/module-types/HPE/739254-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 750W Common Slot Platinum Hot Plug Power Supply
+part_number: 739254-B21
+description: Platinum Common Slot PSU on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 750

--- a/module-types/HPE/748287-B21.yaml
+++ b/module-types/HPE/748287-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: HPE 1200W Common Slot Platinum Hot Plug Power Supply
+part_number: 748287-B21
+description: Platinum Common Slot PSU on various HPE Proliant G6, G7 and Gen8 servers
+comments: "See:\r\n\r\n- [QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=c04111541)"
+weight: 1.13
+weight_unit: kg
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 1200


### PR DESCRIPTION
Introduces all possible AC powered common slot power supplies for various HPE ProLiant G6, G7 and Gen8 servers