### PR TITLE
add Cisco/WS-C3550-48-SMI.yaml

### DIFF
--- a/device-types/Cisco/WS-C3550-48-SMI.yaml
+++ b/device-types/Cisco/WS-C3550-48-SMI.yaml
@@ -3,10 +3,11 @@ manufacturer: Cisco
 model: WS-C3550-48-SMI
 slug: cisco-ws-c3550-48-smi
 part_number: WS-C3550-48-SMI
-description: 'Cisco Catalyst 3550 48 10/100 baseT ports + 2 Gig uplinks fixed configuration Layer 2/3 Ethernet Switch'
+description: Cisco Catalyst 3550 48 10/100 baseT ports + 2 Gig uplinks fixed configuration Layer 2/3 Ethernet Switch
 u_height: 1
 weight: 5.9
 weight_unit: kg
+airflow: side-to-rear
 is_full_depth: true
 console-ports:
   - name: con 0


### PR DESCRIPTION
Cisco WS-C3550-48-SMI Catalyst 3550 10/100 48-Port Switch 
This is an EOL model, but since the 24 ports model is listed, you should add this one as well.