### PR TITLE
Add Fujitsu CELSIUS W580 workstation device type

### DIFF
--- a/device-types/Fujitsu/celsius-w580.yaml
+++ b/device-types/Fujitsu/celsius-w580.yaml
@@ -1,0 +1,20 @@
+---
+manufacturer: Fujitsu
+model: CELSIUS W580
+slug: fujitsu-celsius-w580
+part_number: S26361-K1446-V515
+u_height: 0
+is_full_depth: false
+airflow: front-to-rear
+comments: '[Fujitsu CELSIUS W580 Data Sheet](https://sp.ts.fujitsu.com/dmsp/Publications/public/ds-CELSIUS-W580.pdf). Microtower workstation (21 L). Base configuration uses a 280 W PSU; CELSIUS W580power / W580power+ use up to 400 W. Optional RS-232 and second serial (POS) per configuration.'
+# Weight approx. 10 kg base model (12 kg for W580power); actual weight varies by configuration
+weight: 10.0
+weight_unit: kg
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 280
+interfaces:
+  - name: LAN1
+    type: 1000base-t
+    description: Intel I219LM 10/100/1000 Mbit/s (RJ-45)

--- a/device-types/Fujitsu/celsius-w580.yaml
+++ b/device-types/Fujitsu/celsius-w580.yaml
@@ -6,7 +6,8 @@ part_number: S26361-K1446-V515
 u_height: 0
 is_full_depth: false
 airflow: front-to-rear
-comments: '[Fujitsu CELSIUS W580 Data Sheet](https://sp.ts.fujitsu.com/dmsp/Publications/public/ds-CELSIUS-W580.pdf). Microtower workstation (21 L). Base configuration uses a 280 W PSU; CELSIUS W580power / W580power+ use up to 400 W. Optional RS-232 and second serial (POS) per configuration.'
+comments: '[Fujitsu CELSIUS W580 Data Sheet](https://sp.ts.fujitsu.com/dmsp/Publications/public/ds-CELSIUS-W580.pdf). Microtower workstation (21 L). Base
+  configuration uses a 280 W PSU; CELSIUS W580power / W580power+ use up to 400 W. Optional RS-232 and second serial (POS) per configuration.'
 # Weight approx. 10 kg base model (12 kg for W580power); actual weight varies by configuration
 weight: 10.0
 weight_unit: kg


### PR DESCRIPTION
This change adds a NetBox device type definition for the Fujitsu CELSIUS W580 microtower workstation (0U). It includes the OEM base SKU, weight, airflow, a single onboard Intel I219LM Gigabit Ethernet interface (LAN1), and an IEC C14 power port with a 280 W maximum draw to match the standard PSU; the comments note the higher-output W580power variants and optional serial configurations. Part numbers and networking details are taken from the [official datasheet](https://sp.ts.fujitsu.com/dmsp/Publications/public/ds-CELSIUS-W580.pdf).