### PR TITLE
ADD: part_number UDM-PRO to UniFi Dream Machine Pro

### DIFF
--- a/device-types/Ubiquiti/UniFi-Dream-Machine-Pro.yaml
+++ b/device-types/Ubiquiti/UniFi-Dream-Machine-Pro.yaml
@@ -3,6 +3,7 @@ manufacturer: Ubiquiti
 model: UniFi Dream Machine Pro
 slug: ubiquiti-unifi-dream-machine-pro
 airflow: front-to-rear
+part_number: UDM-PRO
 comments: |
   UniFi Dream Machine Pro
 


### PR DESCRIPTION
This PR adds the `part_number` field to the Ubiquiti Dream Machine Pro