### PR TITLE
schema/moduletype: Add `airflow` property

### DIFF
--- a/schema/moduletype.json
+++ b/schema/moduletype.json
@@ -15,6 +15,9 @@
             "type": "string",
             "maxLength": 50
         },
+        "airflow": {
+            "$ref": "urn:devicetype-library:generated-schema#/definitions/airflow"
+        },
         "weight": {
             "$ref": "urn:devicetype-library:reusable#/definitions/weight"
         },


### PR DESCRIPTION
This is useful for fan modules, as well as hot plug power supply modules with built-in fans.

Examples would be #3505 and #3508: both those PRs introduce 2 parts each with opposite air flow directions.