### PR TITLE
C9600-LC-24C in SUP2 mode

### DIFF
--- a/module-types/Cisco/C9600-LC-24C-SUP2.yaml
+++ b/module-types/Cisco/C9600-LC-24C-SUP2.yaml
@@ -1,0 +1,54 @@
+---
+manufacturer: Cisco
+model: C9600-LC-24C
+part_number: C9600-LC-24C
+comments: '[Cisco Catalyst 9600 Series Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-series-line-data-sheet-cte-en.html)'
+interfaces:
+  - name: HundredGigE{module}/0/1
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/2
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/3
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/4
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/5
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/6
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/7
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/8
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/9
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/10
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/11
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/12
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/13
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/14
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/15
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/16
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/17
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/18
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/19
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/20
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/21
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/22
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/23
+    type: 100gbase-x-qsfp28
+  - name: HundredGigE{module}/0/24
+    type: 100gbase-x-qsfp28

--- a/module-types/Cisco/C9600-LC-24C-SUP2.yaml
+++ b/module-types/Cisco/C9600-LC-24C-SUP2.yaml
@@ -1,7 +1,7 @@
 ---
 manufacturer: Cisco
-model: C9600-LC-24C
-part_number: C9600-LC-24C
+model: C9600-LC-24C-SUP2
+part_number: C9600-LC-24C-SUP2
 comments: '[Cisco Catalyst 9600 Series Line Cards Data Sheet](https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9600-series-switches/nb-06-cat9600-series-line-data-sheet-cte-en.html)'
 interfaces:
   - name: HundredGigE{module}/0/1


### PR DESCRIPTION
Adds the C9600-LC-24C for use in supervisor 2 mode. #4014