### PR TITLE
Add neu folder for module type profiles with an exemplary SFP profile

### DIFF
--- a/module-type-profiles/sfp-transceiver.yaml
+++ b/module-type-profiles/sfp-transceiver.yaml
@@ -1,0 +1,29 @@
+---
+name: SFP Transceiver
+schema: {
+    "properties": {
+        "connector_type": {
+            "description": "Physical connector type",
+            "enum": [
+                "LC",
+                "SC",
+                "MPO",
+                "RJ45"
+            ],
+            "type": "string"
+        },
+        "wavelength": {
+            "description": "Operating wavelength",
+            "enum": [
+                "850nm",
+                "1310nm",
+                "1550nm",
+                "SWDM",
+                "CWDM",
+                "DWDM",
+                "copper"
+            ],
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
This PR includes a new folder, that will contain future module type profiles. Also it contains a profile for SFP transceiver based on one of the latest [blog](https://netboxlabs.com/blog/sfp-modeling-modules-over-inventory-items/) posts.