### PR TITLE
Add device type HT-EM4 for Hitron Technologies

### DIFF
--- a/device-types/Hitron/HT-EM4.yml
+++ b/device-types/Hitron/HT-EM4.yml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Hitron
-model: Hitron-HT-EM4
-slug: ht-em4
+model: HT-EM4
+slug: hitron-ht-em4
 part_number: 1420700003V2
 comments: '[Hitron HT-EM4](https://us.hitrontech.com/products/consumers/ht-em4-coax-to-ethernet-adapter/)'
 u_height: 0


### PR DESCRIPTION
adding Hitron HT-EM4 Moca Adaptor