### PR TITLE
Add CE6865-48S8CQ-EI.yaml

### DIFF
--- a/device-types/Huawei/CE6865-48S8CQ-EI.yaml
+++ b/device-types/Huawei/CE6865-48S8CQ-EI.yaml
@@ -1,0 +1,141 @@
+---
+manufacturer: Huawei
+model: CE6865-48S8CQ-EI
+slug: huawei-ce6865-48s8cq-ei
+part_number: 02351RFC
+description: CE6865-48S8CQ switch (48*25G SFP28, 8*100G QSFP28)
+u_height: 1
+is_full_depth: true
+weight: 6.2
+weight_unit: kg
+comments: CE6865-48S8CQ-EI (https://support.huawei.com/enterprise/en/doc/EDOC1000019246/3082bcde/ce6865-48s8cq-ei)
+console-ports:
+  - name: console0
+    type: rj-45
+    label: CONSOLE
+module-bays:
+  - name: FAN1
+    position: Fan 1
+  - name: FAN2
+    position: Fan 2
+  - name: PSU1
+    position: PSU 1
+  - name: PSU2
+    position: PSU 2
+interfaces:
+  - name: MEth0/0/0
+    type: 1000base-t
+    label: ETH
+    mgmt_only: true
+  - name: 25GE1/0/1
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/2
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/3
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/4
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/5
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/6
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/7
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/8
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/9
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/10
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/11
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/12
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/13
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/14
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/15
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/16
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/17
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/18
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/19
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/20
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/21
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/22
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/23
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/24
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/25
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/26
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/27
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/28
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/29
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/30
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/31
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/32
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/33
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/34
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/35
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/36
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/37
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/38
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/39
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/40
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/41
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/42
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/43
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/44
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/45
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/46
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/47
+    type: 25gbase-x-sfp28
+  - name: 25GE1/0/48
+    type: 25gbase-x-sfp28
+  - name: 100GE1/0/1
+    type: 100gbase-x-qsfp28
+  - name: 100GE1/0/2
+    type: 100gbase-x-qsfp28
+  - name: 100GE1/0/3
+    type: 100gbase-x-qsfp28
+  - name: 100GE1/0/4
+    type: 100gbase-x-qsfp28
+  - name: 100GE1/0/5
+    type: 100gbase-x-qsfp28
+  - name: 100GE1/0/6
+    type: 100gbase-x-qsfp28
+  - name: 100GE1/0/7
+    type: 100gbase-x-qsfp28
+  - name: 100GE1/0/8
+    type: 100gbase-x-qsfp28


### PR DESCRIPTION
Huawei CloudEngine 6865, 48x25GE, 8x100GE

Link: https://support.huawei.com/enterprise/en/doc/EDOC1000019246/3082bcde/ce6865-48s8cq-ei
Link: https://info.support.huawei.com/info-finder/vue/search-center/en/enterprise/routers/ce6800-pid-C00000000059/hardwarecenter?keyword=02351RFC&productModel=CE6865-48S8CQ-EI#specifacations

This device __does not__ have a fixed air flow direction, so `airflow` is not specified. The direction of air flow is determined by the fan modules installed.