### PR TITLE
Fixes manufacturer's name on N00T01-FA-L-IO.yaml

### DIFF
--- a/device-types/MDX/N00T01-FA-L-IO.yaml
+++ b/device-types/MDX/N00T01-FA-L-IO.yaml
@@ -1,5 +1,5 @@
 ---
-manufacturer: mdx
+manufacturer: MDX
 model: N00T01-FA-L-IO
 slug: mdx-n00t01-fa-l-io
 part_number: N00T01-FA-L-IO


### PR DESCRIPTION
Fixes manufacturer's name from lower case to upper: 'mdx'-> 'MDX'.

Print below shows current error:
<img width="1357" height="249" alt="image" src="https://github.com/user-attachments/assets/645118d9-2ee9-4261-85af-9f77e0ef17d0" />
