### PR TITLE
Delete non existing interface (Ge1/0/0) on HPE 5130 Serie

### DIFF
--- a/device-types/HPE/FlexNetwork-5130-24G-4SFPP-EI.yml
+++ b/device-types/HPE/FlexNetwork-5130-24G-4SFPP-EI.yml
@@ -16,8 +16,6 @@ power-ports:
     type: iec-60320-c14
     maximum_draw: 26
 interfaces:
-  - name: GigabitEthernet1/0/0
-    type: 1000base-t
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2

--- a/device-types/HPE/FlexNetwork-5130-24G-PoEP-4SFPP-EI.yml
+++ b/device-types/HPE/FlexNetwork-5130-24G-PoEP-4SFPP-EI.yml
@@ -16,8 +16,6 @@ power-ports:
     type: iec-60320-c14
     maximum_draw: 460
 interfaces:
-  - name: GigabitEthernet1/0/0
-    type: 1000base-t
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2

--- a/device-types/HPE/FlexNetwork-5130-48G-4SFPP-1-slot-HI.yml
+++ b/device-types/HPE/FlexNetwork-5130-48G-4SFPP-1-slot-HI.yml
@@ -23,8 +23,6 @@ interfaces:
   - name: Management
     type: 1000base-t
     mgmt_only: true
-  - name: GigabitEthernet1/0/0
-    type: 1000base-t
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2

--- a/device-types/HPE/FlexNetwork-5130-48G-4SFPP-EI.yml
+++ b/device-types/HPE/FlexNetwork-5130-48G-4SFPP-EI.yml
@@ -16,8 +16,6 @@ power-ports:
     type: iec-60320-c14
     maximum_draw: 45
 interfaces:
-  - name: GigabitEthernet1/0/0
-    type: 1000base-t
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2

--- a/device-types/HPE/FlexNetwork-5130-48G-POEP-4SFPP-1-slot-HI.yml
+++ b/device-types/HPE/FlexNetwork-5130-48G-POEP-4SFPP-1-slot-HI.yml
@@ -23,8 +23,6 @@ interfaces:
   - name: Management
     type: 1000base-t
     mgmt_only: true
-  - name: GigabitEthernet1/0/0
-    type: 1000base-t
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2

--- a/device-types/HPE/FlexNetwork-5130-48G-PoEP-4SFPP-EI.yml
+++ b/device-types/HPE/FlexNetwork-5130-48G-PoEP-4SFPP-EI.yml
@@ -13,8 +13,6 @@ power-ports:
     type: iec-60320-c14
     maximum_draw: 490
 interfaces:
-  - name: GigabitEthernet1/0/0
-    type: 1000base-t
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2


### PR DESCRIPTION
Delete non existing interface (Ge1/0/0)