### PR TITLE
Add fan modules FAN-180A for Huawei switches

### DIFF
--- a/module-types/Huawei/FAN-180A-B.yaml
+++ b/module-types/Huawei/FAN-180A-B.yaml
@@ -1,0 +1,12 @@
+---
+profile: Fan
+manufacturer: Huawei
+model: FAN-180A-B
+part_number: 02350KJA
+description: Automatic fan speed adjustment, hot swap is supported
+weight: 0.9
+weight_unit: kg
+airflow: rear-to-front
+attribute_data:
+  rpm: 12000
+comments: See [Hardware Description](https://support.huawei.com/enterprise/en/doc/EDOC1000019246/1c26cf41/fan-180a-series-fan-modules#EN-US_CONCEPT_0138782276).

--- a/module-types/Huawei/FAN-180A-F.yaml
+++ b/module-types/Huawei/FAN-180A-F.yaml
@@ -1,0 +1,12 @@
+---
+profile: Fan
+manufacturer: Huawei
+model: FAN-180A-F
+part_number: 02350KHY
+description: Automatic fan speed adjustment, hot swap is supported
+weight: 0.9
+weight_unit: kg
+airflow: front-to-rear
+attribute_data:
+  rpm: 12000
+comments: See [Hardware Description](https://support.huawei.com/enterprise/en/doc/EDOC1000019246/1c26cf41/fan-180a-series-fan-modules#EN-US_CONCEPT_0138782276).


### PR DESCRIPTION
- FAN-180A-B: back-to-front airflow, air exhaust on fan module panel
- FAN-180A-F: front-to-back airflow, air intake on fan module panel