### PR TITLE
Update USW-Pro-Max-48-PoE.yaml

### DIFF
--- a/device-types/Ubiquiti/USW-Pro-Max-48-PoE.yaml
+++ b/device-types/Ubiquiti/USW-Pro-Max-48-PoE.yaml
@@ -150,35 +150,35 @@ interfaces:
   - name: Port 33
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3at
+    poe_type: type2-ieee802.3at
   - name: Port 34
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3at
+    poe_type: type2-ieee802.3at
   - name: Port 35
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3at
+    poe_type: type2-ieee802.3at
   - name: Port 36
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3at
+    poe_type: type2-ieee802.3at
   - name: Port 37
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3at
+    poe_type: type2-ieee802.3at
   - name: Port 38
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3at
+    poe_type: type2-ieee802.3at
   - name: Port 39
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3at
+    poe_type: type2-ieee802.3at
   - name: Port 40
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3at
+    poe_type: type2-ieee802.3at
   # 2.5GbE PoE++ ports (41-48)
   - name: Port 41
     type: 2.5gbase-t

--- a/device-types/Ubiquiti/USW-Pro-Max-48-PoE.yaml
+++ b/device-types/Ubiquiti/USW-Pro-Max-48-PoE.yaml
@@ -146,39 +146,40 @@ interfaces:
     type: 1000base-t
     poe_mode: pse
     poe_type: type3-ieee802.3bt
-  # 2.5GbE PoE++ ports (33-48)
+  # 2.5GbE PoE+ ports (33-40)
   - name: Port 33
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3bt
+    poe_type: type3-ieee802.3at
   - name: Port 34
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3bt
+    poe_type: type3-ieee802.3at
   - name: Port 35
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3bt
+    poe_type: type3-ieee802.3at
   - name: Port 36
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3bt
+    poe_type: type3-ieee802.3at
   - name: Port 37
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3bt
+    poe_type: type3-ieee802.3at
   - name: Port 38
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3bt
+    poe_type: type3-ieee802.3at
   - name: Port 39
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3bt
+    poe_type: type3-ieee802.3at
   - name: Port 40
     type: 2.5gbase-t
     poe_mode: pse
-    poe_type: type3-ieee802.3bt
+    poe_type: type3-ieee802.3at
+  # 2.5GbE PoE++ ports (41-48)
   - name: Port 41
     type: 2.5gbase-t
     poe_mode: pse


### PR DESCRIPTION
Ports 33-40 are PoE+. They are not PoE++ as currently identified. See https://techspecs.ui.com/unifi/switching/usw-pro-max-48-poe for reference.