### PR TITLE
Add Ubiquiti EdgeSwitch ES-8-150W

### DIFF
--- a/device-types/Ubiquiti/ES-8-150W.yaml
+++ b/device-types/Ubiquiti/ES-8-150W.yaml
@@ -18,41 +18,41 @@ console-ports:
   - name: Console
     type: rj-45
 interfaces:
-  - name: '0/1'
+  - name: 0/1
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: '0/2'
+  - name: 0/2
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: '0/3'
+  - name: 0/3
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: '0/4'
+  - name: 0/4
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: '0/5'
+  - name: 0/5
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: '0/6'
+  - name: 0/6
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: '0/7'
+  - name: 0/7
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: '0/8'
+  - name: 0/8
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: '0/9'
+  - name: 0/9
     type: 1000base-x-sfp
-  - name: '0/10'
+  - name: 0/10
     type: 1000base-x-sfp
 power-ports:
   - name: PSU1


### PR DESCRIPTION
Adding device type for Ubiquiti EdgeSwitch ES-8-150W.
   
   - 8x 1000BASE-T PoE+ ports (802.3at)
   - 2x SFP ports
   - 150W total power budget
   - Based on official datasheet: https://dl.ubnt.com/datasheets/edgemax/EdgeSwitch_DS.pdf