### PR TITLE
Addition of the Cisco Meraki MS130-24P to the Library

### DIFF
--- a/device-types/Cisco/Meraki-MS130-24P.yaml
+++ b/device-types/Cisco/Meraki-MS130-24P.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Cisco
 model: Meraki MS130-24P
-slug: cisco-meraki-ms130-24P
+slug: cisco-meraki-ms130-24p
 part_number: Meraki MS130-24P
 weight: 5.5
 weight_unit: kg


### PR DESCRIPTION
This adds the Meraki MS130-24P to the list of available switches.