### PR TITLE
Add Apple iPhone device types (iPhone X through 17, SE, Air, e)

### DIFF
--- a/device-types/Apple/iphone-11-pro-max.yaml
+++ b/device-types/Apple/iphone-11-pro-max.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 11 Pro Max
+slug: apple-iphone-11-pro-max
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 226
+weight_unit: g
+comments: |
+  Model numbers: A2161, A2218, A2220
+  [iPhone 11 Pro Max - Tech Specs](https://support.apple.com/kb/SP806)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-11-pro.yaml
+++ b/device-types/Apple/iphone-11-pro.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 11 Pro
+slug: apple-iphone-11-pro
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 188
+weight_unit: g
+comments: |
+  Model numbers: A2160, A2215, A2217
+  [iPhone 11 Pro - Tech Specs](https://support.apple.com/kb/SP805)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-11.yaml
+++ b/device-types/Apple/iphone-11.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 11
+slug: apple-iphone-11
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 194
+weight_unit: g
+comments: |
+  Model numbers: A2111, A2221, A2223
+  [iPhone 11 - Tech Specs](https://support.apple.com/kb/SP804)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-12-mini.yaml
+++ b/device-types/Apple/iphone-12-mini.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 12 mini
+slug: apple-iphone-12-mini
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 135
+weight_unit: g
+comments: |
+  Model numbers: A2176, A2398, A2399, A2400
+  [iPhone 12 mini - Tech Specs](https://support.apple.com/kb/SP829)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-12-pro-max.yaml
+++ b/device-types/Apple/iphone-12-pro-max.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 12 Pro Max
+slug: apple-iphone-12-pro-max
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 228
+weight_unit: g
+comments: |
+  Model numbers: A2342, A2410, A2411, A2412
+  [iPhone 12 Pro Max - Tech Specs](https://support.apple.com/kb/SP832)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-12-pro.yaml
+++ b/device-types/Apple/iphone-12-pro.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 12 Pro
+slug: apple-iphone-12-pro
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 189
+weight_unit: g
+comments: |
+  Model numbers: A2341, A2406, A2407, A2408
+  [iPhone 12 Pro - Tech Specs](https://support.apple.com/kb/SP831)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-12.yaml
+++ b/device-types/Apple/iphone-12.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 12
+slug: apple-iphone-12
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 164
+weight_unit: g
+comments: |
+  Model numbers: A2172, A2402, A2403, A2404
+  [iPhone 12 - Tech Specs](https://support.apple.com/kb/SP830)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-13-mini.yaml
+++ b/device-types/Apple/iphone-13-mini.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 13 mini
+slug: apple-iphone-13-mini
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 140
+weight_unit: g
+comments: |
+  Model numbers: A2481, A2626, A2628, A2629, A2630
+  [iPhone 13 mini - Tech Specs](https://support.apple.com/kb/SP847)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-13-pro-max.yaml
+++ b/device-types/Apple/iphone-13-pro-max.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 13 Pro Max
+slug: apple-iphone-13-pro-max
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 240
+weight_unit: g
+comments: |
+  Model numbers: A2484, A2641, A2643, A2644, A2645
+  [iPhone 13 Pro Max - Tech Specs](https://support.apple.com/kb/SP848)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-13-pro.yaml
+++ b/device-types/Apple/iphone-13-pro.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 13 Pro
+slug: apple-iphone-13-pro
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 204
+weight_unit: g
+comments: |
+  Model numbers: A2483, A2636, A2638, A2639, A2640
+  [iPhone 13 Pro - Tech Specs](https://support.apple.com/kb/SP852)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-13.yaml
+++ b/device-types/Apple/iphone-13.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 13
+slug: apple-iphone-13
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 174
+weight_unit: g
+comments: |
+  Model numbers: A2482, A2631, A2633, A2634, A2635
+  [iPhone 13 - Tech Specs](https://support.apple.com/kb/SP851)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-14-plus.yaml
+++ b/device-types/Apple/iphone-14-plus.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 14 Plus
+slug: apple-iphone-14-plus
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 203
+weight_unit: g
+comments: |
+  Model numbers: A2632, A2885, A2886, A2887, A2888
+  [iPhone 14 Plus - Tech Specs](https://support.apple.com/kb/SP874)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-14-pro-max.yaml
+++ b/device-types/Apple/iphone-14-pro-max.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 14 Pro Max
+slug: apple-iphone-14-pro-max
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 240
+weight_unit: g
+comments: |
+  Model numbers: A2651, A2893, A2894, A2895, A2896
+  [iPhone 14 Pro Max - Tech Specs](https://support.apple.com/kb/SP876)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-14-pro.yaml
+++ b/device-types/Apple/iphone-14-pro.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 14 Pro
+slug: apple-iphone-14-pro
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 206
+weight_unit: g
+comments: |
+  Model numbers: A2650, A2889, A2890, A2891, A2892
+  [iPhone 14 Pro - Tech Specs](https://support.apple.com/kb/SP875)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-14.yaml
+++ b/device-types/Apple/iphone-14.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 14
+slug: apple-iphone-14
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 172
+weight_unit: g
+comments: |
+  Model numbers: A2649, A2881, A2882, A2883, A2884
+  [iPhone 14 - Tech Specs](https://support.apple.com/kb/SP873)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-15-plus.yaml
+++ b/device-types/Apple/iphone-15-plus.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 15 Plus
+slug: apple-iphone-15-plus
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 201
+weight_unit: g
+comments: |
+  Model numbers: A2847, A3093, A3094, A3096
+  [iPhone 15 Plus - Tech Specs](https://support.apple.com/kb/SP902)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-15-pro-max.yaml
+++ b/device-types/Apple/iphone-15-pro-max.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 15 Pro Max
+slug: apple-iphone-15-pro-max
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 221
+weight_unit: g
+comments: |
+  Model numbers: A2849, A3105, A3106, A3108
+  [iPhone 15 Pro Max - Tech Specs](https://support.apple.com/kb/SP904)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-15-pro.yaml
+++ b/device-types/Apple/iphone-15-pro.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 15 Pro
+slug: apple-iphone-15-pro
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 187
+weight_unit: g
+comments: |
+  Model numbers: A2848, A3101, A3102, A3104
+  [iPhone 15 Pro - Tech Specs](https://support.apple.com/kb/SP903)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-15.yaml
+++ b/device-types/Apple/iphone-15.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 15
+slug: apple-iphone-15
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 171
+weight_unit: g
+comments: |
+  Model numbers: A2846, A3089, A3090, A3092
+  [iPhone 15 - Tech Specs](https://support.apple.com/kb/SP901)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-16-plus.yaml
+++ b/device-types/Apple/iphone-16-plus.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 16 Plus
+slug: apple-iphone-16-plus
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 199
+weight_unit: g
+comments: |
+  Model numbers: A3082, A3289, A3290, A3291
+  [iPhone 16 Plus - Tech Specs](https://support.apple.com/en-us/121030)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11be
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-16-pro-max.yaml
+++ b/device-types/Apple/iphone-16-pro-max.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 16 Pro Max
+slug: apple-iphone-16-pro-max
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 227
+weight_unit: g
+comments: |
+  Model numbers: A3084, A3295, A3296, A3297
+  [iPhone 16 Pro Max - Tech Specs](https://support.apple.com/en-us/121032)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11be
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-16-pro.yaml
+++ b/device-types/Apple/iphone-16-pro.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 16 Pro
+slug: apple-iphone-16-pro
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 199
+weight_unit: g
+comments: |
+  Model numbers: A3083, A3292, A3293, A3294
+  [iPhone 16 Pro - Tech Specs](https://support.apple.com/en-us/121031)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11be
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-16.yaml
+++ b/device-types/Apple/iphone-16.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 16
+slug: apple-iphone-16
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 170
+weight_unit: g
+comments: |
+  Model numbers: A3081, A3286, A3287, A3288
+  [iPhone 16 - Tech Specs](https://support.apple.com/en-us/121029)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11be
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-16e.yaml
+++ b/device-types/Apple/iphone-16e.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 16e
+slug: apple-iphone-16e
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 167
+weight_unit: g
+comments: |
+  Model numbers: A3212, A3408, A3409, A3410
+  [iPhone 16e - Tech Specs](https://support.apple.com/en-us/122208)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-17-pro-max.yaml
+++ b/device-types/Apple/iphone-17-pro-max.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 17 Pro Max
+slug: apple-iphone-17-pro-max
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 233
+weight_unit: g
+comments: |
+  Model numbers: A3257, A3525, A3526, A3527
+  [iPhone 17 Pro Max - Tech Specs](https://support.apple.com/en-us/125091)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11be
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-17-pro.yaml
+++ b/device-types/Apple/iphone-17-pro.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 17 Pro
+slug: apple-iphone-17-pro
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 206
+weight_unit: g
+comments: |
+  Model numbers: A3256, A3522, A3523, A3524
+  [iPhone 17 Pro - Tech Specs](https://support.apple.com/en-us/125090)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11be
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-17.yaml
+++ b/device-types/Apple/iphone-17.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 17
+slug: apple-iphone-17
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 177
+weight_unit: g
+comments: |
+  Model numbers: A3258, A3519, A3520, A3521
+  [iPhone 17 - Tech Specs](https://support.apple.com/en-us/125089)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11be
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-17e.yaml
+++ b/device-types/Apple/iphone-17e.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone 17e
+slug: apple-iphone-17e
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 169
+weight_unit: g
+comments: |
+  Model numbers: A3575, A3634, A3635
+  [iPhone 17e - Tech Specs](https://support.apple.com/en-us/126470)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-air.yaml
+++ b/device-types/Apple/iphone-air.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone Air
+slug: apple-iphone-air
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 165
+weight_unit: g
+comments: |
+  Model numbers: A3260, A3516, A3517, A3518
+  [iPhone Air - Tech Specs](https://support.apple.com/en-us/125092)
+power-ports:
+  - name: USB-C
+    type: usb-c
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11be
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-se-1st-generation.yaml
+++ b/device-types/Apple/iphone-se-1st-generation.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone SE (1st generation)
+slug: apple-iphone-se-1st-generation
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 113
+weight_unit: g
+comments: |
+  Model numbers: A1662, A1723, A1724
+  [iPhone SE (1st generation) - Tech Specs](https://support.apple.com/kb/SP738)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ac
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-se-2nd-generation.yaml
+++ b/device-types/Apple/iphone-se-2nd-generation.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone SE (2nd generation)
+slug: apple-iphone-se-2nd-generation
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 148
+weight_unit: g
+comments: |
+  Model numbers: A2275, A2296, A2298
+  [iPhone SE (2nd generation) - Tech Specs](https://support.apple.com/kb/SP820)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-se-3rd-generation.yaml
+++ b/device-types/Apple/iphone-se-3rd-generation.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone SE (3rd generation)
+slug: apple-iphone-se-3rd-generation
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 144
+weight_unit: g
+comments: |
+  Model numbers: A2595, A2782, A2783, A2784, A2785
+  [iPhone SE (3rd generation) - Tech Specs](https://support.apple.com/kb/SP867)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: 5g
+  - name: Wi-Fi
+    type: ieee802.11ax
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-x.yaml
+++ b/device-types/Apple/iphone-x.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone X
+slug: apple-iphone-x
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 174
+weight_unit: g
+comments: |
+  Model numbers: A1865, A1901, A1902
+  [iPhone X - Tech Specs](https://support.apple.com/kb/SP770)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ac
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-xr.yaml
+++ b/device-types/Apple/iphone-xr.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone XR
+slug: apple-iphone-xr
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 194
+weight_unit: g
+comments: |
+  Model numbers: A1984, A2105, A2106, A2107, A2108
+  [iPhone XR - Tech Specs](https://support.apple.com/kb/SP781)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ac
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-xs-max.yaml
+++ b/device-types/Apple/iphone-xs-max.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone XS Max
+slug: apple-iphone-xs-max
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 208
+weight_unit: g
+comments: |
+  Model numbers: A1921, A2101, A2102, A2103, A2104
+  [iPhone XS Max - Tech Specs](https://support.apple.com/kb/SP780)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ac
+  - name: Bluetooth
+    type: ieee802.15.1

--- a/device-types/Apple/iphone-xs.yaml
+++ b/device-types/Apple/iphone-xs.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Apple
+model: iPhone XS
+slug: apple-iphone-xs
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 177
+weight_unit: g
+comments: |
+  Model numbers: A1920, A2097, A2098, A2099, A2100
+  [iPhone XS - Tech Specs](https://support.apple.com/kb/SP779)
+power-ports:
+  - name: Lightning
+    type: other
+interfaces:
+  - name: Cellular
+    type: lte
+  - name: Wi-Fi
+    type: ieee802.11ac
+  - name: Bluetooth
+    type: ieee802.15.1


### PR DESCRIPTION
Adds 36 device-type definitions for Apple iPhones, from iPhone X up to the iPhone 17 line, including all Pro / Pro Max / Plus / mini variants as well as iPhone SE (1st–3rd generation), iPhone Air, and the 16e / 17e models.