### PR TITLE
Add "airflow" and "profile" to moduletype test

### DIFF
--- a/schema/moduletype.json
+++ b/schema/moduletype.json
@@ -74,6 +74,9 @@
         },
         "comments": {
             "type": "string"
+        },
+        "profile": {
+            "type": "string"
         }
     },
     "required": ["manufacturer", "model"],

--- a/schema/moduletype.json
+++ b/schema/moduletype.json
@@ -12,6 +12,9 @@
         "part_number": {
             "type": "string"
         },
+        "airflow": {
+            "$ref": "urn:devicetype-library:generated-schema#/definitions/airflow"
+        },
         "weight": {
             "$ref": "urn:devicetype-library:reusable#/definitions/weight"
         },


### PR DESCRIPTION
This commit add "airflow" and "profile" to moduletype tests to allow using those objects.

- airflow : Usefull for fan and power supply
- profile : Introduced in netbox v4.3 (https://netboxlabs.com/docs/netbox/models/dcim/moduletypeprofile/)