### PR TITLE
fix(rack-types): max_weight and mounting_depth are expected to be int

### DIFF
--- a/rack-types/APC/AR1300.yaml
+++ b/rack-types/APC/AR1300.yaml
@@ -11,8 +11,8 @@ outer_width: 600
 outer_height: 1991
 outer_depth: 1070
 outer_unit: mm
-mounting_depth: 914.9
+mounting_depth: 914
 weight: 125.09
-max_weight: 1020.6
+max_weight: 1020
 weight_unit: kg
 desc_units: false

--- a/rack-types/APC/AR3107.yaml
+++ b/rack-types/APC/AR3107.yaml
@@ -12,6 +12,6 @@ outer_depth: 1070
 outer_unit: mm
 mounting_depth: 710
 weight: 138.23
-max_weight: 1022.73
+max_weight: 1022
 weight_unit: kg
 desc_units: false

--- a/rack-types/APC/AR3157.yaml
+++ b/rack-types/APC/AR3157.yaml
@@ -12,6 +12,6 @@ outer_depth: 1070
 outer_unit: mm
 mounting_depth: 710
 weight: 169.09
-max_weight: 1022.73
+max_weight: 1022
 weight_unit: kg
 desc_units: false

--- a/schema/racktype.json
+++ b/schema/racktype.json
@@ -70,17 +70,15 @@
             "multipleOf": 0.01
         },
         "max_weight": {
-            "type": "number",
-            "minimum": 0,
-            "multipleOf": 0.01
+            "type": "integer",
+            "minimum": 0
         },
         "weight_unit": {
             "$ref": "urn:devicetype-library:generated-schema#/definitions/weight-unit"
         },
         "mounting_depth": {
-            "type": "number",
-            "minimum": 0,
-            "multipleOf": 0.01
+            "type": "integer",
+            "minimum": 0
         },
         "starting_unit": {
             "type": "number",


### PR DESCRIPTION
fix https://github.com/netbox-community/devicetype-library/issues/3764

Round all float weight to floor. 