### PR TITLE
Fixing failure case for empty commit on master slugs

### DIFF
--- a/.github/workflows/master-slugs.yml
+++ b/.github/workflows/master-slugs.yml
@@ -42,7 +42,11 @@ jobs:
       - name: Commit
         run: |
           git add .
-          git commit -m "Regenerate master slug list after successful PR merge"
+          if git diff --cached --quiet; then
+            echo "No slug changes to commit."
+          else
+            git commit -m "Regenerate master slug list after successful PR merge"
+          fi
       - name: Push to remote
         run: |
           git push


### PR DESCRIPTION
The workflow would fail when there is nothing new to commit. Adding small check so it only commits when the slug list actually changes.