### PR TITLE
Add HPE P65741-B21 iLO enablement kit.

### DIFF
--- a/module-types/HPE/P65741-B21.yaml
+++ b/module-types/HPE/P65741-B21.yaml
@@ -1,0 +1,12 @@
+---
+manufacturer: HPE
+model: ML30 Gen11 iLO/NIC/M.2/COM Port Kit
+part_number: P65741-B21
+console-ports:
+  - name: Serial
+    type: de-9
+interfaces:
+  - name: iLO
+    type: 1000base-t
+    enabled: true
+    mgmt_only: true


### PR DESCRIPTION
iLO kit for new HPE Proliant Microserver Gen11 boxes.
Also has M.2 bay, but not sure if adding that is better handled by "disks" tab in device.