### PR TITLE
fix Juniper SRX1600 port names

### DIFF
--- a/device-types/Juniper/SRX1600.yaml
+++ b/device-types/Juniper/SRX1600.yaml
@@ -53,17 +53,17 @@ interfaces:
     type: 1000base-t
   - name: ge-0/0/15
     type: 1000base-t
-  - name: et-0/1/16
+  - name: et-0/1/0
     type: 25gbase-x-sfp28
-  - name: et-0/1/17
+  - name: et-0/1/1
     type: 25gbase-x-sfp28
-  - name: xe-0/2/18
+  - name: xe-0/2/0
     type: 10gbase-x-sfpp
-  - name: xe-0/2/19
+  - name: xe-0/2/1
     type: 10gbase-x-sfpp
-  - name: xe-0/2/20
+  - name: xe-0/2/2
     type: 10gbase-x-sfpp
-  - name: xe-0/2/21
+  - name: xe-0/2/3
     type: 10gbase-x-sfpp
 module-bays:
   - name: PSU 0


### PR DESCRIPTION
This PR fixes the port names for the Juniper SRX1600 to match the [documentation](https://www.juniper.net/documentation//us/en/software/junos/interfaces-security-devices/topics/topic-map/port-speed-srx-firewalls.html#concept_igk_dsh_vcc__d146e185).