### PR TITLE
Update WS-C2960X-24PD-L.yaml - removed non-existing interfaces from device type

### DIFF
--- a/device-types/Cisco/WS-C2960X-24PD-L.yaml
+++ b/device-types/Cisco/WS-C2960X-24PD-L.yaml
@@ -105,10 +105,6 @@ interfaces:
     type: 1000base-t
     poe_mode: pse
     poe_type: type2-ieee802.3at
-  - name: GigabitEthernet1/0/25
-    type: 1000base-x-sfp
-  - name: GigabitEthernet1/0/26
-    type: 1000base-x-sfp
   - name: TenGigabitEthernet1/0/1
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/0/2


### PR DESCRIPTION
Removed two interfaces from the 24PD-L.yaml, since they only exist on the 24PS-L model. The Cisco 24PD-L model only has two SFP ports (TenGig) which already exist in this template.