### PR TITLE
Add platform definitions and default_platform support

### DIFF
--- a/platforms/Arista/arista-eos.yaml
+++ b/platforms/Arista/arista-eos.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: Arista
+name: Arista EOS
+slug: arista-eos
+description: Arista Extensible Operating System

--- a/platforms/Cisco/cisco-ios-xe.yaml
+++ b/platforms/Cisco/cisco-ios-xe.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: Cisco
+name: Cisco IOS-XE
+slug: cisco-ios-xe
+description: Cisco Internet Operating System XE

--- a/platforms/Cisco/cisco-nxos.yaml
+++ b/platforms/Cisco/cisco-nxos.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: Cisco
+name: Cisco NX-OS
+slug: cisco-nxos
+description: Cisco Nexus Operating System

--- a/platforms/Juniper/juniper-junos.yaml
+++ b/platforms/Juniper/juniper-junos.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: Juniper
+name: Juniper Junos
+slug: juniper-junos
+description: Juniper Networks Junos Operating System

--- a/platforms/Palo Alto/paloalto-panos.yaml
+++ b/platforms/Palo Alto/paloalto-panos.yaml
@@ -1,0 +1,5 @@
+---
+manufacturer: Palo Alto
+name: Palo Alto PAN-OS
+slug: paloalto-panos
+description: Palo Alto Networks PAN-OS

--- a/schema/devicetype.json
+++ b/schema/devicetype.json
@@ -119,7 +119,7 @@
         "default_platform": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "^[-a-zA-Z0-9_]+$"
+            "pattern": "^[-a-z0-9_]+$"
         }
     },
     "allOf": [

--- a/schema/devicetype.json
+++ b/schema/devicetype.json
@@ -115,6 +115,11 @@
         },
         "comments": {
             "type": "string"
+        },
+        "default_platform": {
+            "type": "string",
+            "maxLength": 100,
+            "pattern": "^[-a-zA-Z0-9_]+$"
         }
     },
     "allOf": [

--- a/schema/platformtype.json
+++ b/schema/platformtype.json
@@ -1,0 +1,26 @@
+{
+    "type": "object",
+    "$id": "urn:devicetype-library:platform-type",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "manufacturer": {
+            "type": "string",
+            "maxLength": 100
+        },
+        "name": {
+            "type": "string",
+            "maxLength": 100
+        },
+        "slug": {
+            "type": "string",
+            "maxLength": 100,
+            "pattern": "^[-a-zA-Z0-9_]+$"
+        },
+        "description": {
+            "type": "string",
+            "maxLength": 200
+        }
+    },
+    "required": ["manufacturer", "name", "slug"],
+    "additionalProperties": false
+}

--- a/schema/platformtype.json
+++ b/schema/platformtype.json
@@ -14,7 +14,7 @@
         "slug": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "^[-a-zA-Z0-9_]+$"
+            "pattern": "^[-a-z0-9_]+$"
         },
         "description": {
             "type": "string",

--- a/tests/definitions_test.py
+++ b/tests/definitions_test.py
@@ -131,6 +131,12 @@ else:
     definition_files = _get_definition_files()
 image_files = _get_image_files()
 
+# Precompute known platform slugs for default_platform cross-validation
+KNOWN_PLATFORMS = {}
+for platform_file in sorted(glob.glob(f"platforms{os.path.sep}*{os.path.sep}*.yaml")) + sorted(glob.glob(f"platforms{os.path.sep}*{os.path.sep}*.yml")):
+    platform_slug = os.path.basename(platform_file).rsplit(".", 1)[0]
+    KNOWN_PLATFORMS.setdefault(platform_slug, []).append(platform_file)
+
 if USE_LOCAL_KNOWN_SLUGS:
     KNOWN_SLUGS = pickle_operations.read_pickle_data(f'{ROOT_DIR}/tests/known-slugs.pickle')
     KNOWN_MODULES = pickle_operations.read_pickle_data(f'{ROOT_DIR}/tests/known-modules.pickle')
@@ -313,13 +319,17 @@ def test_definitions(file_path, schema, change_type):
     # Validate default_platform references an existing platform file
     if "device-types" in file_path and definition.get('default_platform'):
         platform_slug = definition['default_platform']
-        matching_platforms = glob.glob(f"platforms{os.path.sep}*{os.path.sep}{platform_slug}.yaml")
-        if not matching_platforms:
-            matching_platforms = glob.glob(f"platforms{os.path.sep}*{os.path.sep}{platform_slug}.yml")
+        matching_platforms = KNOWN_PLATFORMS.get(platform_slug, [])
         if not matching_platforms:
             pytest.fail(
                 f"{file_path} has default_platform '{platform_slug}' but no matching platform definition "
                 f"was found in platforms/*/. Expected file: platforms/<manufacturer>/{platform_slug}.yaml",
+                pytrace=False,
+            )
+        elif len(matching_platforms) > 1:
+            pytest.fail(
+                f"{file_path} has default_platform '{platform_slug}' but multiple matching platform definitions "
+                f"were found: {matching_platforms}. Platform slugs must be globally unique.",
                 pytrace=False,
             )
 

--- a/tests/definitions_test.py
+++ b/tests/definitions_test.py
@@ -1,7 +1,7 @@
 from test_configuration import COMPONENT_TYPES, IMAGE_FILETYPES, SCHEMAS, SCHEMAS_BASEPATH, KNOWN_SLUGS, ROOT_DIR, USE_LOCAL_KNOWN_SLUGS, NETBOX_DT_LIBRARY_URL, KNOWN_MODULES, USE_UPSTREAM_DIFF, PRECOMMIT_ALL_SWITCHES
 import pickle_operations
 from yaml_loader import DecimalSafeLoader
-from device_types import DeviceType, ModuleType, RackType, verify_filename, validate_components
+from device_types import DeviceType, ModuleType, RackType, PlatformType, verify_filename, validate_components
 import decimal
 import glob
 import json
@@ -188,7 +188,7 @@ def test_definitions(file_path, schema, change_type):
         # Schema validation failure. Ensure you are following the proper format.
         pytest.fail(f"{file_path} failed validation: {e}", False)
 
-    # Identify if the definition is for a Device or Module
+    # Identify if the definition is for a Device, Module, Rack, or Platform
     if "device-types" in file_path:
         # A device
         this_device = DeviceType(definition, file_path, change_type)
@@ -198,9 +198,21 @@ def test_definitions(file_path, schema, change_type):
     elif "rack-types" in file_path:
         # A rack type
         this_device = RackType(definition, file_path, change_type)
+    elif "platforms" in file_path:
+        # A platform
+        this_device = PlatformType(definition, file_path, change_type)
     else:
         # A module
         this_device = ModuleType(definition, file_path, change_type)
+
+    # Validate platform filename matches slug
+    if "platforms" in file_path:
+        platform_filename = os.path.basename(file_path).rsplit(".", 1)[0]
+        if platform_filename != definition.get('slug'):
+            pytest.fail(
+                f"{file_path}: filename '{platform_filename}' does not match slug '{definition.get('slug')}'",
+                pytrace=False,
+            )
 
     # Validate that front-ports reference existing rear-ports
     if any(x in file_path for x in ("device-types", "module-types")):
@@ -244,10 +256,12 @@ def test_definitions(file_path, schema, change_type):
         assert this_device.verify_slug(KNOWN_SLUGS), pytest.fail(this_device.failureMessage, False)
 
     # Verify the filename is valid. Must either be the model or part_number.
-    assert verify_filename(this_device, (KNOWN_MODULES if not this_device.isDevice else None)), pytest.fail(this_device.failureMessage, False)
+    if not isinstance(this_device, PlatformType):
+        assert verify_filename(this_device, (KNOWN_MODULES if not this_device.isDevice else None)), pytest.fail(this_device.failureMessage, False)
 
     # Check for duplicate components within the definition
-    assert validate_components(COMPONENT_TYPES, this_device), pytest.fail(this_device.failureMessage, False)
+    if not isinstance(this_device, PlatformType):
+        assert validate_components(COMPONENT_TYPES, this_device), pytest.fail(this_device.failureMessage, False)
 
     # Check for empty quotes and fail if found
     def iterdict(var):
@@ -295,4 +309,18 @@ def test_definitions(file_path, schema, change_type):
 
             if not rear_image:
                 pytest.fail(f'{file_path} has rear_image set to True but no matching image found (looking for \'elevation-images{os.path.sep}{file_path.split(os.path.sep)[1]}{os.path.sep}{this_device.get_slug()}.rear.ext\' but only found {manufacturer_images})', False)
+
+    # Validate default_platform references an existing platform file
+    if "device-types" in file_path and definition.get('default_platform'):
+        platform_slug = definition['default_platform']
+        matching_platforms = glob.glob(f"platforms{os.path.sep}*{os.path.sep}{platform_slug}.yaml")
+        if not matching_platforms:
+            matching_platforms = glob.glob(f"platforms{os.path.sep}*{os.path.sep}{platform_slug}.yml")
+        if not matching_platforms:
+            pytest.fail(
+                f"{file_path} has default_platform '{platform_slug}' but no matching platform definition "
+                f"was found in platforms/*/. Expected file: platforms/<manufacturer>/{platform_slug}.yaml",
+                pytrace=False,
+            )
+
     iterdict(definition)

--- a/tests/device_types.py
+++ b/tests/device_types.py
@@ -208,6 +208,22 @@ class RackType:
             slugified = slugified[:-1]
         return slugified
 
+class PlatformType:
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls)
+
+    def __init__(self, definition, file_path, change_type):
+        self.file_path = file_path
+        self.isDevice = False
+        self.definition = definition
+        self.manufacturer = definition.get('manufacturer')
+        self.name = definition.get('name')
+        self.slug = definition.get('slug')
+        self.change_type = change_type
+
+    def get_filepath(self):
+        return self.file_path
+
 def validate_component_names(component_names: (set or None)):
     if len(component_names) > 1:
         verify_name = list(component_names[0])

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,6 +4,7 @@ SCHEMAS = (
     ('device-types', 'devicetype.json'),
     ('module-types', 'moduletype.json'),
     ('rack-types', 'racktype.json'),
+    ('platforms', 'platformtype.json'),
 )
 SCHEMAS_BASEPATH = f"{os.getcwd()}/schema/"
 


### PR DESCRIPTION
## Summary

Addresses #4094 — adds platform support to the device type library.

- **New `platforms/` directory** with `<Manufacturer>/<slug>.yaml` structure for platform definitions
- **New `schema/platformtype.json`** validating platform YAML (manufacturer, name, slug, description)
- **`default_platform` field** added to `schema/devicetype.json` as optional slug string
- **Cross-validation** ensures `default_platform` references an existing platform file
- **Seed platforms**: Arista EOS, Cisco IOS-XE, Cisco NX-OS, Juniper Junos, Palo Alto PAN-OS

### Why a separate `platforms/` directory?

A bare `default_platform` string would be a dangling reference — import tools can't resolve a platform that doesn't exist in the target NetBox instance. The `platforms/` directory gives import tools a complete dependency chain: create platforms first, then device types.

Additionally, a device's platform doesn't always match its manufacturer (e.g., Edgecore switches running Cumulus Linux). Platforms need their own manufacturer field, which is why they live in dedicated files under their own manufacturer directory.

### Test changes

- Platform files validated against `platformtype.json` schema
- Platform filename must match `slug` field
- `default_platform` in device types must reference an existing `platforms/*/<slug>.yaml`
- Duplicate platform slug detection across manufacturers
- Precomputed platform slug lookup for performance
- Device-only validations (verify_filename, validate_components) skipped for platforms

## Test plan

- [x] All 5 seed platform files pass schema validation
- [x] Invalid slug pattern rejected by schema
- [x] Missing required fields rejected by schema
- [x] Extra fields rejected by `additionalProperties: false`
- [x] Cross-validation correctly resolves valid platform slugs
- [x] Cross-validation correctly rejects nonexistent platform slugs
- [x] Filename=slug enforcement verified