### PR TITLE
Create DGS-1100-10MPP.yaml

### DIFF
--- a/device-types/D-Link/DGS-1100-10MPP.yaml
+++ b/device-types/D-Link/DGS-1100-10MPP.yaml
@@ -4,10 +4,10 @@ model: DGS-1100-10MPP
 slug: d-link-dgs-1100-10mpp
 part_number: DGS-1100-10MPP
 comments: |
-  [D-Link DGS‑1100‑10MPP Surveillance Datasheet v1.11WW](https://www.dlink.com/en/-/media/business_products/dgs/dgs-1100/datasheet/dgs1100mpmppc1surveillancedatasheetv111ww.pdf)
-  - 8 × 10/100/1000BASE-T PoE ports (IEEE 802.3af/at)
-  - Ports 7–8 support IEEE 802.3bt (PoE++) up to 90W
-  - 2 × 1000BASE-X SFP uplink ports
+  [D-Link DGS-1100-10MPP Surveillance Datasheet v1.11WW](https://www.dlink.com/en/-/media/business_products/dgs/dgs-1100/datasheet/dgs1100mpmppc1surveillancedatasheetv111ww.pdf)
+  - 8 x 10/100/1000BASE-T PoE ports (IEEE 802.3af/at)
+  - Ports 7-8 support IEEE 802.3bt (PoE++) up to 90W
+  - 2 x 1000BASE-X SFP uplink ports
   - 242W total PoE budget
   - Surveillance features: Loopback Detection, Cable Diagnostics, ONVIF VLAN, QoS, IGMP snooping
 

--- a/device-types/D-Link/DGS-1100-10MPP.yaml
+++ b/device-types/D-Link/DGS-1100-10MPP.yaml
@@ -1,0 +1,82 @@
+---
+manufacturer: D-Link
+model: DGS-1100-10MPP
+slug: d-link-dgs-1100-10mpp
+part_number: DGS-1100-10MPP
+comments: |
+  [D-Link DGS‑1100‑10MPP Surveillance Datasheet v1.11](https://www.dlink.com/en/-/media/business_products/dgs/dgs-1100/datasheet/dgs1100mpmppc1surveillancedatasheetv111ww.pdf)
+  - 8× 10/100/1000BASE-T PoE ports with IEEE 802.3af/at/bt support
+  - 2× 1000BASE-X SFP uplink ports
+  - PoE budget: 242 W (30 W per port for ports 1–6; 90 W per port for ports 7–8) :contentReference[oaicite:1]{index=1}
+  - 1U rack-mountable with fan-based cooling :contentReference[oaicite:2]{index=2}
+  - Advanced features: Loopback Detection, Cable Diagnostics, ONVIF surveillance VLAN, IGMP snooping, QoS, VLANs :contentReference[oaicite:3]{index=3}
+
+is_full_depth: false
+u_height: 1
+weight: 1830
+weight_unit: g
+airflow: front-to-rear
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 300
+
+interfaces:
+  - name: Port 1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: Port 8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: Port 9
+    type: 1000base-x-sfp
+  - name: Port 10
+    type: 1000base-x-sfp
+
+memory:
+  ram: 128
+  ram_unit: MB
+  flash: 32
+  flash_unit: MB
+
+features:
+  - loopback detection
+  - cable diagnostics
+  - igmp snooping
+  - surveillance vlan
+  - qos
+  - vlan
+  - spanning tree
+  - snmp
+  - onvif surveillance
+
+warranty: "Lifetime (after registration)"

--- a/device-types/D-Link/DGS-1100-10MPP.yaml
+++ b/device-types/D-Link/DGS-1100-10MPP.yaml
@@ -4,21 +4,23 @@ model: DGS-1100-10MPP
 slug: d-link-dgs-1100-10mpp
 part_number: DGS-1100-10MPP
 comments: |
-  [D-Link DGS‑1100‑10MPP Surveillance Datasheet v1.11](https://www.dlink.com/en/-/media/business_products/dgs/dgs-1100/datasheet/dgs1100mpmppc1surveillancedatasheetv111ww.pdf)
-  - 8× 10/100/1000BASE-T PoE ports with IEEE 802.3af/at/bt support
-  - 2× 1000BASE-X SFP uplink ports
-  - PoE budget: 242 W (30 W per port for ports 1–6; 90 W per port for ports 7–8) :contentReference[oaicite:1]{index=1}
-  - 1U rack-mountable with fan-based cooling :contentReference[oaicite:2]{index=2}
-  - Advanced features: Loopback Detection, Cable Diagnostics, ONVIF surveillance VLAN, IGMP snooping, QoS, VLANs :contentReference[oaicite:3]{index=3}
+  [D-Link DGS‑1100‑10MPP Surveillance Datasheet v1.11WW](https://www.dlink.com/en/-/media/business_products/dgs/dgs-1100/datasheet/dgs1100mpmppc1surveillancedatasheetv111ww.pdf)
+  - 8 × 10/100/1000BASE-T PoE ports (IEEE 802.3af/at)
+  - Ports 7–8 support IEEE 802.3bt (PoE++) up to 90W
+  - 2 × 1000BASE-X SFP uplink ports
+  - 242W total PoE budget
+  - Surveillance features: Loopback Detection, Cable Diagnostics, ONVIF VLAN, QoS, IGMP snooping
 
 is_full_depth: false
 u_height: 1
 weight: 1830
 weight_unit: g
 airflow: front-to-rear
+
 console-ports:
   - name: Console
     type: rj-45
+
 power-ports:
   - name: PSU
     type: iec-60320-c14
@@ -61,22 +63,3 @@ interfaces:
     type: 1000base-x-sfp
   - name: Port 10
     type: 1000base-x-sfp
-
-memory:
-  ram: 128
-  ram_unit: MB
-  flash: 32
-  flash_unit: MB
-
-features:
-  - loopback detection
-  - cable diagnostics
-  - igmp snooping
-  - surveillance vlan
-  - qos
-  - vlan
-  - spanning tree
-  - snmp
-  - onvif surveillance
-
-warranty: "Lifetime (after registration)"

--- a/device-types/D-Link/DGS-1100-26MPP.yaml
+++ b/device-types/D-Link/DGS-1100-26MPP.yaml
@@ -1,0 +1,137 @@
+---
+manufacturer: D-Link
+model: DGS-1100-26MPP
+slug: d-link-dgs-1100-26mpp
+part_number: DGS-1100-26MPP
+comments: |
+  [D-Link DGS-1100-26MPP Surveillance Datasheet v1.11WW](https://www.dlink.com/en/-/media/business_products/dgs/dgs-1100/datasheet/dgs1100mpmppc1surveillancedatasheetv111ww.pdf)
+  - 24 x 10/100/1000BASE-T PoE ports (IEEE 802.3af/at)
+  - Ports 25-26 support IEEE 802.3bt (PoE++) up to 90W
+  - 2 x 1000BASE-X SFP uplink ports
+  - 370W total PoE budget
+  - Surveillance features: Loopback Detection, Cable Diagnostics, ONVIF VLAN, QoS, IGMP snooping
+
+is_full_depth: false
+u_height: 1
+weight: 2000
+weight_unit: g
+airflow: front-to-rear
+
+console-ports:
+  - name: Console
+    type: rj-45
+
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 400
+
+interfaces:
+  - name: Port 1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 13
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 14
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 15
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 16
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 17
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 18
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 19
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 20
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 21
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 22
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 23
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 24
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: Port 25
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: Port 26
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type4-ieee802.3bt
+  - name: Port 27
+    type: 1000base-x-sfp
+  - name: Port 28
+    type: 1000base-x-sfp


### PR DESCRIPTION
Add D-Link DGS-1100-10MPP device type

- 8 × 10/100/1000BASE-T PoE ports (IEEE 802.3af/at)
- Ports 7–8 support IEEE 802.3bt (PoE++ up to 90W)
- 2 × 1000BASE-X SFP uplink ports
- 1U rack-mountable compact form factor
- PoE budget: 242 W total
- Smart Surveillance features: ONVIF, Cable Diagnostics, Loopback Detection
- Source: [D-Link DGS-1100-10MPP Surveillance Datasheet v1.11WW](https://www.dlink.com/en/-/media/business_products/dgs/dgs-1100/datasheet/dgs1100mpmppc1surveillancedatasheetv111ww.pdf)