### PR TITLE
Add 16 Fortinet FortiAP device types

### DIFF
--- a/device-types/Fortinet/FAP-221K.yaml
+++ b/device-types/Fortinet/FAP-221K.yaml
@@ -6,7 +6,7 @@ part_number: FAP-221K
 u_height: 0.0
 is_full_depth: false
 airflow: passive
-weight: 0.385
+weight: 0.39
 weight_unit: kg
 comments: '[FortiAP 221K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-221k-quickstart-guide)'
 console-ports:

--- a/device-types/Fortinet/FAP-221K.yaml
+++ b/device-types/Fortinet/FAP-221K.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: Fortinet
+model: FortiAP 221K
+slug: fortinet-fap-221k
+part_number: FAP-221K
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 221K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-221k-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 18
+    allocated_draw: 18
+interfaces:
+  - name: lan1-poe
+    type: 2.5gbase-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11be
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11be
+    description: 5GHz

--- a/device-types/Fortinet/FAP-221K.yaml
+++ b/device-types/Fortinet/FAP-221K.yaml
@@ -6,6 +6,8 @@ part_number: FAP-221K
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 0.385
+weight_unit: kg
 comments: '[FortiAP 221K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-221k-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-222KL.yaml
+++ b/device-types/Fortinet/FAP-222KL.yaml
@@ -6,6 +6,8 @@ part_number: FAP-222KL
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 2.7
+weight_unit: kg
 comments: '[FortiAP 222KL QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-222kl-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-222KL.yaml
+++ b/device-types/Fortinet/FAP-222KL.yaml
@@ -1,0 +1,36 @@
+---
+manufacturer: Fortinet
+model: FortiAP 222KL
+slug: fortinet-fap-222kl
+part_number: FAP-222KL
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 222KL QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-222kl-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: lan1-poe
+    type: 2.5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: lan2-pse
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type1-ieee802.3af
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-4
+    type: lte
+    description: LTE cellular radio
+  - name: radio-5
+    type: other-wireless
+    description: LoRa IoT radio

--- a/device-types/Fortinet/FAP-231G.yaml
+++ b/device-types/Fortinet/FAP-231G.yaml
@@ -6,6 +6,8 @@ part_number: FAP-231G
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 0.8
+weight_unit: kg
 comments: '[FortiAP 231G/233G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-231g-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-231G.yaml
+++ b/device-types/Fortinet/FAP-231G.yaml
@@ -1,0 +1,36 @@
+---
+manufacturer: Fortinet
+model: FortiAP 231G
+slug: fortinet-fap-231g
+part_number: FAP-231G
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 231G/233G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-231g-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 30
+    allocated_draw: 30
+interfaces:
+  - name: lan1-poe
+    type: 2.5gbase-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: lan2
+    type: 1000base-t
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11ax
+    description: 6GHz

--- a/device-types/Fortinet/FAP-231K.yaml
+++ b/device-types/Fortinet/FAP-231K.yaml
@@ -6,6 +6,8 @@ part_number: FAP-231K
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 1.01
+weight_unit: kg
 comments: '[FortiAP 231K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-231k-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-231K.yaml
+++ b/device-types/Fortinet/FAP-231K.yaml
@@ -1,0 +1,34 @@
+---
+manufacturer: Fortinet
+model: FortiAP 231K
+slug: fortinet-fap-231k
+part_number: FAP-231K
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 231K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-231k-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 36
+    allocated_draw: 36
+interfaces:
+  - name: lan1-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11be
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11be
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11be
+    description: 6GHz

--- a/device-types/Fortinet/FAP-234G.yaml
+++ b/device-types/Fortinet/FAP-234G.yaml
@@ -6,6 +6,8 @@ part_number: FAP-234G
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 1.38
+weight_unit: kg
 comments: '[FortiAP 234G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-234g-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-234G.yaml
+++ b/device-types/Fortinet/FAP-234G.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: Fortinet
+model: FortiAP 234G
+slug: fortinet-fap-234g
+part_number: FAP-234G
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 234G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-234g-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: lan1-poe
+    type: 2.5gbase-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: lan2
+    type: 1000base-t
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11ax
+    description: 6GHz

--- a/device-types/Fortinet/FAP-23JF.yaml
+++ b/device-types/Fortinet/FAP-23JF.yaml
@@ -1,0 +1,46 @@
+---
+manufacturer: Fortinet
+model: FortiAP 23JF
+slug: fortinet-fap-23jf
+part_number: FAP-23JF
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 23JF QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-23jf-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 43
+    allocated_draw: 43
+interfaces:
+  - name: wan-poe-in
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: lan1
+    type: 1000base-t
+  - name: lan2
+    type: 1000base-t
+  - name: lan3-pse
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type1-ieee802.3af
+  - name: pt-in
+    type: 1000base-t
+  - name: pt-out
+    type: 1000base-t
+  - name: radio-1
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-2
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-3
+    type: other-wireless
+    description: Scanning radio
+  - name: radio-4
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio

--- a/device-types/Fortinet/FAP-23JF.yaml
+++ b/device-types/Fortinet/FAP-23JF.yaml
@@ -6,6 +6,8 @@ part_number: FAP-23JF
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 0.45
+weight_unit: kg
 comments: '[FortiAP 23JF QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-23jf-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-23JK.yaml
+++ b/device-types/Fortinet/FAP-23JK.yaml
@@ -6,6 +6,8 @@ part_number: FAP-23JK
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 0.52
+weight_unit: kg
 comments: '[FortiAP 23JK QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-23jk-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-23JK.yaml
+++ b/device-types/Fortinet/FAP-23JK.yaml
@@ -1,0 +1,44 @@
+---
+manufacturer: Fortinet
+model: FortiAP 23JK
+slug: fortinet-fap-23jk
+part_number: FAP-23JK
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 23JK QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-23jk-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 65
+    allocated_draw: 65
+interfaces:
+  - name: wan-poe-in
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: lan1
+    type: 1000base-t
+  - name: lan2
+    type: 1000base-t
+  - name: lan3-pse-out
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type1-ieee802.3af
+  - name: pt-in
+    type: 1000base-t
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11be
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11be
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11be
+    description: 6GHz

--- a/device-types/Fortinet/FAP-243K.yaml
+++ b/device-types/Fortinet/FAP-243K.yaml
@@ -1,0 +1,36 @@
+---
+manufacturer: Fortinet
+model: FortiAP 243K
+slug: fortinet-fap-243k
+part_number: FAP-243K
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 241K/243K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-241k-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 36
+    allocated_draw: 36
+interfaces:
+  - name: lan1-poe
+    type: 10gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: lan2
+    type: 1000base-t
+  - name: radio-1
+    type: ieee802.11be
+    description: 2.4GHz
+  - name: radio-2
+    type: ieee802.11be
+    description: 5GHz
+  - name: radio-3
+    type: ieee802.11be
+    description: 6GHz
+  - name: radio-4
+    type: other-wireless
+    description: Scanning radio

--- a/device-types/Fortinet/FAP-243K.yaml
+++ b/device-types/Fortinet/FAP-243K.yaml
@@ -6,6 +6,8 @@ part_number: FAP-243K
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 1.18
+weight_unit: kg
 comments: '[FortiAP 241K/243K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-241k-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-244K.yaml
+++ b/device-types/Fortinet/FAP-244K.yaml
@@ -6,6 +6,8 @@ part_number: FAP-244K
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 2.4
+weight_unit: kg
 comments: '[FortiAP 244K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-244k-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-244K.yaml
+++ b/device-types/Fortinet/FAP-244K.yaml
@@ -1,0 +1,31 @@
+---
+manufacturer: Fortinet
+model: FortiAP 244K
+slug: fortinet-fap-244k
+part_number: FAP-244K
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 244K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-244k-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: lan1-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: sfp-uplink
+    type: 10gbase-x-sfpp
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11be
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11be
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11be
+    description: 6GHz

--- a/device-types/Fortinet/FAP-431F.yaml
+++ b/device-types/Fortinet/FAP-431F.yaml
@@ -1,0 +1,35 @@
+---
+manufacturer: Fortinet
+model: FortiAP 431F
+slug: fortinet-fap-431f
+part_number: FAP-431F
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 431F QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-431f-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 30
+    allocated_draw: 30
+interfaces:
+  - name: lan1-poe
+    type: 2.5gbase-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: lan2-poe
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: radio-1
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-2
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-3
+    type: other-wireless
+    description: BLE/ZigBee and scanning radio

--- a/device-types/Fortinet/FAP-431F.yaml
+++ b/device-types/Fortinet/FAP-431F.yaml
@@ -6,6 +6,8 @@ part_number: FAP-431F
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 0.98
+weight_unit: kg
 comments: '[FortiAP 431F QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-431f-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-431G.yaml
+++ b/device-types/Fortinet/FAP-431G.yaml
@@ -6,6 +6,8 @@ part_number: FAP-431G
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 1.4
+weight_unit: kg
 comments: '[FortiAP 431G/433G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-431g-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-431G.yaml
+++ b/device-types/Fortinet/FAP-431G.yaml
@@ -1,0 +1,38 @@
+---
+manufacturer: Fortinet
+model: FortiAP 431G
+slug: fortinet-fap-431g
+part_number: FAP-431G
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 431G/433G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-431g-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 48
+    allocated_draw: 48
+interfaces:
+  - name: lan1-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: lan2-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11ax
+    description: 6GHz

--- a/device-types/Fortinet/FAP-432G.yaml
+++ b/device-types/Fortinet/FAP-432G.yaml
@@ -6,6 +6,8 @@ part_number: FAP-432G
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 3.2
+weight_unit: kg
 comments: '[FortiAP 432G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-432g-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-432G.yaml
+++ b/device-types/Fortinet/FAP-432G.yaml
@@ -1,0 +1,33 @@
+---
+manufacturer: Fortinet
+model: FortiAP 432G
+slug: fortinet-fap-432g
+part_number: FAP-432G
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 432G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-432g-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+interfaces:
+  - name: lan1-poe
+    type: 10gbase-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: lan2-pse
+    type: 1000base-t
+    poe_mode: pse
+    poe_type: type1-ieee802.3af
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11ax
+    description: 6GHz

--- a/device-types/Fortinet/FAP-433G.yaml
+++ b/device-types/Fortinet/FAP-433G.yaml
@@ -6,6 +6,8 @@ part_number: FAP-433G
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 1.4
+weight_unit: kg
 comments: '[FortiAP 431G/433G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-431g-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-433G.yaml
+++ b/device-types/Fortinet/FAP-433G.yaml
@@ -1,0 +1,38 @@
+---
+manufacturer: Fortinet
+model: FortiAP 433G
+slug: fortinet-fap-433g
+part_number: FAP-433G
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 431G/433G QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-431g-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 48
+    allocated_draw: 48
+interfaces:
+  - name: lan1-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: lan2-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11ax
+    description: 6GHz

--- a/device-types/Fortinet/FAP-441K.yaml
+++ b/device-types/Fortinet/FAP-441K.yaml
@@ -6,6 +6,8 @@ part_number: FAP-441K
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 1.98
+weight_unit: kg
 comments: '[FortiAP 441K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-441k-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-441K.yaml
+++ b/device-types/Fortinet/FAP-441K.yaml
@@ -1,0 +1,38 @@
+---
+manufacturer: Fortinet
+model: FortiAP 441K
+slug: fortinet-fap-441k
+part_number: FAP-441K
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 441K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-441k-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 48
+    allocated_draw: 48
+interfaces:
+  - name: lan1-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: lan2-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11be
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11be
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11be
+    description: 6GHz

--- a/device-types/Fortinet/FAP-443K.yaml
+++ b/device-types/Fortinet/FAP-443K.yaml
@@ -1,0 +1,38 @@
+---
+manufacturer: Fortinet
+model: FortiAP 443K
+slug: fortinet-fap-443k
+part_number: FAP-443K
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 443K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-443k-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 48
+    allocated_draw: 48
+interfaces:
+  - name: lan1-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: lan2-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type3-ieee802.3bt
+  - name: radio-1
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio
+  - name: radio-2
+    type: ieee802.11be
+    description: 2.4GHz
+  - name: radio-3
+    type: ieee802.11be
+    description: 5GHz
+  - name: radio-4
+    type: ieee802.11be
+    description: 6GHz

--- a/device-types/Fortinet/FAP-443K.yaml
+++ b/device-types/Fortinet/FAP-443K.yaml
@@ -6,6 +6,8 @@ part_number: FAP-443K
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 1.98
+weight_unit: kg
 comments: '[FortiAP 443K QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-443k-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-831F.yaml
+++ b/device-types/Fortinet/FAP-831F.yaml
@@ -6,6 +6,8 @@ part_number: FAP-831F
 u_height: 0.0
 is_full_depth: false
 airflow: passive
+weight: 1.02
+weight_unit: kg
 comments: '[FortiAP 831F QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-831f-quickstart-guide)'
 console-ports:
   - name: Console

--- a/device-types/Fortinet/FAP-831F.yaml
+++ b/device-types/Fortinet/FAP-831F.yaml
@@ -1,0 +1,38 @@
+---
+manufacturer: Fortinet
+model: FortiAP 831F
+slug: fortinet-fap-831f
+part_number: FAP-831F
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+comments: '[FortiAP 831F QuickStart Guide](https://docs.fortinet.com/document/fortiap/hardware/fortiap-831f-quickstart-guide)'
+console-ports:
+  - name: Console
+    type: rj-45
+power-ports:
+  - name: DC-In
+    type: dc-terminal
+    maximum_draw: 36
+    allocated_draw: 36
+interfaces:
+  - name: lan1-poe
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: lan2-poe
+    type: 1000base-t
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+  - name: radio-1
+    type: ieee802.11ax
+    description: 2.4GHz
+  - name: radio-2
+    type: ieee802.11ax
+    description: 5GHz
+  - name: radio-3
+    type: other-wireless
+    description: Scanning radio
+  - name: radio-4
+    type: ieee802.15.1
+    description: BLE/ZigBee IoT radio


### PR DESCRIPTION
Adds YAML definitions for the following FortiAP models not previously in the library:

Wi-Fi 7 (802.11be): FAP-221K, FAP-231K, FAP-243K, FAP-244K, FAP-441K,
  FAP-443K, FAP-23JK
Wi-Fi 6E (802.11ax, 6GHz): FAP-222KL, FAP-231G, FAP-234G, FAP-431G,
  FAP-432G, FAP-433G
Wi-Fi 6 (802.11ax): FAP-23JF, FAP-431F, FAP-831F

Specs sourced from official Fortinet QuickStart Guide PDFs.