### PR TITLE
Adding Cisco Meraki MS390-24UX device type

### DIFF
--- a/device-types/Cisco/Meraki-MS390-24UX.yaml
+++ b/device-types/Cisco/Meraki-MS390-24UX.yaml
@@ -8,7 +8,7 @@ is_full_depth: true
 airflow: front-to-rear
 weight: 8.25
 weight_unit: kg
-comments: [Meraki MS390-24UX Datasheet](https://documentation.meraki.com/MS/Product_Information/Overviews_and_Datasheets/MS390_Datasheet)
+comments: '[Meraki MS390-24UX Datasheet](https://documentation.meraki.com/MS/Product_Information/Overviews_and_Datasheets/MS390_Datasheet)'
 module-bays:
   - name: PSU 0
     position: '0'


### PR DESCRIPTION
I added this device type to my netbox, so I made this commit adds the Cisco Meraki MS390-24UX switch to the device-type library.

- 24 × multigigabit (mGbE) UPoE/802.3bt access ports
- 4 × 10 G SFP+ uplink ports
- 2 × 40 G QSFP dedicated stacking ports
- 1 × dedicated management port
- Dual IEC C14 power inputs (Slot 0, Slot 1)
- 1 RU height, full depth, 8.25 kg
- Idle/maximum power draw: 162.7 W / 809.9 W

Reference: [Meraki MS390-24UX Datasheet](https://documentation.meraki.com/MS/Product_Information/Overviews_and_Datasheets/MS390_Datasheet)