### PR TITLE
Add Commscope copper and fiber panel

### DIFF
--- a/device-types/Commscope/360-E-MOD-1U-24.yaml
+++ b/device-types/Commscope/360-E-MOD-1U-24.yaml
@@ -1,0 +1,185 @@
+---
+manufacturer: Commscope
+model: 360-E-MOD-1U-24
+slug: commscope-360-e-mod-1u-24
+description: SYSTIMAX 360-E-MOD-1U-24 - 360 Evolve 24-port RJ45 flat patch panel
+comments: '[Commscope SYSTIMAX 360-E-MOD-1U-24 Product Page](https://www.commscope.com/product-type/frames-panels-cassettes-modules/copper-panels-modules-cassettes/copper-panels/item760187187/)'
+part_number: '760187187'
+u_height: 1.0
+is_full_depth: false
+airflow: passive
+weight: 0.5
+weight_unit: kg
+front_image: false
+rear_image: false
+is_powered: false
+front-ports:
+  - name: '1'
+    type: 8p8c
+    rear_port: '1'
+    rear_port_position: 1
+  - name: '2'
+    type: 8p8c
+    rear_port: '2'
+    rear_port_position: 1
+  - name: '3'
+    type: 8p8c
+    rear_port: '3'
+    rear_port_position: 1
+  - name: '4'
+    type: 8p8c
+    rear_port: '4'
+    rear_port_position: 1
+  - name: '5'
+    type: 8p8c
+    rear_port: '5'
+    rear_port_position: 1
+  - name: '6'
+    type: 8p8c
+    rear_port: '6'
+    rear_port_position: 1
+  - name: '7'
+    type: 8p8c
+    rear_port: '7'
+    rear_port_position: 1
+  - name: '8'
+    type: 8p8c
+    rear_port: '8'
+    rear_port_position: 1
+  - name: '9'
+    type: 8p8c
+    rear_port: '9'
+    rear_port_position: 1
+  - name: '10'
+    type: 8p8c
+    rear_port: '10'
+    rear_port_position: 1
+  - name: '11'
+    type: 8p8c
+    rear_port: '11'
+    rear_port_position: 1
+  - name: '12'
+    type: 8p8c
+    rear_port: '12'
+    rear_port_position: 1
+  - name: '13'
+    type: 8p8c
+    rear_port: '13'
+    rear_port_position: 1
+  - name: '14'
+    type: 8p8c
+    rear_port: '14'
+    rear_port_position: 1
+  - name: '15'
+    type: 8p8c
+    rear_port: '15'
+    rear_port_position: 1
+  - name: '16'
+    type: 8p8c
+    rear_port: '16'
+    rear_port_position: 1
+  - name: '17'
+    type: 8p8c
+    rear_port: '17'
+    rear_port_position: 1
+  - name: '18'
+    type: 8p8c
+    rear_port: '18'
+    rear_port_position: 1
+  - name: '19'
+    type: 8p8c
+    rear_port: '19'
+    rear_port_position: 1
+  - name: '20'
+    type: 8p8c
+    rear_port: '20'
+    rear_port_position: 1
+  - name: '21'
+    type: 8p8c
+    rear_port: '21'
+    rear_port_position: 1
+  - name: '22'
+    type: 8p8c
+    rear_port: '22'
+    rear_port_position: 1
+  - name: '23'
+    type: 8p8c
+    rear_port: '23'
+    rear_port_position: 1
+  - name: '24'
+    type: 8p8c
+    rear_port: '24'
+    rear_port_position: 1
+rear-ports:
+  - name: '1'
+    type: 110-punch
+    positions: 1
+  - name: '2'
+    type: 110-punch
+    positions: 1
+  - name: '3'
+    type: 110-punch
+    positions: 1
+  - name: '4'
+    type: 110-punch
+    positions: 1
+  - name: '5'
+    type: 110-punch
+    positions: 1
+  - name: '6'
+    type: 110-punch
+    positions: 1
+  - name: '7'
+    type: 110-punch
+    positions: 1
+  - name: '8'
+    type: 110-punch
+    positions: 1
+  - name: '9'
+    type: 110-punch
+    positions: 1
+  - name: '10'
+    type: 110-punch
+    positions: 1
+  - name: '11'
+    type: 110-punch
+    positions: 1
+  - name: '12'
+    type: 110-punch
+    positions: 1
+  - name: '13'
+    type: 110-punch
+    positions: 1
+  - name: '14'
+    type: 110-punch
+    positions: 1
+  - name: '15'
+    type: 110-punch
+    positions: 1
+  - name: '16'
+    type: 110-punch
+    positions: 1
+  - name: '17'
+    type: 110-punch
+    positions: 1
+  - name: '18'
+    type: 110-punch
+    positions: 1
+  - name: '19'
+    type: 110-punch
+    positions: 1
+  - name: '20'
+    type: 110-punch
+    positions: 1
+  - name: '21'
+    type: 110-punch
+    positions: 1
+  - name: '22'
+    type: 110-punch
+    positions: 1
+  - name: '23'
+    type: 110-punch
+    positions: 1
+  - name: '24'
+    type: 110-punch
+    positions: 1

--- a/device-types/Commscope/360G2-1U-MOD-SD.yaml
+++ b/device-types/Commscope/360G2-1U-MOD-SD.yaml
@@ -2,9 +2,10 @@
 manufacturer: Commscope
 model: 360G2-1U-MOD-SD
 slug: commscope-360g2-1u-mod-sd
-comments: '[Commscope Product Page](https://www.commscope.com/product-type/cabinets-panels-enclosures/fiber-panels-cassettes/fiber-panels/item760193771/)'
+description: 360G2-1U-MOD-SD - G2 1U Sliding Modular Cassette 4-slot Fiber Panel, unloaded
+comments: '[Commscope Product Page](https://www.commscope.com/product-type/frames-panels-cassettes-modules/fiber-panels-modules-cassettes/fiber-panels/item760193771/)'
 part_number: '760193771'
-u_height: 1
+u_height: 1.0
 is_full_depth: false
 airflow: passive
 weight: 5.44

--- a/device-types/Commscope/HD-1U.yaml
+++ b/device-types/Commscope/HD-1U.yaml
@@ -1,0 +1,29 @@
+---
+manufacturer: Commscope
+model: HD-1U
+slug: commscope-hd-1u
+description: HD-1U - High Density 1U modular cassette sliding Panel, accepts (4) G2 modules or MPO panels, providing up to 48 duplex LC ports, or up to
+  32 MPO ports
+comments: '[Commscope HD-1U Product Page](https://www.commscope.com/product-type/frames-panels-cassettes-modules/fiber-panels-modules-cassettes/fiber-panels/item760209940/)'
+part_number: '760209940'
+u_height: 1.0
+is_full_depth: false
+airflow: passive
+weight: 5.63
+weight_unit: kg
+front_image: false
+rear_image: false
+is_powered: false
+module-bays:
+  - name: '1'
+    position: '1'
+    description: Accepts G2 modules or MPO panels
+  - name: '2'
+    position: '2'
+    description: Accepts G2 modules or MPO panels
+  - name: '3'
+    position: '3'
+    description: Accepts G2 modules or MPO panels
+  - name: '4'
+    position: '4'
+    description: Accepts G2 modules or MPO panels

--- a/device-types/Commscope/HD-2U.yaml
+++ b/device-types/Commscope/HD-2U.yaml
@@ -1,0 +1,41 @@
+---
+manufacturer: Commscope
+model: HD-2U
+slug: commscope-hd-2u
+description: HD-2U - High Density 2U modular cassette sliding Panel, accepts (8) G2 modules or MPO panels, providing up to 96 duplex LC ports or up to 64
+  MPO ports
+comments: '[Commscope HD-2U Product Page](https://www.commscope.com/product-type/frames-panels-cassettes-modules/fiber-panels-modules-cassettes/fiber-panels/item760209957/)'
+part_number: '760209957'
+u_height: 2.0
+is_full_depth: false
+airflow: passive
+weight: 7.71
+weight_unit: kg
+front_image: false
+rear_image: false
+is_powered: false
+module-bays:
+  - name: '1'
+    position: '1'
+    description: Accepts G2 modules or MPO panels
+  - name: '2'
+    position: '2'
+    description: Accepts G2 modules or MPO panels
+  - name: '3'
+    position: '3'
+    description: Accepts G2 modules or MPO panels
+  - name: '4'
+    position: '4'
+    description: Accepts G2 modules or MPO panels
+  - name: '5'
+    position: '5'
+    description: Accepts G2 modules or MPO panels
+  - name: '6'
+    position: '6'
+    description: Accepts G2 modules or MPO panels
+  - name: '7'
+    position: '7'
+    description: Accepts G2 modules or MPO panels
+  - name: '8'
+    position: '8'
+    description: Accepts G2 modules or MPO panels


### PR DESCRIPTION
Adds the following Commscope panels:

- [Commscope SYSTIMAX 360-E-MOD-1U-24 Product Page](https://www.commscope.com/product-type/frames-panels-cassettes-modules/copper-panels-modules-cassettes/copper-panels/item760187187/)
- [Commscope HD-1U Product Page](https://www.commscope.com/product-type/frames-panels-cassettes-modules/fiber-panels-modules-cassettes/fiber-panels/item760209940/)
- [Commscope HD-2U Product Page](https://www.commscope.com/product-type/frames-panels-cassettes-modules/fiber-panels-modules-cassettes/fiber-panels/item760209957/)

Updates the following Commscope panel:
- [Commscope 360G2-1U-MOD-SD Product Page](https://www.commscope.com/product-type/frames-panels-cassettes-modules/fiber-panels-modules-cassettes/fiber-panels/item760193771/)