### PR TITLE
HPE: Fix ProCurve 2910al-48G module-bays to 2 slots (A+B) 

### DIFF
--- a/device-types/HPE/ProCurve-2910al-48G.yaml
+++ b/device-types/HPE/ProCurve-2910al-48G.yaml
@@ -130,7 +130,3 @@ module-bays:
     position: A
   - name: Module Bay B
     position: B
-  - name: Module Bay C
-    position: C
-  - name: Module Bay D
-    position: D


### PR DESCRIPTION
## Description
Corrects the number of module-bay slots from 4 (A/B/C/D) to 2 (A/B).

The HP ProCurve 2910al Installation Guide (Publication 5992-3084) states:
"Two slots are provided in the back of the device to support expansion modules"

The previous submission incorrectly added 4 bays. Physical hardware and
the official installation guide both confirm only slots A and B exist.

## Reference
HP ProCurve 2910al Switches Installation and Getting Started Guide
Publication Number: 5992-3084, March 2010