### PR TITLE
fix(device-type): incorrect attributes on importing

### DIFF
--- a/device-types/Cisco/WS-C2960C-12PC-L.yaml
+++ b/device-types/Cisco/WS-C2960C-12PC-L.yaml
@@ -5,6 +5,7 @@ slug: cisco-ws-c2960c-12pc-l
 part_number: WS-C2960C-12PC-L
 is_full_depth: false
 weight: 1.86
+weight_unit: kg
 airflow: passive
 u_height: 1
 interfaces:

--- a/device-types/Fortinet/FIM-7941F.yaml
+++ b/device-types/Fortinet/FIM-7941F.yaml
@@ -5,7 +5,7 @@ part_number: FIM-7941F
 slug: fortinet-fim-7941f
 subdevice_role: child
 is_full_depth: true
-u_height: 2
+u_height: 0
 airflow: passive
 weight: 11.65
 weight_unit: kg

--- a/device-types/Fortinet/FPM-7620F.yaml
+++ b/device-types/Fortinet/FPM-7620F.yaml
@@ -4,7 +4,7 @@ model: FortiGate Module 7620F
 slug: fortinet-fpm-7620f
 subdevice_role: child
 part_number: FPM-7620F
-u_height: 2
+u_height: 0
 is_full_depth: true
 weight: 7.35
 weight_unit: kg


### PR DESCRIPTION
Some device-type yaml has missing/incorrect attributes and rejected by Netbox

https://github.com/netbox-community/devicetype-library/issues/3763#issuecomment-3577682685