### PR TITLE
Rename custom `is_powered` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ The following fields may **optionally** be declared:
 - `comments`: A string field which allows for comments to be added to the device. (**Default: None**)
   - Type: String
   - :test_tube: Example: `comments: This is a comment that will appear on all NetBox devices of this type`
-- `is_powered`: A boolean which indicates whether the device type does not take power. This is mainly used as a workaround for validation testing on non powered devices (i.e. rackmount kits or patch pannels.) (**Default: True**)
+- `_is_powered`: Indicates that the device type requires power to operate. Only used internally for power validation testing on non-powered devices (i.e. rackmount kits or patch pannels.) (**Default: True**)
   - Type: Boolean
-  - :test_tube: Example: `is_powered: false`
+  - :test_tube: Example: `_is_powered: false`
 - `weight`: A number representing the numeric weight value. Must be a multiple of 0.01 (2 decimal places). (**Default: None**)
   - Type: Number
   - Value: must be a multiple of 0.01

--- a/device-types/ADC/7033-Fibre-Panel.yaml
+++ b/device-types/ADC/7033-Fibre-Panel.yaml
@@ -9,7 +9,7 @@ is_full_depth: false
 airflow: passive
 weight: 1.14
 weight_unit: kg
-is_powered: false
+_is_powered: false
 front_image: true
 module-bays:
   - name: '1'

--- a/device-types/ADVA/f7-48csm-1hu-19600-19130.yaml
+++ b/device-types/ADVA/f7-48csm-1hu-19600-19130.yaml
@@ -5,7 +5,7 @@ slug: adva-f7-48csm-1hu-19600-19130
 part_number: 1078708781-01
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 airflow: passive
 front-ports:
   - name: C1

--- a/device-types/AFL/FXUCXXBXXX-01BH.yaml
+++ b/device-types/AFL/FXUCXXBXXX-01BH.yaml
@@ -7,7 +7,7 @@ u_height: 1
 weight: 1.6
 weight_unit: kg
 is_full_depth: false
-is_powered: false
+_is_powered: false
 module-bays:
   - name: A
     position: A

--- a/device-types/AFL/FXUCXXBXXX-02BH.yaml
+++ b/device-types/AFL/FXUCXXBXXX-02BH.yaml
@@ -7,7 +7,7 @@ u_height: 2
 weight: 2.6
 weight_unit: kg
 is_full_depth: false
-is_powered: false
+_is_powered: false
 module-bays:
   - name: A
     position: A

--- a/device-types/Check Point/CPAC-1500-3600-3800-RM-DUAL.yaml
+++ b/device-types/Check Point/CPAC-1500-3600-3800-RM-DUAL.yaml
@@ -5,7 +5,7 @@ slug: check-point-cpac-1500-3600-3800-rm-dual
 part_number: CPAC-1500/3600/3800-RM-DUAL
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 comments: Rack Mount shelf for Single/Dual for 1500/ 3600/ 3800 desktop appliances
 subdevice_role: parent
 device-bays:

--- a/device-types/Cisco/C8300-1N1S-4T2X.yaml
+++ b/device-types/Cisco/C8300-1N1S-4T2X.yaml
@@ -6,7 +6,6 @@ part_number: C8300-1N1S-4T2X
 u_height: 1
 is_full_depth: false
 airflow: front-to-rear
-is_powered: true
 comments: '[Cisco 8000 Series Routers Data Sheet](https://www.cisco.com/c/en/us/products/collateral/routers/catalyst-8300-series-edge-platforms/datasheet-c78-744088.html)'
 weight: 9.0
 weight_unit: kg

--- a/device-types/Cisco/C8300-2N2S-4T2X.yaml
+++ b/device-types/Cisco/C8300-2N2S-4T2X.yaml
@@ -6,7 +6,6 @@ part_number: C8300-2N2S-4T2X
 u_height: 2
 is_full_depth: false
 airflow: front-to-rear
-is_powered: true
 comments: '[Cisco 8000 Series Routers Data Sheet](https://www.cisco.com/c/en/us/products/collateral/routers/catalyst-8300-series-edge-platforms/datasheet-c78-744088.html)'
 weight: 18.0
 weight_unit: kg

--- a/device-types/Cisco/C891-K9.yml
+++ b/device-types/Cisco/C891-K9.yml
@@ -5,7 +5,6 @@ part_number: C891-K9
 slug: cisco-c891-k9
 u_height: 1
 is_full_depth: false
-is_powered: true
 weight: 4.84
 weight_unit: kg
 airflow: passive

--- a/device-types/Cisco/C891F-K9.yml
+++ b/device-types/Cisco/C891F-K9.yml
@@ -5,7 +5,6 @@ part_number: C891F-K9
 slug: cisco-c891f-k9
 u_height: 1
 is_full_depth: false
-is_powered: true
 weight: 2.5
 weight_unit: kg
 airflow: passive

--- a/device-types/Cisco/C9800-L-RMNT.yaml
+++ b/device-types/Cisco/C9800-L-RMNT.yaml
@@ -7,7 +7,7 @@ u_height: 2
 subdevice_role: parent
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Left Slot
   - name: Right Slot

--- a/device-types/Cisco/Catalyst-9200CX-8T-E-2G.yaml
+++ b/device-types/Cisco/Catalyst-9200CX-8T-E-2G.yaml
@@ -9,7 +9,6 @@ comments: >
   Cisco Catalyst 9200CX-8T-E-2G is a compact, fanless Layer 3 switch featuring
   8x 1G copper ports and 2x 1G SFP uplink ports. Ideal for branch and compact
   enterprise deployments with full enterprise-class feature support and security.
-is_powered: true
 weight: 3.1
 weight_unit: kg
 interfaces:

--- a/device-types/Cisco/Catalyst-9500X-60L4D.yaml
+++ b/device-types/Cisco/Catalyst-9500X-60L4D.yaml
@@ -10,7 +10,6 @@ comments: >
   layer switch designed for enterprise and data center deployments.
   It features 60x 1/10/25G multi-rate SFP28 ports and 4x 40/100G QSFP28 uplinks,
   running Cisco IOS XE and supporting advanced routing, segmentation, and telemetry.
-is_powered: true
 weight: 9.2
 weight_unit: kg
 interfaces:

--- a/device-types/Cisco/FPR1K-DT-RACK-MNT.yaml
+++ b/device-types/Cisco/FPR1K-DT-RACK-MNT.yaml
@@ -9,7 +9,7 @@ subdevice_role: parent
 comments: '[Rack Mount Installation guide](https://www.cisco.com/c/en/us/td/docs/security/firepower/1010/hw/guide/hw-install-1010/mount.html)'
 weight: 900.0
 weight_unit: g
-is_powered: false
+_is_powered: false
 device-bays:
   - name: slot-1
   - name: slot-2

--- a/device-types/Cisco/IE-3200-8P2S.yaml
+++ b/device-types/Cisco/IE-3200-8P2S.yaml
@@ -6,7 +6,6 @@ part_number: IE-3200-8P2S
 u_height: 1
 is_full_depth: false
 airflow: front-to-rear
-is_powered: true
 comments: '[Cisco Catalyst IE3200 Rugged Series Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-ie3200-rugged-series/cat-ie3200-rugged-series-ds.html)'
 weight: 1.7
 weight_unit: kg

--- a/device-types/Cisco/ISR-C1111-4P.yaml
+++ b/device-types/Cisco/ISR-C1111-4P.yaml
@@ -5,7 +5,6 @@ part_number: C1111-4P
 slug: cisco-isr-c1111-4p
 u_height: 1
 is_full_depth: false
-is_powered: true
 weight: 1.98
 weight_unit: kg
 airflow: passive

--- a/device-types/Cisco/N2K-C2248TP-1GE.yaml
+++ b/device-types/Cisco/N2K-C2248TP-1GE.yaml
@@ -9,7 +9,6 @@ weight_unit: kg
 is_full_depth: true
 front_image: true
 rear_image: false
-is_powered: true
 comments: '[Cisco Nexus 2000 Series Fabric Extenders Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/nexus-2000-series-fabric-extenders/data_sheet_c78-507093.html)'
 interfaces:
   - name: Ethernet1/1/1

--- a/device-types/Cisco/UCS-X9508.yaml
+++ b/device-types/Cisco/UCS-X9508.yaml
@@ -10,7 +10,7 @@ subdevice_role: parent
 airflow: front-to-rear
 weight: 43.09
 weight_unit: kg
-is_powered: false
+_is_powered: false
 device-bays:
   - name: slot-1
   - name: slot-2

--- a/device-types/Cisco/WS-C3560CX-12PC-S.yaml
+++ b/device-types/Cisco/WS-C3560CX-12PC-S.yaml
@@ -4,7 +4,6 @@ model: Catalyst 3560-CX-12PC-S
 slug: cisco-ws-c3560cx-12pc-s
 part_number: WS-C3560CX-12PC-S
 is_full_depth: false
-is_powered: true
 front_image: true
 rear_image: true
 u_height: 1

--- a/device-types/Cisco/WS-C3560CX-12TC-S.yaml
+++ b/device-types/Cisco/WS-C3560CX-12TC-S.yaml
@@ -5,7 +5,6 @@ slug: cisco-ws-c3560cx-12tc-s
 part_number: WS-C3560CX-12TC-S
 is_full_depth: false
 u_height: 1
-is_powered: true
 interfaces:
   - name: GigabitEthernet1/0/1
     type: 1000base-t

--- a/device-types/Cisco/catalyst-9136axi.yaml
+++ b/device-types/Cisco/catalyst-9136axi.yaml
@@ -10,7 +10,6 @@ comments: >
   with tri-band support (2.4 GHz, 5 GHz, and 6 GHz) and integrated environmental
   sensors. It is ideal for high-density enterprise and campus deployments with
   advanced RF and client management features.
-is_powered: true
 weight: 1.7
 weight_unit: kg
 interfaces:

--- a/device-types/Commscope/360G2-1U-MOD-SD.yaml
+++ b/device-types/Commscope/360G2-1U-MOD-SD.yaml
@@ -11,7 +11,7 @@ weight: 5.44
 weight_unit: kg
 front_image: true
 rear_image: true
-is_powered: false
+_is_powered: false
 module-bays:
   - name: '1'
     position: '1'

--- a/device-types/Commscope/CPP-SDDM-SL-1U-24.yaml
+++ b/device-types/Commscope/CPP-SDDM-SL-1U-24.yaml
@@ -8,7 +8,7 @@ u_height: 1
 is_full_depth: false
 airflow: passive
 comments: '[Commscope Product Page](https://www.commscope.com/product-type/cabinets-panels-enclosures/copper-panels-modules-cassettes/copper-panels/item760237046/)'
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '1'

--- a/device-types/Commscope/CPP-UDDM-M-1U-24.yaml
+++ b/device-types/Commscope/CPP-UDDM-M-1U-24.yaml
@@ -10,7 +10,7 @@ airflow: passive
 comments: '[Commscope Product Page](https://www.commscope.com/product-type/cabinets-panels-enclosures/copper-panels-modules-cassettes/copper-panels/item760207274/)'
 front_image: true
 rear_image: true
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Commscope/CPPA-UDDM-M-2U-48.yaml
+++ b/device-types/Commscope/CPPA-UDDM-M-2U-48.yaml
@@ -10,7 +10,7 @@ airflow: passive
 comments: '[Commscope Product Page](https://www.commscope.com/product-type/cabinets-panels-enclosures/copper-panels-modules-cassettes/copper-panels/item760207308/)'
 front_image: true
 rear_image: true
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Commscope/FMS-K2BI-L1A1-48-SP.yaml
+++ b/device-types/Commscope/FMS-K2BI-L1A1-48-SP.yaml
@@ -7,7 +7,7 @@ u_height: 1
 is_full_depth: false
 comments: FMS Fiber Optic Panel, 1U, 19 in, black, Includes 24 x LC SM Duplex
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: lc-apc

--- a/device-types/Commscope/HTK-19-SS-1U.yaml
+++ b/device-types/Commscope/HTK-19-SS-1U.yaml
@@ -10,4 +10,4 @@ airflow: passive
 weight: 3.35
 weight_unit: lb
 comments: '[Commscope Product Page](https://www.commscope.com/product-type/cable-management/horizontal-vertical-cable-managers/item760072942/)'
-is_powered: false
+_is_powered: false

--- a/device-types/Commscope/HTK-19-SS-2U.yaml
+++ b/device-types/Commscope/HTK-19-SS-2U.yaml
@@ -11,4 +11,4 @@ weight: 4.52
 weight_unit: lb
 comments: '[Commscope Product Page](https://www.commscope.com/product-type/cable-management/horizontal-vertical-cable-managers/item760072959/)'
 front_image: true
-is_powered: false
+_is_powered: false

--- a/device-types/Commscope/MFPS-KHD-P-SIL1-048.yaml
+++ b/device-types/Commscope/MFPS-KHD-P-SIL1-048.yaml
@@ -8,7 +8,7 @@ u_height: 1.0
 is_full_depth: false
 airflow: passive
 comments: '[Commscope MFPS-KHD-P-SIL1-048](https://www.commscope.com/globalassets/digizuite/149234-p360-eh6592-000-external.pdf)'
-is_powered: false
+_is_powered: false
 front-ports:
   - name: 1-2
     type: lc-apc

--- a/device-types/Commscope/MFPS-KHD-P-SIL2-048.yaml
+++ b/device-types/Commscope/MFPS-KHD-P-SIL2-048.yaml
@@ -8,7 +8,7 @@ u_height: 1.0
 is_full_depth: false
 airflow: passive
 comments: '[Commscope MFPS-KHD-P-SIL2-048](https://www.commscope.com/globalassets/digizuite/149232-p360-eh6588-000-external.pdf)'
-is_powered: false
+_is_powered: false
 front-ports:
   - name: 1-2
     type: lc-apc

--- a/device-types/Commscope/SD-1U.yaml
+++ b/device-types/Commscope/SD-1U.yaml
@@ -11,7 +11,7 @@ airflow: passive
 weight: 14
 weight_unit: lb
 front_image: true
-is_powered: false
+_is_powered: false
 module-bays:
   - name: '1'
     position: '1'

--- a/device-types/Commscope/SD-4U.yaml
+++ b/device-types/Commscope/SD-4U.yaml
@@ -11,7 +11,7 @@ airflow: passive
 weight: 24.5
 weight_unit: lb
 front_image: true
-is_powered: false
+_is_powered: false
 module-bays:
   - name: '1'
     position: '1'

--- a/device-types/ConnectCom/CCM-Patchpanel-1HE-SLITE-HD-Right.yaml
+++ b/device-types/ConnectCom/CCM-Patchpanel-1HE-SLITE-HD-Right.yaml
@@ -10,7 +10,7 @@ airflow: passive
 comments: |
   Connector type A: LC-APC connector, Standards: IEC 61754-20, TIA 604-10-A, Insertion loss: type. =< 0.12 dB - 97% =< 0.25dB (Grade B), Return loss:
   type. > 85 dB - min. 65 dB, Ferrule material: all-ceramic ferrule (1.25 mm)'
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Front Port 1
     type: lc-apc

--- a/device-types/Corning/MAXCSV-02408-C001.yaml
+++ b/device-types/Corning/MAXCSV-02408-C001.yaml
@@ -10,7 +10,7 @@ airflow: passive
 comments: '[Corning Product Page](https://ecatalog.corning.com/optical-communications/EMEA/en_GB/Copper-Hardware/Everon%C2%AE-Copper-Datacom-Patch-Panels/Everon%C2%AE-Copper-Datacom-VOL-Patch-panel-19%27-inch/p/MAXCSV-02408-C001)'
 front_image: false
 rear_image: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/CyberPower/CP1500AVRLCD.yaml
+++ b/device-types/CyberPower/CP1500AVRLCD.yaml
@@ -9,7 +9,6 @@ comments: >
   CyberPower CP1500AVRLCD is a mini-tower UPS system with 1500VA/900W capacity,
   simulated sine wave output, AVR support, and 12 NEMA 5-15R outlets. Ideal for
   home offices and network protection.
-is_powered: true
 weight: 11.79
 weight_unit: kg
 

--- a/device-types/Datwyler/patch-panel-ks-24x-black.yaml
+++ b/device-types/Datwyler/patch-panel-ks-24x-black.yaml
@@ -8,7 +8,7 @@ is_full_depth: false
 weight: 0.93
 weight_unit: kg
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 comments: '[KS 24x Specifications](https://itinfra.datwyler.com/en/copper-networks/patch-panels/patch-panel-ks-24x/)'
 front-ports:

--- a/device-types/Datwyler/patch-panel-ks-24x-light-grey.yaml
+++ b/device-types/Datwyler/patch-panel-ks-24x-light-grey.yaml
@@ -8,7 +8,7 @@ is_full_depth: false
 weight: 0.93
 weight_unit: kg
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 comments: '[KS 24x Specifications](https://itinfra.datwyler.com/en/copper-networks/patch-panels/patch-panel-ks-24x/)'
 front-ports:

--- a/device-types/Datwyler/patch-panel-ku-24x-black.yaml
+++ b/device-types/Datwyler/patch-panel-ku-24x-black.yaml
@@ -8,7 +8,7 @@ is_full_depth: false
 weight: 1
 weight_unit: kg
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 comments: '[KU 24x Specifications](https://itinfra.datwyler.com/en/copper-networks/patch-panels/patch-panel-ku-24x/)'
 front-ports:

--- a/device-types/Datwyler/patch-panel-ku-24x-light-grey.yaml
+++ b/device-types/Datwyler/patch-panel-ku-24x-light-grey.yaml
@@ -8,7 +8,7 @@ is_full_depth: false
 weight: 1
 weight_unit: kg
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 comments: '[KU 24x Specifications](https://itinfra.datwyler.com/en/copper-networks/patch-panels/patch-panel-ku-24x/)'
 front-ports:

--- a/device-types/Datwyler/patch-panel-mgk-24x-light-grey.yaml
+++ b/device-types/Datwyler/patch-panel-mgk-24x-light-grey.yaml
@@ -8,7 +8,7 @@ is_full_depth: false
 weight: 1.16
 weight_unit: kg
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 comments: '[MGK 24x Specifications](https://itinfra.datwyler.com/en/copper-networks/patch-panels/patch-panels-mgk-24x/)'
 front-ports:

--- a/device-types/Datwyler/patch-panel-mgk-24x-silver.yaml
+++ b/device-types/Datwyler/patch-panel-mgk-24x-silver.yaml
@@ -8,7 +8,7 @@ is_full_depth: false
 weight: 1.16
 weight_unit: kg
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 comments: '[MGK 24x Specifications](https://itinfra.datwyler.com/en/copper-networks/patch-panels/patch-panels-mgk-24x/)'
 front-ports:

--- a/device-types/Dell/PowerScale-H700-Chassis.yaml
+++ b/device-types/Dell/PowerScale-H700-Chassis.yaml
@@ -9,7 +9,7 @@ subdevice_role: parent
 airflow: front-to-rear
 weight: 118.0
 weight_unit: kg
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Node 1
     label: '1'

--- a/device-types/Dell/PowerSwitch-N3248P-ON.yaml
+++ b/device-types/Dell/PowerSwitch-N3248P-ON.yaml
@@ -11,7 +11,6 @@ rear_image: true
 comments: '[dell-networking-n3200-series-spec-sheet.pdf](https://www.delltechnologies.com/asset/en-au/products/networking/technical-support/dell-networking-n3200-powerswitch-specsheet.pdf)'
 weight: 7.57
 weight_unit: kg
-is_powered: true
 console-ports:
   - name: Console
     type: usb-micro-b

--- a/device-types/Dell/PowerSwitch-S4128F-ON.yaml
+++ b/device-types/Dell/PowerSwitch-S4128F-ON.yaml
@@ -11,7 +11,6 @@ rear_image: true
 comments: '[dell-networking-s4100-series-spec-sheet.pdf](https://www.delltechnologies.com/asset/en-us/products/networking/technical-support/dell-networking-s4100-series-spec-sheet.pdf)'
 weight: 8.92
 weight_unit: kg
-is_powered: true
 console-ports:
   - name: Console
     type: usb-micro-b

--- a/device-types/Eaton/Tripp-Lite-N054-024.yaml
+++ b/device-types/Eaton/Tripp-Lite-N054-024.yaml
@@ -5,7 +5,7 @@ slug: eaton-tripp-lite-n054-024
 part_number: N054-024
 u_height: 1.0
 is_full_depth: false
-is_powered: false
+_is_powered: false
 airflow: passive
 weight: 0.8
 weight_unit: kg

--- a/device-types/FS/FHD-1U-CMP400.yaml
+++ b/device-types/FS/FHD-1U-CMP400.yaml
@@ -8,7 +8,7 @@ part_number: '70419'
 u_height: 1
 airflow: passive
 is_full_depth: false
-is_powered: false
+_is_powered: false
 module-bays:
   - name: '1'
     position: '1'

--- a/device-types/FS/FHD-1UFMT-N.yaml
+++ b/device-types/FS/FHD-1UFMT-N.yaml
@@ -5,7 +5,7 @@ slug: fs-fhd-1ufmt-n
 comments: '[FHD High Density 1U Rack Mount Enclosure Unloaded, Holds up to 4 x FHD Cassettes or Panels, 144 Fibers (LC)](https://www.fs.com/uk/products/96427.html)'
 part_number: FHD-1UFMT-N (#96427)
 airflow: passive
-is_powered: false
+_is_powered: false
 u_height: 1
 is_full_depth: false
 module-bays:

--- a/device-types/FS/FHD-1UFMT-S.yaml
+++ b/device-types/FS/FHD-1UFMT-S.yaml
@@ -5,7 +5,7 @@ slug: fs-fhd-1ufmt-s
 comments: '[FHD High Density 1U Rack Mount Enclosure Unloaded, Sliding and Tilt-down drawer, Holds up to 4 x FHD Cassettes or Panels, 144 Fibers (LC)](https://www.fs.com/uk/products/145167.html)'
 part_number: FHD-1UFMT-S (#145167)
 airflow: passive
-is_powered: false
+_is_powered: false
 weight: 3.6
 weight_unit: kg
 u_height: 1

--- a/device-types/FS/FHD-4UFCE.yaml
+++ b/device-types/FS/FHD-4UFCE.yaml
@@ -5,7 +5,7 @@ slug: fs-fhd-4ufce
 comments: '[FHD High Density 4U Rack Mount Enclosure Unloaded, Sliding Drawer, Holds up to 12 x FHD Cassettes or Panels, 432 Fibers (LC)](https://www.fs.com/uk/products/73206.html)'
 part_number: FHD-4UFCE (#73206)
 airflow: passive
-is_powered: false
+_is_powered: false
 u_height: 4
 is_full_depth: true
 module-bays:

--- a/device-types/FS/FHU-FPP48FLCSMF.yaml
+++ b/device-types/FS/FHU-FPP48FLCSMF.yaml
@@ -6,7 +6,7 @@ part_number: FHU-FPP48FLCSMF (#35530)
 u_height: 1.0
 is_full_depth: true
 comments: FHU 1U 19" Fiber Adapter Panel, 48 Fibers OS2 Single Mode, 24 x LC UPC Duplex (Blue) Adapter, Ceramic Sleeve
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Front Port 1
     type: lc

--- a/device-types/FS/FMU-1UFMX-N.yaml
+++ b/device-types/FS/FMU-1UFMX-N.yaml
@@ -8,7 +8,7 @@ u_height: 1
 is_full_depth: false
 airflow: passive
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: '1'
   - name: '2'

--- a/device-types/FS/FMU-C182761M.yaml
+++ b/device-types/FS/FMU-C182761M.yaml
@@ -6,7 +6,7 @@ part_number: FMU-C182761M
 u_height: 1
 is_full_depth: false
 comments: 18 Channels 1270-1610nm, with Monitor Port, LC/UPC, Dual Fiber CWDM Mux Demux, 1U Rack Mount
-is_powered: false
+_is_powered: false
 front-ports:
   - name: 1270nm
     type: lc

--- a/device-types/FS/FMU-D402160M.yaml
+++ b/device-types/FS/FMU-D402160M.yaml
@@ -6,7 +6,7 @@ part_number: FMU-D402160M
 u_height: 1
 is_full_depth: false
 comments: 40 Channels 100GHz C21-C60, with Monitor Port, LC/UPC, Dual Fiber DWDM Mux Demux, 1U Rack Mount
-is_powered: false
+_is_powered: false
 front-ports:
   - name: C21
     type: lc

--- a/device-types/Fortinet/SP-RACKTRAY-02.yaml
+++ b/device-types/Fortinet/SP-RACKTRAY-02.yaml
@@ -7,7 +7,7 @@ u_height: 1.0
 is_full_depth: false
 subdevice_role: parent
 comments: '[Fortinet Rack Mount Tray QuickStart Guide](https://fortinetweb.s3.amazonaws.com/docs.fortinet.com/v2/attachments/d3b3c280-1a08-11e9-9685-f8bc1258b856/Fortinet-Rack-Mount-Tray-QSG.pdf)'
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Left
   - name: Right

--- a/device-types/Generic/12-port-copper-patch-panel-full-depth.yaml
+++ b/device-types/Generic/12-port-copper-patch-panel-full-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-12-port-copper-patch-panel-full-depth
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/Generic/12-port-copper-patch-panel-half-depth.yaml
+++ b/device-types/Generic/12-port-copper-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-12-port-copper-patch-panel-half-depth
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/Generic/24-port-copper-patch-panel-half-depth.yaml
+++ b/device-types/Generic/24-port-copper-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-24-port-copper-patch-panel-half-depth
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: Port 1

--- a/device-types/Generic/24-port-copper-patch-panel.yaml
+++ b/device-types/Generic/24-port-copper-patch-panel.yaml
@@ -5,7 +5,7 @@ slug: generic-24-port-copper-patch-panel
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: Port 1

--- a/device-types/Generic/48-port-copper-patch-panel-half-depth.yaml
+++ b/device-types/Generic/48-port-copper-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-48-port-copper-patch-panel-half-depth
 u_height: 2
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: Port 1

--- a/device-types/Generic/48-port-copper-patch-panel.yaml
+++ b/device-types/Generic/48-port-copper-patch-panel.yaml
@@ -5,7 +5,7 @@ slug: generic-48-port-copper-patch-panel
 u_height: 2
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: Port 1

--- a/device-types/Generic/Blanking-Panel-1U.yaml
+++ b/device-types/Generic/Blanking-Panel-1U.yaml
@@ -2,6 +2,6 @@
 manufacturer: Generic
 model: Blanking Panel 1U
 slug: generic-blanking-panel-1u
-is_powered: false
+_is_powered: false
 u_height: 1.0
 is_full_depth: false

--- a/device-types/Generic/Blanking-Panel-2U.yaml
+++ b/device-types/Generic/Blanking-Panel-2U.yaml
@@ -2,6 +2,6 @@
 manufacturer: Generic
 model: Blanking Panel 2U
 slug: generic-blanking-panel-2u
-is_powered: false
+_is_powered: false
 u_height: 2.0
 is_full_depth: false

--- a/device-types/Generic/LC-12-port-fiber-patch-panel-half-depth.yaml
+++ b/device-types/Generic/LC-12-port-fiber-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-lc-12-port-fiber-patch-panel-half-depth
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: lc

--- a/device-types/Generic/LC-12-port-fiber-patch-panel.yaml
+++ b/device-types/Generic/LC-12-port-fiber-patch-panel.yaml
@@ -5,7 +5,7 @@ slug: generic-lc-12-port-fiber-patch-panel
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: lc

--- a/device-types/Generic/LC-24-port-fiber-patch-panel-half-depth.yaml
+++ b/device-types/Generic/LC-24-port-fiber-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-lc-24-port-fiber-patch-panel-half-depth
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: Port 1

--- a/device-types/Generic/LC-24-port-fiber-patch-panel.yaml
+++ b/device-types/Generic/LC-24-port-fiber-patch-panel.yaml
@@ -5,7 +5,7 @@ slug: generic-lc-24-port-fiber-patch-panel
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: Port 1

--- a/device-types/Generic/LC-48-port-fiber-patch-panel-half-depth.yaml
+++ b/device-types/Generic/LC-48-port-fiber-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-lc-48-port-fiber-patch-panel-half-depth
 u_height: 2
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: Port 1

--- a/device-types/Generic/LC-48-port-fiber-patch-panel.yaml
+++ b/device-types/Generic/LC-48-port-fiber-patch-panel.yaml
@@ -5,7 +5,7 @@ slug: generic-lc-48-port-fiber-patch-panel
 u_height: 2
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: Port 1

--- a/device-types/Generic/LSH-APC-24-port-fiber-patch-panel-full-depth.yaml
+++ b/device-types/Generic/LSH-APC-24-port-fiber-patch-panel-full-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-lsh-apc-24-port-fiber-patch-panel-full-depth
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: lsh-apc

--- a/device-types/Generic/LSH-APC-24-port-fiber-patch-panel-half-depth.yaml
+++ b/device-types/Generic/LSH-APC-24-port-fiber-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-lsh-apc-24-port-fiber-patch-panel-half-depth
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: lsh-apc

--- a/device-types/Generic/LSH-APC-48-port-fiber-patch-panel-full-depth.yaml
+++ b/device-types/Generic/LSH-APC-48-port-fiber-patch-panel-full-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-lsh-apc-48-port-fiber-patch-panel-full-depth
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: lsh-apc

--- a/device-types/Generic/LSH-APC-48-port-fiber-patch-panel-half-depth.yaml
+++ b/device-types/Generic/LSH-APC-48-port-fiber-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-lsh-apc-48-port-fiber-patch-panel-half-depth
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: lsh-apc

--- a/device-types/Generic/SC-12-port-duplex-fiber-patch-panel-rear-splice.yaml
+++ b/device-types/Generic/SC-12-port-duplex-fiber-patch-panel-rear-splice.yaml
@@ -5,7 +5,7 @@ slug: generic-sc-12-port-duplex-fiber-patch-panel-rear-splice
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port/1.a
     type: sc

--- a/device-types/Generic/SC-24-double-port-fiber-patch-panel-half-depth.yaml
+++ b/device-types/Generic/SC-24-double-port-fiber-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-sc-24-double-port-fiber-patch-panel-half-depth
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '1.1'

--- a/device-types/Generic/SC-24-double-port-fiber-patch-panel.yaml
+++ b/device-types/Generic/SC-24-double-port-fiber-patch-panel.yaml
@@ -5,7 +5,7 @@ slug: generic-sc-24-double-port-fiber-patch-panel
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '1.1'

--- a/device-types/Generic/SC-24-port-fiber-patch-panel-half-depth.yaml
+++ b/device-types/Generic/SC-24-port-fiber-patch-panel-half-depth.yaml
@@ -5,7 +5,7 @@ slug: generic-sc-24-port-fiber-patch-panel-half-depth
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: sc

--- a/device-types/Generic/SC-24-port-fiber-patch-panel.yaml
+++ b/device-types/Generic/SC-24-port-fiber-patch-panel.yaml
@@ -5,7 +5,7 @@ slug: generic-sc-24-port-fiber-patch-panel
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: sc

--- a/device-types/Generic/ST-16-port-fiber-patch-panel-rear-splice.yaml
+++ b/device-types/Generic/ST-16-port-fiber-patch-panel-rear-splice.yaml
@@ -5,7 +5,7 @@ slug: generic-st-16-port-fiber-patch-panel-rear-splice
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port/1
     type: st

--- a/device-types/Generic/ST-24-port-fiber-patch-panel-rear-splice.yaml
+++ b/device-types/Generic/ST-24-port-fiber-patch-panel-rear-splice.yaml
@@ -5,7 +5,7 @@ slug: generic-st-24-port-fiber-patch-panel-rear-splice
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port/1
     type: st

--- a/device-types/Generic/Storage-Drawer-2U.yaml
+++ b/device-types/Generic/Storage-Drawer-2U.yaml
@@ -4,4 +4,4 @@ model: Storage Drawer 2U
 slug: generic-storage-drawer-2u
 u_height: 2.0
 is_full_depth: false
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/Storage-Drawer-4U.yaml
+++ b/device-types/Generic/Storage-Drawer-4U.yaml
@@ -4,4 +4,4 @@ model: Storage Drawer 4U
 slug: generic-storage-drawer-4u
 u_height: 4.0
 is_full_depth: false
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/Vented-Blanking-Panel-1U.yaml
+++ b/device-types/Generic/Vented-Blanking-Panel-1U.yaml
@@ -2,7 +2,7 @@
 manufacturer: Generic
 model: Vented Blanking Panel 1U
 slug: generic-vented-blanking-panel-1u
-is_powered: false
+_is_powered: false
 u_height: 1.0
 is_full_depth: false
 airflow: passive

--- a/device-types/Generic/Vented-Blanking-Panel-2U.yaml
+++ b/device-types/Generic/Vented-Blanking-Panel-2U.yaml
@@ -2,7 +2,7 @@
 manufacturer: Generic
 model: Vented Blanking Panel 2U
 slug: generic-vented-blanking-panel-2u
-is_powered: false
+_is_powered: false
 u_height: 2.0
 is_full_depth: false
 airflow: passive

--- a/device-types/Generic/cable-management-panel-1u.yaml
+++ b/device-types/Generic/cable-management-panel-1u.yaml
@@ -5,4 +5,4 @@ slug: generic-cable-management-panel-1u
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/cable-management-panel-2u.yaml
+++ b/device-types/Generic/cable-management-panel-2u.yaml
@@ -5,4 +5,4 @@ slug: generic-cable-management-panel-2u
 u_height: 2
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/din-rail-3u.yaml
+++ b/device-types/Generic/din-rail-3u.yaml
@@ -8,4 +8,4 @@ weight_unit: kg
 is_full_depth: false
 airflow: passive
 comments: '[3U Rack panel with DIN rail, typical Data Sheet](https://www.penn-elcom.com/3u-rack-panel-with-din-rack-rail-r2299-3uk-kit)'
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/shelf-1he-full-depth.yaml
+++ b/device-types/Generic/shelf-1he-full-depth.yaml
@@ -5,4 +5,4 @@ slug: generic-shelf-1he-full-depth
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/shelf-1he.yaml
+++ b/device-types/Generic/shelf-1he.yaml
@@ -5,4 +5,4 @@ slug: generic-shelf-1he
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/shelf-2he.yaml
+++ b/device-types/Generic/shelf-2he.yaml
@@ -5,4 +5,4 @@ slug: generic-shelf-2he
 u_height: 2
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/shelf-drawer-1u-full-depth.yaml
+++ b/device-types/Generic/shelf-drawer-1u-full-depth.yaml
@@ -5,4 +5,4 @@ slug: generic-shelf-drawer-1u-full
 u_height: 1
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/sliding-shelf-drawer-1u.yaml
+++ b/device-types/Generic/sliding-shelf-drawer-1u.yaml
@@ -7,4 +7,4 @@ weight: 2
 weight_unit: kg
 is_full_depth: true
 airflow: passive
-is_powered: false
+_is_powered: false

--- a/device-types/Generic/wall-box-1-utp-plug.yaml
+++ b/device-types/Generic/wall-box-1-utp-plug.yaml
@@ -4,7 +4,7 @@ model: Wall box, 1 UTP plug
 slug: generic-wall-box-1-utp-plug
 u_height: 0.0
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/Generic/wall-box-2-utp-plugs.yaml
+++ b/device-types/Generic/wall-box-2-utp-plugs.yaml
@@ -4,7 +4,7 @@ model: Wall box, 2 UTP plugs
 slug: generic-wall-box-2-utp-plugs
 u_height: 0.0
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/Generic/wall-box-3-utp-plugs.yaml
+++ b/device-types/Generic/wall-box-3-utp-plugs.yaml
@@ -4,7 +4,7 @@ model: Wall box, 3 UTP plugs
 slug: generic-wall-box-3-utp-plugs
 u_height: 0.0
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/Generic/wall-box-4-utp-plugs.yaml
+++ b/device-types/Generic/wall-box-4-utp-plugs.yaml
@@ -4,7 +4,7 @@ model: Wall box, 4 UTP plugs
 slug: generic-wall-box-4-utp-plugs
 u_height: 0.0
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/Generic/wall-box-6-utp-plugs.yaml
+++ b/device-types/Generic/wall-box-6-utp-plugs.yaml
@@ -4,7 +4,7 @@ model: Wall box, 6 UTP plugs
 slug: generic-wall-box-6-utp-plugs
 u_height: 0.0
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/Huawei/S5720-12TP-PWR-LI-AC.yaml
+++ b/device-types/Huawei/S5720-12TP-PWR-LI-AC.yaml
@@ -8,7 +8,6 @@ part_number: '98010570'
 airflow: passive
 weight: 3.0
 weight_unit: kg
-is_powered: true
 comments: '[S5720-12TP-PWR-LI-AC](https://support.huawei.com/enterprise/en/doc/EDOC1000013597/b50f8344/s5720-12tp-pwr-li-ac)'
 console-ports:
   - name: Console

--- a/device-types/LANCOM/Rack-Mount.yaml
+++ b/device-types/LANCOM/Rack-Mount.yaml
@@ -6,7 +6,7 @@ part_number: '61501'
 u_height: 1
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 comments: '[LANCOM Rack Mount Data sheet](https://www.lancom-systems.de/fileadmin/produkte/rack_mount/Rack-Mount_DE.pdf)'
 device-bays:
   - name: Device

--- a/device-types/Mellanox/SX60-DKIT.yaml
+++ b/device-types/Mellanox/SX60-DKIT.yaml
@@ -7,7 +7,7 @@ u_height: 1
 is_full_depth: true
 # weight:
 # weight_unit: kg
-is_powered: false
+_is_powered: false
 subdevice_role: parent
 comments: |
   Rail kit for mounting two half-width SX6012 switches

--- a/device-types/Middle Atlantic/D2.yaml
+++ b/device-types/Middle Atlantic/D2.yaml
@@ -5,4 +5,4 @@ slug: middle-atlantic-d2
 part_number: D2
 u_height: 2.0
 is_full_depth: false
-is_powered: false
+_is_powered: false

--- a/device-types/Middle Atlantic/D4.yaml
+++ b/device-types/Middle Atlantic/D4.yaml
@@ -5,4 +5,4 @@ slug: middle-atlantic-d4
 part_number: D4
 u_height: 4.0
 is_full_depth: false
-is_powered: false
+_is_powered: false

--- a/device-types/MikroTik/CCR1072-1G-8S-Plus.yaml
+++ b/device-types/MikroTik/CCR1072-1G-8S-Plus.yaml
@@ -8,7 +8,6 @@ comments: |
   [Product Page](https://mikrotik.com/product/CCR1072-1G-8Splus)
 front_image: false
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CCR2004-16G-2S-Plus.yaml
+++ b/device-types/MikroTik/CCR2004-16G-2S-Plus.yaml
@@ -9,7 +9,6 @@ comments: |
   [Product Page](https://mikrotik.com/product/ccr2004_16g_2splus)
 front_image: false
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CCR2004-1G-12S-Plus-2XS.yaml
+++ b/device-types/MikroTik/CCR2004-1G-12S-Plus-2XS.yaml
@@ -9,7 +9,6 @@ comments: |
   [Product Page](https://mikrotik.com/product/ccr2004_1g_12s_2xs)
 front_image: true
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CCR2116-12G-4S-Plus.yaml
+++ b/device-types/MikroTik/CCR2116-12G-4S-Plus.yaml
@@ -9,7 +9,6 @@ comments: |
   [Product Page](https://mikrotik.com/product/ccr2116_12g_4splus)
 front_image: true
 rear_image: true
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CCR2216-1G-12XS-2XQ.yaml
+++ b/device-types/MikroTik/CCR2216-1G-12XS-2XQ.yaml
@@ -9,7 +9,6 @@ comments: |
   [Product Page](https://mikrotik.com/product/ccr2216_1g_12xs_2xq)
 front_image: true
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CRS320-8P-8B-4S-Plus-RM.yaml
+++ b/device-types/MikroTik/CRS320-8P-8B-4S-Plus-RM.yaml
@@ -10,7 +10,6 @@ comments: |
   [Product Page](https://mikrotik.com/product/crs320_8p_8b_4s_rm)
 front_image: false
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CRS326-4C-Plus-20G-Plus-2Q-Plus-RM.yaml
+++ b/device-types/MikroTik/CRS326-4C-Plus-20G-Plus-2Q-Plus-RM.yaml
@@ -17,7 +17,6 @@ comments: |
   (T) 2.5GBASE-T (2.5GE) mode.
 front_image: false
 rear_image: false
-is_powered: true
 interfaces:
   - name: combo1
     type: 10gbase-x-sfpp

--- a/device-types/MikroTik/CRS504-4XQ-IN.yaml
+++ b/device-types/MikroTik/CRS504-4XQ-IN.yaml
@@ -13,7 +13,6 @@ comments: |
   forget to add the other if you use breakout cables.
 front_image: false
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CRS510-8XS-2XQ-IN.yaml
+++ b/device-types/MikroTik/CRS510-8XS-2XQ-IN.yaml
@@ -10,7 +10,6 @@ comments: |
   [Product Page](https://mikrotik.com/product/crs510_8xs_2xq_in)
 front_image: false
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CRS518-16XS-2XQ.yaml
+++ b/device-types/MikroTik/CRS518-16XS-2XQ.yaml
@@ -13,7 +13,6 @@ comments: |
   don't forget to add the other if you use breakout cables.
 front_image: false
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 1000base-t

--- a/device-types/MikroTik/CRS520-4XS-16XQ.yaml
+++ b/device-types/MikroTik/CRS520-4XS-16XQ.yaml
@@ -13,7 +13,6 @@ comments: |
   don't forget to add the other if you use breakout cables.
 front_image: false
 rear_image: false
-is_powered: true
 interfaces:
   - name: ether1
     type: 10gbase-t

--- a/device-types/Palo Alto/PA-220-Rack-Kit.yaml
+++ b/device-types/Palo Alto/PA-220-Rack-Kit.yaml
@@ -6,7 +6,7 @@ part_number: PAN-PA-220-RACK-SINGLE
 u_height: 1
 subdevice_role: parent
 is_full_depth: false
-is_powered: false
+_is_powered: false
 airflow: passive
 device-bays:
   - name: Firewall

--- a/device-types/Palo Alto/PA-220-Rack-Tray-Kit.yaml
+++ b/device-types/Palo Alto/PA-220-Rack-Tray-Kit.yaml
@@ -6,7 +6,7 @@ part_number: PAN-PA-220-RACKTRAY
 u_height: 1
 subdevice_role: parent
 is_full_depth: false
-is_powered: false
+_is_powered: false
 airflow: passive
 device-bays:
   - name: Firewall A

--- a/device-types/Palo Alto/PAN-1RU-RGD-RACK-KIT-4POST.yaml
+++ b/device-types/Palo Alto/PAN-1RU-RGD-RACK-KIT-4POST.yaml
@@ -6,7 +6,7 @@ part_number: PAN-1RU-RGD-RACK-KIT-4POST
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one PA-415-5G firewall in a four-post rack.
 device-bays:

--- a/device-types/Palo Alto/PAN-1RU-SMALL-RACK4.yaml
+++ b/device-types/Palo Alto/PAN-1RU-SMALL-RACK4.yaml
@@ -6,7 +6,7 @@ part_number: PAN-1RU-SMALL-RACK4
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one PA-455 or PA-455-5G firewall in a four-post rack.
 device-bays:

--- a/device-types/Palo Alto/PAN-ION-1200-C5G-RACKTRAY.yaml
+++ b/device-types/Palo Alto/PAN-ION-1200-C5G-RACKTRAY.yaml
@@ -5,7 +5,7 @@ slug: palo-alto-pan-ion-1200-c5g-racktray
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one cellular variant of an ION 1200 device in a four-post rack.
 device-bays:

--- a/device-types/Palo Alto/PAN-ION-1200-RACKTRAY.yaml
+++ b/device-types/Palo Alto/PAN-ION-1200-RACKTRAY.yaml
@@ -5,7 +5,7 @@ slug: palo-alto-pan-ion-1200-racktray
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one non-cellular ION 1200 device in a four-post rack.
 device-bays:

--- a/device-types/Palo Alto/PAN-ION-RACKTRAY-1200-S-C.yaml
+++ b/device-types/Palo Alto/PAN-ION-RACKTRAY-1200-S-C.yaml
@@ -5,7 +5,7 @@ slug: palo-alto-pan-ion-racktray-1200-s-c
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one 4G variant of an ION 1200 or ION 1200-S device in a four-post rack.
 device-bays:

--- a/device-types/Palo Alto/PAN-ION-RACKTRAY-1200-S-C5G.yaml
+++ b/device-types/Palo Alto/PAN-ION-RACKTRAY-1200-S-C5G.yaml
@@ -5,7 +5,7 @@ slug: palo-alto-pan-ion-racktray-1200-s-c5g
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one non-cellular or 5G variant of an ION 1200 or 1200-S device in a four-post rack.
 device-bays:

--- a/device-types/Palo Alto/PAN-ION-RACKTRAY-3200.yaml
+++ b/device-types/Palo Alto/PAN-ION-RACKTRAY-3200.yaml
@@ -5,7 +5,7 @@ slug: palo-alto-pan-ion-racktray-3200
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one ION 3200 device in a four-post rack.
 device-bays:

--- a/device-types/Palo Alto/PAN-PA-400-POE-RACKTRAY.yaml
+++ b/device-types/Palo Alto/PAN-PA-400-POE-RACKTRAY.yaml
@@ -6,7 +6,7 @@ part_number: PAN-PA-400-POE-RACKTRAY
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one PA-415 or PA-445 firewall in a four-post rack.
 device-bays:

--- a/device-types/Palo Alto/PAN-PA-400-RACKTRAY.yaml
+++ b/device-types/Palo Alto/PAN-PA-400-RACKTRAY.yaml
@@ -6,7 +6,7 @@ part_number: PAN-PA-400-RACKTRAY
 u_height: 1
 subdevice_role: parent
 is_full_depth: true
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds one or two PA-440, PA-450, or PA-460 firewalls in a four-post rack.
 device-bays:

--- a/device-types/Panduit/CDPP8RG-S.yaml
+++ b/device-types/Panduit/CDPP8RG-S.yaml
@@ -5,7 +5,7 @@ slug: panduit-cdpp8rg-s
 part_number: CDPP8RG-S
 u_height: 3
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '01'
     type: 8p8c

--- a/device-types/Panduit/CDPP8RG.yaml
+++ b/device-types/Panduit/CDPP8RG.yaml
@@ -5,7 +5,7 @@ slug: panduit-cdpp8rg
 part_number: CDPP8RG
 u_height: 3
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '01'
     type: 8p8c

--- a/device-types/Panduit/CP24BLY.yaml
+++ b/device-types/Panduit/CP24BLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cp24bly
 part_number: CP24BLY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CP48BLY.yaml
+++ b/device-types/Panduit/CP48BLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cp48bly
 part_number: CP48BLY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '01'
     type: 8p8c

--- a/device-types/Panduit/CP48HDBL.yaml
+++ b/device-types/Panduit/CP48HDBL.yaml
@@ -5,7 +5,7 @@ slug: panduit-cp48hdbl
 part_number: CP48HDBL
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '01'
     type: 8p8c

--- a/device-types/Panduit/CPA24BLY.yaml
+++ b/device-types/Panduit/CPA24BLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpa24bly
 part_number: CPA24BLY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPA48BLY.yaml
+++ b/device-types/Panduit/CPA48BLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpa48bly
 part_number: CPA48BLY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPA48HDBL.yaml
+++ b/device-types/Panduit/CPA48HDBL.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpa48hdbl
 part_number: CPA48HDBL
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '01'
     type: 8p8c

--- a/device-types/Panduit/CPP24FMWBLY.yaml
+++ b/device-types/Panduit/CPP24FMWBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpp24fmwbly
 part_number: CPP24FMWBLY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPP24WBLY.yaml
+++ b/device-types/Panduit/CPP24WBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpp24wbly
 part_number: CPP24WBLY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPP48FMWBLY.yaml
+++ b/device-types/Panduit/CPP48FMWBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpp48fmwbly
 part_number: CPP48FMWBLY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPP48HDEWBL.yaml
+++ b/device-types/Panduit/CPP48HDEWBL.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpp48hdewbl
 part_number: CPP48HDEWBL
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPP48WBLY.yaml
+++ b/device-types/Panduit/CPP48WBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpp48wbly
 part_number: CPP48WBLY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPP72FMWBLY.yaml
+++ b/device-types/Panduit/CPP72FMWBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cpp72fmwbly
 part_number: CPP72FMWBLY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPPA24FMWBLY.yaml
+++ b/device-types/Panduit/CPPA24FMWBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cppa24fmwbly
 part_number: CPPA24FMWBLY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPPA48FMWBLY.yaml
+++ b/device-types/Panduit/CPPA48FMWBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cppa48fmwbly
 part_number: CPPA48FMWBLY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPPA48HDWBLY.yaml
+++ b/device-types/Panduit/CPPA48HDWBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cppa48hdwbly
 part_number: CPPA48HDWBLY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/CPPA72FMWBLY.yaml
+++ b/device-types/Panduit/CPPA72FMWBLY.yaml
@@ -5,7 +5,7 @@ slug: panduit-cppa72fmwbly
 part_number: CPPA72FMWBLY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/DP245E88TGY.yaml
+++ b/device-types/Panduit/DP245E88TGY.yaml
@@ -5,7 +5,7 @@ slug: panduit-dp245e88tgy
 part_number: DP245E88TGY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/DP24688TGY.yaml
+++ b/device-types/Panduit/DP24688TGY.yaml
@@ -5,7 +5,7 @@ slug: panduit-dp24688tgy
 part_number: DP24688TGY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/DP246X88TGY.yaml
+++ b/device-types/Panduit/DP246X88TGY.yaml
@@ -5,7 +5,7 @@ slug: panduit-dp246x88tgy
 part_number: DP246X88TGY
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/DP485E88TGY.yaml
+++ b/device-types/Panduit/DP485E88TGY.yaml
@@ -5,7 +5,7 @@ slug: panduit-dp485e88tgy
 part_number: DP485E88TGY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/DP48688TGY.yaml
+++ b/device-types/Panduit/DP48688TGY.yaml
@@ -5,7 +5,7 @@ slug: panduit-dp48688tgy
 part_number: DP48688TGY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/DP486X88TGY.yaml
+++ b/device-types/Panduit/DP486X88TGY.yaml
@@ -5,7 +5,7 @@ slug: panduit-dp486x88tgy
 part_number: DP486X88TGY
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true
 front-ports:
   - name: '01'

--- a/device-types/Panduit/FCE1.yaml
+++ b/device-types/Panduit/FCE1.yaml
@@ -6,7 +6,7 @@ part_number: FCE1
 u_height: 1
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: A
   - name: B

--- a/device-types/Panduit/FCE1U.yaml
+++ b/device-types/Panduit/FCE1U.yaml
@@ -6,7 +6,7 @@ part_number: FCE1U
 u_height: 1
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 front_image: true
 device-bays:
   - name: A

--- a/device-types/Panduit/FCE2.yaml
+++ b/device-types/Panduit/FCE2.yaml
@@ -6,7 +6,7 @@ part_number: FCE2
 u_height: 2
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: A
   - name: B

--- a/device-types/Panduit/FCE2U.yaml
+++ b/device-types/Panduit/FCE2U.yaml
@@ -6,7 +6,7 @@ part_number: FCE2U
 u_height: 2
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 front_image: true
 device-bays:
   - name: A

--- a/device-types/Panduit/FMD1.yaml
+++ b/device-types/Panduit/FMD1.yaml
@@ -6,7 +6,7 @@ part_number: FMD1
 u_height: 1
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: '01'
   - name: '02'

--- a/device-types/Panduit/FMD2.yaml
+++ b/device-types/Panduit/FMD2.yaml
@@ -6,7 +6,7 @@ part_number: FMD2
 u_height: 2
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: '01'
   - name: '02'

--- a/device-types/Panduit/FRME1.yaml
+++ b/device-types/Panduit/FRME1.yaml
@@ -6,7 +6,7 @@ part_number: FRME1
 u_height: 1
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 module-bays:
   - name: A
     position: A

--- a/device-types/Panduit/FRME2.yaml
+++ b/device-types/Panduit/FRME2.yaml
@@ -6,7 +6,7 @@ part_number: FRME2
 u_height: 2
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 module-bays:
   - name: A
     position: A

--- a/device-types/Panduit/FRME4.yaml
+++ b/device-types/Panduit/FRME4.yaml
@@ -6,7 +6,7 @@ part_number: FRME4
 u_height: 4
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 module-bays:
   - name: A
     position: A

--- a/device-types/Panduit/FWME2.yaml
+++ b/device-types/Panduit/FWME2.yaml
@@ -6,7 +6,7 @@ part_number: FWME2
 u_height: 0
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: '01'
   - name: '02'

--- a/device-types/Panduit/FWME4.yaml
+++ b/device-types/Panduit/FWME4.yaml
@@ -6,7 +6,7 @@ part_number: FWME4
 u_height: 0
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: '01'
   - name: '02'

--- a/device-types/Panduit/FWME8.yaml
+++ b/device-types/Panduit/FWME8.yaml
@@ -6,7 +6,7 @@ part_number: FWME8
 u_height: 0
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: '01'
   - name: '02'

--- a/device-types/Panduit/WMPF1E.yaml
+++ b/device-types/Panduit/WMPF1E.yaml
@@ -5,5 +5,5 @@ slug: panduit-wmpf1e
 part_number: WMPF1E
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front_image: true

--- a/device-types/Rackmount IT/RM-WG-T6.yaml
+++ b/device-types/Rackmount IT/RM-WG-T6.yaml
@@ -5,7 +5,7 @@ slug: rackmount-it-rm-wg-t6
 u_height: 1
 subdevice_role: parent
 is_full_depth: false
-is_powered: false
+_is_powered: false
 airflow: passive
 comments: Holds Watchguard T20, T25, T40 and T45
 front_image: true

--- a/device-types/Rockwell Automation/1756-A10.yaml
+++ b/device-types/Rockwell Automation/1756-A10.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a10
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A10K.yaml
+++ b/device-types/Rockwell Automation/1756-A10K.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a10k
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A10XT.yaml
+++ b/device-types/Rockwell Automation/1756-A10XT.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a10xt
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A13.yaml
+++ b/device-types/Rockwell Automation/1756-A13.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a13
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A13K.yaml
+++ b/device-types/Rockwell Automation/1756-A13K.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a13k
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A17.yaml
+++ b/device-types/Rockwell Automation/1756-A17.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a17
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A17K.yaml
+++ b/device-types/Rockwell Automation/1756-A17K.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a17k
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A4.yaml
+++ b/device-types/Rockwell Automation/1756-A4.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a4
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A4K.yaml
+++ b/device-types/Rockwell Automation/1756-A4K.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a4k
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A7.yaml
+++ b/device-types/Rockwell Automation/1756-A7.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a7
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A7K.yaml
+++ b/device-types/Rockwell Automation/1756-A7K.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a7k
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/Rockwell Automation/1756-A7XT.yaml
+++ b/device-types/Rockwell Automation/1756-A7XT.yaml
@@ -6,7 +6,7 @@ slug: rockwell-automation-1756-a7xt
 u_height: 3
 is_full_depth: false
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Power Supply
   - name: Slot 0

--- a/device-types/SNR/SNR-FB-ORG-3.yaml
+++ b/device-types/SNR/SNR-FB-ORG-3.yaml
@@ -4,6 +4,6 @@ model: SNR-FB-ORG-3
 comments: Cable organiser with cover, 1 RU
 slug: snr-fb-org-3
 part_number: SNR-FB-ORG-3
-is_powered: false
+_is_powered: false
 u_height: 1
 is_full_depth: false

--- a/device-types/SSD/SKOS-1U-3B.yaml
+++ b/device-types/SSD/SKOS-1U-3B.yaml
@@ -5,7 +5,7 @@ slug: ssd-skos-1u-3b
 comments: '[1U Rack Mount Enclosure up to 3 x optic Panels, 48 Fibers (LC)](https://www.ssd.ru/kross-shkos-l-1u-2-korpus-b-planok-b-zip-b-kassety/)'
 part_number: 130308-00048
 airflow: passive
-is_powered: false
+_is_powered: false
 is_full_depth: false
 weight: 2.4
 weight_unit: kg

--- a/device-types/Schweitzer Engineering Laboratories/SEL-451-6-SV.yaml
+++ b/device-types/Schweitzer Engineering Laboratories/SEL-451-6-SV.yaml
@@ -4,7 +4,6 @@ model: SEL-451-6 SV
 slug: schweitzer-engineering-laboratories-sel-451-6-sv
 u_height: 4
 is_full_depth: false
-is_powered: true
 comments: SEL Time-Domain Link (TiDL) technology is a protectioncentered digital secondary system solution engineered with simplicity in mind. This technology
   minimizes cybersecurity risks and network engineering by using point-to-point communications and a nonroutable protocol.
 

--- a/device-types/Schweitzer Engineering Laboratories/SEL-451-6-TIDL.yaml
+++ b/device-types/Schweitzer Engineering Laboratories/SEL-451-6-TIDL.yaml
@@ -4,7 +4,6 @@ model: SEL-451-6 TiDL
 slug: schweitzer-engineering-laboratories-sel-451-6-tidl
 u_height: 4
 is_full_depth: false
-is_powered: true
 comments: SEL Time-Domain Link (TiDL) technology is a protectioncentered digital secondary system solution engineered with simplicity in mind. This technology
   minimizes cybersecurity risks and network engineering by using point-to-point communications and a nonroutable protocol \ Communications Protocols - FTP,
   HTTP, TelNet, SEL ASCII, SEL Fast Message, Synchrophasors, DNP3, PRP, PTPv2, IEC 61850 v2 (optional) \

--- a/device-types/Schweitzer Engineering Laboratories/sel-2242-10-bay-chassis-backplane.yml
+++ b/device-types/Schweitzer Engineering Laboratories/sel-2242-10-bay-chassis-backplane.yml
@@ -5,7 +5,6 @@ slug: schweitzer-engineering-laboratories-sel-2242-10-bay-chassis-backplane
 description: The SEL-2242 10-bay Chassis/Backplane is a 10-slot chassis for SEL Axion systems
 u_height: 2
 is_full_depth: false
-is_powered: true
 module-bays:
   - name: Slot A
     position: A

--- a/device-types/Schweitzer Engineering Laboratories/sel-2242-4-bay-chassis-backplane.yml
+++ b/device-types/Schweitzer Engineering Laboratories/sel-2242-4-bay-chassis-backplane.yml
@@ -5,7 +5,6 @@ slug: schweitzer-engineering-laboratories-sel-2242-4-bay-chassis-backplane
 description: The SEL-2242 4-bay Chassis/Backplane is a 4-slot chassis for SEL Axion systems
 u_height: 2
 is_full_depth: false
-is_powered: true
 module-bays:
   - name: Slot A
     position: A

--- a/device-types/Schweitzer Engineering Laboratories/sel-451-5-relay.yaml
+++ b/device-types/Schweitzer Engineering Laboratories/sel-451-5-relay.yaml
@@ -4,7 +4,6 @@ model: SEL-451-5 Relay
 slug: schweitzer-engineering-laboratories-sel-451-5-relay
 u_height: 2
 is_full_depth: false
-is_powered: true
 comments: Advanced feeder protection and complete substation bay control in one economical system \ Communications Protocols; FTP, HTTP, TelNet, SEL ASCII,
   SEL Fast Message, Synchrophasors, DNP3, PRP, PTPv2, IEC 61850 v2 (optional)
 

--- a/device-types/Siemon/HD5-16.yaml
+++ b/device-types/Siemon/HD5-16.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd5-16
 part_number: HD5-16
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD5-24.yaml
+++ b/device-types/Siemon/HD5-24.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd5-24
 part_number: HD5-24
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD5-24A.yaml
+++ b/device-types/Siemon/HD5-24A.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd5-24a
 part_number: HD5-24A
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD5-32.yaml
+++ b/device-types/Siemon/HD5-32.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd5-32
 part_number: HD5-32
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD5-48.yaml
+++ b/device-types/Siemon/HD5-48.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd5-48
 part_number: HD5-48
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD5-48A.yaml
+++ b/device-types/Siemon/HD5-48A.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd5-48a
 part_number: HD5-48A
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD5-96.yaml
+++ b/device-types/Siemon/HD5-96.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd5-96
 part_number: HD5-96
 u_height: 4
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD6-24.yaml
+++ b/device-types/Siemon/HD6-24.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd6-24
 part_number: HD6-24
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD6-24A.yaml
+++ b/device-types/Siemon/HD6-24A.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd6-24a
 part_number: HD6-24A
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD6-32.yaml
+++ b/device-types/Siemon/HD6-32.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd6-32
 part_number: HD6-32
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD6-48.yaml
+++ b/device-types/Siemon/HD6-48.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd6-48
 part_number: HD6-48
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD6-48A.yaml
+++ b/device-types/Siemon/HD6-48A.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd6-48a
 part_number: HD6-48A
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Siemon/HD6-96.yaml
+++ b/device-types/Siemon/HD6-96.yaml
@@ -5,7 +5,7 @@ slug: siemon-hd6-96
 part_number: HD6-96
 u_height: 4
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1'
     type: 8p8c

--- a/device-types/Solid Optics/SO-CHASSIS-MOD4.yml
+++ b/device-types/Solid Optics/SO-CHASSIS-MOD4.yml
@@ -6,7 +6,7 @@ u_height: 1
 is_full_depth: false
 subdevice_role: parent
 comments: 4 Slot LGX Chassis 1RU, 19" Suitable for MOD4 Mux
-is_powered: false
+_is_powered: false
 device-bays:
   - name: Lower Left
   - name: Lower Right

--- a/device-types/Solid Optics/SO-DWDM-MUX-8CH-Plus-UPG.yaml
+++ b/device-types/Solid Optics/SO-DWDM-MUX-8CH-Plus-UPG.yaml
@@ -4,7 +4,7 @@ model: SO-DWDM-MUX-8CH+UPG
 slug: solid-optics-so-dwdm-mux-8ch-plus-upg
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: C20
     type: lc

--- a/device-types/Solid Optics/SO-DWDM-MUX-CH20-35-Plus-UPG-Plus-MON.yaml
+++ b/device-types/Solid Optics/SO-DWDM-MUX-CH20-35-Plus-UPG-Plus-MON.yaml
@@ -4,7 +4,7 @@ model: SO-DWDM-MUX-CH20-35+UPG+MON
 slug: solid-optics-so-dwdm-mux-ch20-35-plus-upg-plus-mon
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: C20
     type: lc

--- a/device-types/Solid Optics/SO-MOD4-3xMPO-MMF-24xLC.yml
+++ b/device-types/Solid Optics/SO-MOD4-3xMPO-MMF-24xLC.yml
@@ -5,7 +5,7 @@ slug: solid-optics-so-mod4-3xmpo-mmf-24xlc
 u_height: 0
 is_full_depth: false
 subdevice_role: child
-is_powered: false
+_is_powered: false
 front-ports:
   - name: A1
     type: lc

--- a/device-types/TrendNet/TC-P16C5E.yaml
+++ b/device-types/TrendNet/TC-P16C5E.yaml
@@ -4,7 +4,7 @@ model: TC-P16C5E
 slug: trendnet-tc-p16c5e
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/TrendNet/TC-P24C5E.yaml
+++ b/device-types/TrendNet/TC-P24C5E.yaml
@@ -4,7 +4,7 @@ model: TC-P24C5E
 slug: trendnet-tc-p24c5e
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/TrendNet/TC-P48C5E.yaml
+++ b/device-types/TrendNet/TC-P48C5E.yaml
@@ -4,7 +4,7 @@ model: TC-P48C5E
 slug: trendnet-tc-p48c5e
 u_height: 2
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: Port 1
     type: 8p8c

--- a/device-types/Ubiquiti/Surge-Protector.yaml
+++ b/device-types/Ubiquiti/Surge-Protector.yaml
@@ -5,7 +5,7 @@ slug: ubiquiti-surge-protector
 part_number: ETH-SP-G2
 u_height: 0
 is_full_depth: false
-is_powered: false
+_is_powered: false
 comments: '[Ethernet Surge Protector](https://www.ui.com/accessories/ethernet-surge-protector/)'
 front-ports:
   - name: '1'

--- a/device-types/Ubiquiti/UACC-AI-Port-RM.yaml
+++ b/device-types/Ubiquiti/UACC-AI-Port-RM.yaml
@@ -6,7 +6,7 @@ part_number: UACC-AI-Port-RM
 u_height: 1
 is_full_depth: false
 airflow: passive
-is_powered: false
+_is_powered: false
 subdevice_role: parent
 weight: 650
 weight_unit: g

--- a/device-types/Uptime Industries/Bladerunner-1.0-20-blade.yaml
+++ b/device-types/Uptime Industries/Bladerunner-1.0-20-blade.yaml
@@ -15,7 +15,7 @@ weight: 1.5
 weight_unit: kg
 airflow: passive
 subdevice_role: parent
-is_powered: false
+_is_powered: false
 # Can fit 20 Compute Blades
 device-bays:
   - name: '1'

--- a/device-types/ghipsystems/GS5104-1471-EC.yaml
+++ b/device-types/ghipsystems/GS5104-1471-EC.yaml
@@ -6,7 +6,7 @@ comments: '[4 Channels 1471-1531nm, LC/UPC, Dual Fiber, CWDM](https://ghipsystem
 part_number: GS5104-1471-EC
 u_height: 1
 is_full_depth: false
-is_powered: false
+_is_powered: false
 front-ports:
   - name: '1471'
     type: lc

--- a/schema/devicetype.json
+++ b/schema/devicetype.json
@@ -46,8 +46,11 @@
         "subdevice_role": {
             "$ref": "urn:devicetype-library:generated-schema#/definitions/subdevice-role"
         },
-        "is_powered": {
-          "type": "boolean"
+        "_is_powered": {
+            "title": "Device requires Power",
+            "description": "Custom non-NetBox property used for power validation",
+            "type": "boolean",
+            "default": true
         },
         "console-ports": {
             "type": "array",

--- a/tests/device_types.py
+++ b/tests/device_types.py
@@ -73,13 +73,14 @@ class DeviceType:
         return True
 
     def validate_power(self):
+        CUSTOM_POWERED_PROPERTY = '_is_powered'
         CUSTOM_POWER_SOURCE_PROPERTY = '_is_power_source'
 
         # Check if power-ports exists
         if self.definition.get('power-ports', False):
-            # Verify that is_powered is not set to False. If so, there should not be any power-ports defined
-            if not self.definition.get('is_powered', True):
-                self.failureMessage = f'{self.file_path} has is_powered set to False, but "power-ports" are defined.'
+            # Verify that _is_powered is not set to False. If so, there should not be any power-ports defined
+            if not self.definition.get(CUSTOM_POWERED_PROPERTY, True):
+                self.failureMessage = f'{self.file_path} has {CUSTOM_POWERED_PROPERTY} set to False, but "power-ports" are defined.'
                 return False
             return True
 
@@ -116,11 +117,11 @@ class DeviceType:
             # There is not a standardized way to define PSUs that are module bays, so we will just assume they are valid
             return True
 
-        # As the very last case, check if is_powered is defined and is False. Otherwise assume the device is powered
-        if not self.definition.get('is_powered', True): # is_powered defaults to True
-            # Arriving here means is_powered is set to False, so verify that there are no power-outlets defined
+        # As the very last case, check if _is_powered is defined and is False. Otherwise assume the device is powered
+        if not self.definition.get(CUSTOM_POWERED_PROPERTY, True):
+            # Arriving here means _is_powered is set to False, so verify that there are no power-outlets defined
             if self.definition.get('power-outlets', False):
-                self.failureMessage = f'{self.file_path} has is_powered set to False, but "power-outlets" are defined.'
+                self.failureMessage = f'{self.file_path} has {CUSTOM_POWERED_PROPERTY} set to False, but "power-outlets" are defined.'
                 return False
             return True
 


### PR DESCRIPTION
~~Small~~ follow-up to #3391.

~~Fix the `poe` to `_is_power_source` rename for ports in the README, forgot that in the original PR.~~

Rename the device-type-level custom property `is_powered` to `_is_powered`. The leading underscore makes it obvious that it's a custom property, and is then consistent with the ports' `_is_power_source`. Also remove it from device types if it's true (the default).