### PR TITLE
Fix FRITZ!Repeater 1200 AX: correct WiFi type and add dual-band interfaces

### DIFF
--- a/device-types/AVM/FRITZRepeater-1200AX.yaml
+++ b/device-types/AVM/FRITZRepeater-1200AX.yaml
@@ -16,5 +16,9 @@ interfaces:
   - name: LAN
     label: LAN
     type: 1000base-t
-  - name: WiFi
-    type: ieee802.11ac
+  - name: WiFi 5GHz
+    type: ieee802.11ax
+    description: 5 GHz, 2400 Mbit/s
+  - name: WiFi 2.4GHz
+    type: ieee802.11ax
+    description: 2.4 GHz, 600 Mbit/s


### PR DESCRIPTION
   The FRITZ!Repeater 1200 AX supports Wi-Fi 6 (802.11ax) as indicated by its product name,
   but the device type definition had `ieee802.11ac`. 
   Also split the single WiFi interface
   into separate 5 GHz (2400 Mbit/s) and 2.4 GHz (600 Mbit/s) interfaces to match the
   dual-band hardware.
   
   Reference: https://avm.de/produkte/wlan-mesh/fritzrepeater-1200-ax/technische-daten/