### PR TITLE
Add PSU modules PAC-600WA-F/B

### DIFF
--- a/module-types/Huawei/PAC-600WA-B.yaml
+++ b/module-types/Huawei/PAC-600WA-B.yaml
@@ -1,0 +1,18 @@
+---
+profile: Power supply
+manufacturer: Huawei
+model: PAC-600WA-B
+part_number: 02310PMH
+description: 600 W AC Power Module (PAC-600WA)
+weight: 1.0
+weight_unit: kg
+airflow: rear-to-front
+attribute_data:
+  wattage: 600
+  hot_swappable: true
+  input_current: AC
+  input_voltage: 240
+comments: "See [Datasheet](https://support.huawei.com/enterprise/de/doc/EDOC1000019246/adc445c0/600-w-ac-power-module-pac-600wa).\r\n\r\n\r\n| Item | PAC-600WA-B\
+  \ |\r\n|---|---|\r\n| Dimensions (W x D x H) | 100 x 205 x 40 mm |\r\n| Weight | 1 kg |\r\n| Rated input voltage  | 100 V AC-240 V AC, 50/60 Hz  |\r\n\
+  | Maximum input voltage  | 90 V AC-290 V AC, 47 Hz-63 Hz  |\r\n| Rated input current  | 9 A  |\r\n| Rated output current | 50 A  |\r\n| Rated output voltage\
+  \ | 12 V  |\r\n| Rated output power   | 600 W  |\r\n| Part Number          | 02310PMH  |"

--- a/module-types/Huawei/PAC-600WA-F.yaml
+++ b/module-types/Huawei/PAC-600WA-F.yaml
@@ -1,0 +1,18 @@
+---
+profile: Power supply
+manufacturer: Huawei
+model: PAC-600WA-F
+part_number: 02310PMJ
+description: 600 W AC Power Module (PAC-600WA)
+weight: 1.0
+weight_unit: kg
+airflow: front-to-rear
+attribute_data:
+  wattage: 600
+  hot_swappable: true
+  input_current: AC
+  input_voltage: 240
+comments: "See [Datasheet](https://support.huawei.com/enterprise/de/doc/EDOC1000019246/adc445c0/600-w-ac-power-module-pac-600wa).\r\n\r\n| Item | PAC-600WA-F\
+  \ |\r\n|---|---|\r\n| Dimensions (W x D x H) | 100 x 205 x 40 mm |\r\n| Weight | 1 kg  |\r\n| Rated input voltage  | 100 V AC-240 V AC, 50/60 Hz  |\r\n\
+  | Maximum input voltage  | 90 V AC-290 V AC, 47 Hz-63 Hz  |\r\n| Rated input current  | 9 A  |\r\n| Rated output current | 50 A  |\r\n| Rated output voltage\
+  \ | 12 V  |\r\n| Rated output power   | 600 W  |\r\n| Part Number          | 02310PMJ  |"


### PR DESCRIPTION
Power supply units for Huawei switches:
  - PAC-600WA-F: airflow is front to rear
  - PAC-600WA-B: airflow is rear to front