### PR TITLE
Standardise MikroTik QSFP naming

### DIFF
--- a/device-types/MikroTik/CRS326-24S-Plus-2Q-Plus-RM.yaml
+++ b/device-types/MikroTik/CRS326-24S-Plus-2Q-Plus-RM.yaml
@@ -57,9 +57,21 @@ interfaces:
     type: 10gbase-x-sfpp
   - name: sfp-sfpplus24
     type: 10gbase-x-sfpp
-  - name: qsfp-qsfpplus1
+  - name: qsfpplus1-1
     type: 40gbase-x-qsfpp
-  - name: qsfp-qsfpplus2
+  - name: qsfpplus1-2
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus1-3
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus1-4
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-1
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-2
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-3
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-4
     type: 40gbase-x-qsfpp
 console-ports:
   - name: serial0

--- a/device-types/MikroTik/CRS354-48G-4S-Plus-2Q-Plus-RM.yaml
+++ b/device-types/MikroTik/CRS354-48G-4S-Plus-2Q-Plus-RM.yaml
@@ -113,9 +113,21 @@ interfaces:
     type: 10gbase-x-sfpp
   - name: sfp-sfpplus4
     type: 10gbase-x-sfpp
-  - name: qsfpplus1
+  - name: qsfpplus1-1
     type: 40gbase-x-qsfpp
-  - name: qsfpplus2
+  - name: qsfpplus1-2
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus1-3
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus1-4
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-1
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-2
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-3
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-4
     type: 40gbase-x-qsfpp
 console-ports:
   - name: serial0

--- a/device-types/MikroTik/CRS354-48P-4S-Plus-2Q-Plus-RM.yaml
+++ b/device-types/MikroTik/CRS354-48P-4S-Plus-2Q-Plus-RM.yaml
@@ -114,9 +114,21 @@ interfaces:
     type: 10gbase-x-sfpp
   - name: sfp-sfpplus4
     type: 10gbase-x-sfpp
-  - name: qsfpplus1
+  - name: qsfpplus1-1
     type: 40gbase-x-qsfpp
-  - name: qsfpplus2
+  - name: qsfpplus1-2
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus1-3
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus1-4
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-1
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-2
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-3
+    type: 40gbase-x-qsfpp
+  - name: qsfpplus2-4
     type: 40gbase-x-qsfpp
 console-ports:
   - name: serial0


### PR DESCRIPTION
On MikroTik switches the QSFP ports are always defined as 4 different ports. When a QSFP module without breakouts is being used, only the `-1` is being active, all other dormant. If breakouts are being used, all others are also active.

This PR changes to reflect the correct interface naming in the RouterOS commandline, making it the same as as many other MikroTik switches:
- RDS2216-2XG-4S-Plus-4XS-2XQ
- CRS520-4XS-16XQ
- CRS518-16XS-2XQ
- CRS510-8XS-2XQ-IN
- CRS504-4XQ-IN
- CCR2216-1G-12XS-2XQ

Here's an example output:
```
> /interface/ethernet/print
Flags: X - DISABLED, R - RUNNING; S - SLAVE
Columns: NAME, MTU, MAC-ADDRESS, ARP, SWITCH
 #    NAME            MTU  MAC-ADDRESS        ARP      SWITCH
 0 X  ether1         2028  78:9A:18:7F:DF:33  enabled  switch2
 1 RS qsfpplus1-1    9000  78:9A:18:7F:DF:2B  enabled  switch1
 2    qsfpplus1-2    9000  78:9A:18:7F:DF:2C  enabled  switch1
 3    qsfpplus1-3    9000  78:9A:18:7F:DF:2D  enabled  switch1
 4    qsfpplus1-4    9000  78:9A:18:7F:DF:2E  enabled  switch1
 5 RS qsfpplus2-1    9000  78:9A:18:7F:DF:2F  enabled  switch1
 6    qsfpplus2-2    9000  78:9A:18:7F:DF:30  enabled  switch1
 7    qsfpplus2-3    9000  78:9A:18:7F:DF:31  enabled  switch1
 8    qsfpplus2-4    9000  78:9A:18:7F:DF:32  enabled  switch1
 9 RS sfp-sfpplus1   9000  78:9A:18:7F:DF:13  enabled  switch1
10  S sfp-sfpplus2   9000  78:9A:18:7F:DF:14  enabled  switch1
11 RS sfp-sfpplus3   9000  78:9A:18:7F:DF:15  enabled  switch1
12    sfp-sfpplus4   9000  78:9A:18:7F:DF:16  enabled  switch1
13  S sfp-sfpplus5   9000  78:9A:18:7F:DF:17  enabled  switch1
14  S sfp-sfpplus6   9000  78:9A:18:7F:DF:18  enabled  switch1
15  S sfp-sfpplus7   9000  78:9A:18:7F:DF:19  enabled  switch1
16 RS sfp-sfpplus8   9000  78:9A:18:7F:DF:1A  enabled  switch1
17  S sfp-sfpplus9   9000  78:9A:18:7F:DF:1B  enabled  switch1
18  S sfp-sfpplus10  9000  78:9A:18:7F:DF:1C  enabled  switch1
19  S sfp-sfpplus11  9000  78:9A:18:7F:DF:1D  enabled  switch1
20  S sfp-sfpplus12  9000  78:9A:18:7F:DF:1E  enabled  switch1
21  S sfp-sfpplus13  9000  78:9A:18:7F:DF:1F  enabled  switch1
22  S sfp-sfpplus14  9000  78:9A:18:7F:DF:20  enabled  switch1
23  S sfp-sfpplus15  9000  78:9A:18:7F:DF:21  enabled  switch1
24 RS sfp-sfpplus16  9000  78:9A:18:7F:DF:22  enabled  switch1
25    sfp-sfpplus17  9000  78:9A:18:7F:DF:23  enabled  switch1
26  S sfp-sfpplus18  9000  78:9A:18:7F:DF:24  enabled  switch1
27  S sfp-sfpplus19  9000  78:9A:18:7F:DF:25  enabled  switch1
28  S sfp-sfpplus20  9000  78:9A:18:7F:DF:26  enabled  switch1
29 RS sfp-sfpplus21  9000  78:9A:18:7F:DF:27  enabled  switch1
30 RS sfp-sfpplus22  9000  78:9A:18:7F:DF:28  enabled  switch1
31 RS sfp-sfpplus23  9000  78:9A:18:7F:DF:29  enabled  switch1
32 RS sfp-sfpplus24  9000  78:9A:18:7F:DF:2A  enabled  switch1
```