### PR TITLE
Add FortiSwitch's FS-424E (Non PoE) & FS-448E (PoE & Non PoE)

### DIFF
--- a/device-types/Fortinet/FS-424E-FPOE.yaml
+++ b/device-types/Fortinet/FS-424E-FPOE.yaml
@@ -10,8 +10,8 @@ is_full_depth: false
 airflow: side-to-rear
 front_image: true
 rear_image: true
-comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
-  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
+comments: '[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Fortinet/FS-424E-FPOE.yaml
+++ b/device-types/Fortinet/FS-424E-FPOE.yaml
@@ -10,8 +10,7 @@ is_full_depth: false
 airflow: side-to-rear
 front_image: true
 rear_image: true
-comments:
-  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
   [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FS-424E-Fiber.yaml
+++ b/device-types/Fortinet/FS-424E-Fiber.yaml
@@ -9,8 +9,8 @@ weight_unit: lb
 is_full_depth: false
 front_image: true
 rear_image: true
-comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
-  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)'
+comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
 airflow: side-to-rear
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FS-424E-Fiber.yaml
+++ b/device-types/Fortinet/FS-424E-Fiber.yaml
@@ -9,8 +9,8 @@ weight_unit: lb
 is_full_depth: false
 front_image: true
 rear_image: true
-comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
-  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
+comments: '[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)'
 airflow: side-to-rear
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FS-424E-POE.yaml
+++ b/device-types/Fortinet/FS-424E-POE.yaml
@@ -10,8 +10,9 @@ weight: 5.25
 weight_unit: kg
 front_image: true
 rear_image: true
-comments: '[FortiSwitch Secure Access Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/FortiSwitch_Secure_Access_Series.pdf),
-  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)'
+comments:
+  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Fortinet/FS-424E-POE.yaml
+++ b/device-types/Fortinet/FS-424E-POE.yaml
@@ -10,8 +10,8 @@ weight: 5.25
 weight_unit: kg
 front_image: true
 rear_image: true
-comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
-  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
+comments: '[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Fortinet/FS-424E-POE.yaml
+++ b/device-types/Fortinet/FS-424E-POE.yaml
@@ -10,8 +10,7 @@ weight: 5.25
 weight_unit: kg
 front_image: true
 rear_image: true
-comments:
-  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
   [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FS-424E.yaml
+++ b/device-types/Fortinet/FS-424E.yaml
@@ -1,127 +1,81 @@
 ---
 manufacturer: Fortinet
-model: FortiSwitch 424E-FPOE
-slug: fortinet-fs-424e-fpoe
-part_number: FS-424E-FPOE
-u_height: 1
-weight: 5.77
-weight_unit: kg
+model: FortiSwitch 424E
+slug: fortinet-fs-424e
+part_number: FS-424E
+u_height: 1.0
 is_full_depth: false
 airflow: side-to-rear
-front_image: true
-rear_image: true
+weight: 3.1
+weight_unit: kg
 comments:
   "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
   [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
 console-ports:
   - name: Console
     type: rj-45
+    description: Rear of the device
 power-ports:
   - name: PS1
     type: iec-60320-c14
-    maximum_draw: 434
-    allocated_draw: 431
+    maximum_draw: 24
+    allocated_draw: 22
   - name: PS2
     type: iec-60320-c14
-    maximum_draw: 434
-    allocated_draw: 431
+    maximum_draw: 24
+    allocated_draw: 22
 interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
   - name: port1
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port2
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port3
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port4
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port5
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port6
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port7
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port8
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port9
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port10
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port11
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port12
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port13
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port14
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port15
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port16
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port17
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port18
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port19
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port20
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port21
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port22
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port23
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port24
     type: 1000base-t
-    poe_mode: pse
-    poe_type: type2-ieee802.3at
   - name: port25
     type: 10gbase-x-sfpp
   - name: port26
@@ -130,6 +84,3 @@ interfaces:
     type: 10gbase-x-sfpp
   - name: port28
     type: 10gbase-x-sfpp
-  - name: mgmt
-    type: 1000base-t
-    mgmt_only: true

--- a/device-types/Fortinet/FS-424E.yaml
+++ b/device-types/Fortinet/FS-424E.yaml
@@ -8,8 +8,8 @@ is_full_depth: false
 airflow: side-to-rear
 weight: 3.1
 weight_unit: kg
-comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
-  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
+comments: '[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Fortinet/FS-424E.yaml
+++ b/device-types/Fortinet/FS-424E.yaml
@@ -8,8 +8,7 @@ is_full_depth: false
 airflow: side-to-rear
 weight: 3.1
 weight_unit: kg
-comments:
-  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
   [FortiSwitch 424E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-424e-series-quickstart-guide)"
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FS-448E-FPOE.yaml
+++ b/device-types/Fortinet/FS-448E-FPOE.yaml
@@ -8,8 +8,8 @@ is_full_depth: false
 airflow: side-to-rear
 weight: 6.37
 weight_unit: kg
-comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
-  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
+comments: '[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Fortinet/FS-448E-FPOE.yaml
+++ b/device-types/Fortinet/FS-448E-FPOE.yaml
@@ -1,0 +1,230 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 448E-FPOE
+slug: fortinet-fs-448e-fpoe
+part_number: FS-448E-FPOE
+u_height: 1.0
+is_full_depth: false
+airflow: side-to-rear
+weight: 6.37
+weight_unit: kg
+comments:
+  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
+console-ports:
+  - name: Console
+    type: rj-45
+    description: Rear of the device
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 924
+    allocated_draw: 921
+  - name: PS2
+    type: iec-60320-c14
+    maximum_draw: 924
+    allocated_draw: 921
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port13
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port14
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port15
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port16
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port17
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port18
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port19
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port20
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port21
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port22
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port23
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port24
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port25
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port26
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port27
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port28
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port29
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port30
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port31
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port32
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port33
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port34
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port35
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port36
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port37
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port38
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port39
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port40
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port41
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port42
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port43
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port44
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port45
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port46
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port47
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port48
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port49
+    type: 10gbase-x-sfpp
+  - name: port50
+    type: 10gbase-x-sfpp
+  - name: port51
+    type: 10gbase-x-sfpp
+  - name: port52
+    type: 10gbase-x-sfpp

--- a/device-types/Fortinet/FS-448E-FPOE.yaml
+++ b/device-types/Fortinet/FS-448E-FPOE.yaml
@@ -8,8 +8,7 @@ is_full_depth: false
 airflow: side-to-rear
 weight: 6.37
 weight_unit: kg
-comments:
-  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
   [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FS-448E-POE.yaml
+++ b/device-types/Fortinet/FS-448E-POE.yaml
@@ -1,0 +1,230 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 448E-POE
+slug: fortinet-fs-448e-poe
+part_number: FS-448E-POE
+u_height: 1.0
+is_full_depth: false
+airflow: side-to-rear
+weight: 6.26
+weight_unit: kg
+comments:
+  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
+console-ports:
+  - name: Console
+    type: rj-45
+    description: Rear of the device
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 442
+    allocated_draw: 440
+  - name: PS2
+    type: iec-60320-c14
+    maximum_draw: 442
+    allocated_draw: 440
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: port1
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port2
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port3
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port4
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port5
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port6
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port7
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port8
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port9
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port10
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port11
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port12
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port13
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port14
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port15
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port16
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port17
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port18
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port19
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port20
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port21
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port22
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port23
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port24
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port25
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port26
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port27
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port28
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port29
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port30
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port31
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port32
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port33
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port34
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port35
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port36
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port37
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port38
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port39
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port40
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port41
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port42
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port43
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port44
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port45
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port46
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port47
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port48
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type2-ieee802.3at
+  - name: port49
+    type: 10gbase-x-sfpp
+  - name: port50
+    type: 10gbase-x-sfpp
+  - name: port51
+    type: 10gbase-x-sfpp
+  - name: port52
+    type: 10gbase-x-sfpp

--- a/device-types/Fortinet/FS-448E-POE.yaml
+++ b/device-types/Fortinet/FS-448E-POE.yaml
@@ -8,8 +8,7 @@ is_full_depth: false
 airflow: side-to-rear
 weight: 6.26
 weight_unit: kg
-comments:
-  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
   [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FS-448E-POE.yaml
+++ b/device-types/Fortinet/FS-448E-POE.yaml
@@ -8,8 +8,8 @@ is_full_depth: false
 airflow: side-to-rear
 weight: 6.26
 weight_unit: kg
-comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
-  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
+comments: '[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Fortinet/FS-448E.yaml
+++ b/device-types/Fortinet/FS-448E.yaml
@@ -8,8 +8,7 @@ is_full_depth: false
 airflow: side-to-rear
 weight: 4.16
 weight_unit: kg
-comments:
-  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
   [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FS-448E.yaml
+++ b/device-types/Fortinet/FS-448E.yaml
@@ -8,8 +8,8 @@ is_full_depth: false
 airflow: side-to-rear
 weight: 4.16
 weight_unit: kg
-comments: "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
-  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
+comments: '[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Fortinet/FS-448E.yaml
+++ b/device-types/Fortinet/FS-448E.yaml
@@ -1,0 +1,134 @@
+---
+manufacturer: Fortinet
+model: FortiSwitch 448E
+slug: fortinet-fs-448e
+part_number: FS-448E
+u_height: 1.0
+is_full_depth: false
+airflow: side-to-rear
+weight: 4.16
+weight_unit: kg
+comments:
+  "[FortiSwitch Secure Campus Series Datasheet](https://www.fortinet.com/content/dam/fortinet/assets/data-sheets/pdf/fortiswitch-campus-series.pdf),
+  [FortiSwitch 448E Series QuickStart Guide](https://docs.fortinet.com/document/fortiswitch/hardware/fortiswitch-448e-series-qsg)"
+console-ports:
+  - name: Console
+    type: rj-45
+    description: Rear of the device
+power-ports:
+  - name: PS1
+    type: iec-60320-c14
+    maximum_draw: 48
+    allocated_draw: 47
+  - name: PS2
+    type: iec-60320-c14
+    maximum_draw: 48
+    allocated_draw: 47
+interfaces:
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true
+  - name: port1
+    type: 1000base-t
+  - name: port2
+    type: 1000base-t
+  - name: port3
+    type: 1000base-t
+  - name: port4
+    type: 1000base-t
+  - name: port5
+    type: 1000base-t
+  - name: port6
+    type: 1000base-t
+  - name: port7
+    type: 1000base-t
+  - name: port8
+    type: 1000base-t
+  - name: port9
+    type: 1000base-t
+  - name: port10
+    type: 1000base-t
+  - name: port11
+    type: 1000base-t
+  - name: port12
+    type: 1000base-t
+  - name: port13
+    type: 1000base-t
+  - name: port14
+    type: 1000base-t
+  - name: port15
+    type: 1000base-t
+  - name: port16
+    type: 1000base-t
+  - name: port17
+    type: 1000base-t
+  - name: port18
+    type: 1000base-t
+  - name: port19
+    type: 1000base-t
+  - name: port20
+    type: 1000base-t
+  - name: port21
+    type: 1000base-t
+  - name: port22
+    type: 1000base-t
+  - name: port23
+    type: 1000base-t
+  - name: port24
+    type: 1000base-t
+  - name: port25
+    type: 1000base-t
+  - name: port26
+    type: 1000base-t
+  - name: port27
+    type: 1000base-t
+  - name: port28
+    type: 1000base-t
+  - name: port29
+    type: 1000base-t
+  - name: port30
+    type: 1000base-t
+  - name: port31
+    type: 1000base-t
+  - name: port32
+    type: 1000base-t
+  - name: port33
+    type: 1000base-t
+  - name: port34
+    type: 1000base-t
+  - name: port35
+    type: 1000base-t
+  - name: port36
+    type: 1000base-t
+  - name: port37
+    type: 1000base-t
+  - name: port38
+    type: 1000base-t
+  - name: port39
+    type: 1000base-t
+  - name: port40
+    type: 1000base-t
+  - name: port41
+    type: 1000base-t
+  - name: port42
+    type: 1000base-t
+  - name: port43
+    type: 1000base-t
+  - name: port44
+    type: 1000base-t
+  - name: port45
+    type: 1000base-t
+  - name: port46
+    type: 1000base-t
+  - name: port47
+    type: 1000base-t
+  - name: port48
+    type: 1000base-t
+  - name: port49
+    type: 10gbase-x-sfpp
+  - name: port50
+    type: 10gbase-x-sfpp
+  - name: port51
+    type: 10gbase-x-sfpp
+  - name: port52
+    type: 10gbase-x-sfpp


### PR DESCRIPTION
- Adds the missing FS-424E non PoE model and fixes the data sheet URL in the comment field.
- Adds the 48 port switches: FS-448E, FS-448E-POE, FS-448E-FPOE