### PR TITLE
HPE: Add J9008A module type and module-bays to ProCurve 2910al-48G (J9147A)

### DIFF
--- a/device-types/HPE/ProCurve-2910al-48G.yaml
+++ b/device-types/HPE/ProCurve-2910al-48G.yaml
@@ -125,3 +125,12 @@ interfaces:
 #    type: 1000base-x-sfp
 #  - name: '48'
 #    type: 1000base-x-sfp
+module-bays:
+  - name: Module Bay A
+    position: A
+  - name: Module Bay B
+    position: B
+  - name: Module Bay C
+    position: C
+  - name: Module Bay D
+    position: D

--- a/module-types/HPE/J9008A.yaml
+++ b/module-types/HPE/J9008A.yaml
@@ -1,7 +1,6 @@
 ---
 manufacturer: HPE
 model: al 10-GbE 2-port SFP+
-slug: hpe-j9008a
 part_number: J9008A
 interfaces:
   - name: '{module}1'

--- a/module-types/HPE/J9008A.yaml
+++ b/module-types/HPE/J9008A.yaml
@@ -1,0 +1,10 @@
+---
+manufacturer: HPE
+model: al 10-GbE 2-port SFP+
+slug: hpe-j9008a
+part_number: J9008A
+interfaces:
+  - name: '{module} SFP+ 1'
+    type: 10gbase-x-sfpp
+  - name: '{module} SFP+ 2'
+    type: 10gbase-x-sfpp

--- a/module-types/HPE/J9008A.yaml
+++ b/module-types/HPE/J9008A.yaml
@@ -4,7 +4,7 @@ model: al 10-GbE 2-port SFP+
 slug: hpe-j9008a
 part_number: J9008A
 interfaces:
-  - name: '{module} SFP+ 1'
+  - name: '{module}1'
     type: 10gbase-x-sfpp
-  - name: '{module} SFP+ 2'
+  - name: '{module}2'
     type: 10gbase-x-sfpp


### PR DESCRIPTION
## Description
- Adds 4x module-bay templates (A/B/C/D) to the ProCurve 2910al-48G (J9147A)
  to model the physical expansion slots on the switch
- Adds new module type for the HP al 10-GbE 2-port SFP+ (J9008A) expansion
  module with 2x 10GbE SFP+ interfaces (A1/A2 format matching ProCurve OS)

## Verification
Tested against a physical HP J9147A with two J9008A modules installed in
slots A and B (serials SG103IM1N5 and SG103IM15T).