### PR TITLE
Add APC NetShelter AR1300

### DIFF
--- a/rack-types/APC/AR1300.yaml
+++ b/rack-types/APC/AR1300.yaml
@@ -5,7 +5,7 @@ slug: apc-ar1300
 form_factor: 4-post-cabinet
 description: APC NetShelter SX, Server Rack Enclosure, 42U, Black, 1991H x 600W x 1070D mm [TAA]
 width: 19
-u_height: 48
+u_height: 42
 starting_unit: 1
 outer_width: 600
 outer_height: 1991


### PR DESCRIPTION
Adding rack type for APC NetShelter SX AR1300.

- 4 post cabinet rack - 42U

- From documentation on: https://www.se.com/us/en/product/AR3100/apc-netshelter-sx-server-rack-enclosure-42u-black-1991h-x-600w-x-1070d-mm-taa/