### PR TITLE
Create AP36M.yaml

### DIFF
--- a/device-types/Juniper/AP36M.yaml
+++ b/device-types/Juniper/AP36M.yaml
@@ -9,7 +9,7 @@ airflow: passive
 weight: 1.53
 weight_unit: kg
 comments: "- Datasheet: [https://www.hpe.com/psnow/doc/a50014091enw](https://www.hpe.com/psnow/doc/a50014091enw)\r\
-  \n- IEEE Standards: 802.11a, 802.11ac, 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be
+  \n- IEEE Standards: 802.11a, 802.11ac, 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be\r\
   \n- Low Power Indoor and Standard Power (US only)"
 interfaces:
   - name: eth0

--- a/device-types/Juniper/AP36M.yaml
+++ b/device-types/Juniper/AP36M.yaml
@@ -8,9 +8,8 @@ u_height: 0
 airflow: passive
 weight: 1.53
 weight_unit: kg
-comments: "- Datasheet: [https://www.hpe.com/psnow/doc/a50014091enw](https://www.hpe.com/psnow/doc/a50014091enw)\r\n- \
-IEEE Standards: 802.11a, 802.11ac, 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be\r\n- \
-Low Power Indoor and Standard Power (US only)"
+comments: "- Datasheet: [https://www.hpe.com/psnow/doc/a50014091enw](https://www.hpe.com/psnow/doc/a50014091enw)\r\n- IEEE Standards: 802.11a, 802.11ac,\
+  \ 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be\r\n- Low Power Indoor and Standard Power (US only)"
 interfaces:
   - name: eth0
     type: 5gbase-t

--- a/device-types/Juniper/AP36M.yaml
+++ b/device-types/Juniper/AP36M.yaml
@@ -1,0 +1,32 @@
+---
+manufacturer: Juniper
+model: AP36M
+slug: juniper-ap36m
+part_number: AP36M-US
+is_full_depth: false
+u_height: 0
+airflow: passive
+weight: 1.53
+weight_unit: kg
+comments: "- Datasheet: [https://www.hpe.com/psnow/doc/a50014091enw](https://www.hpe.com/psnow/doc/a50014091enw)\r\
+  \n- IEEE Standards: 802.11a, 802.11ac, 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be
+  \n- Low Power Indoor and Standard Power (US only)"
+interfaces:
+  - name: eth0
+    type: 5gbase-t
+    poe_mode: pd
+    poe_type: type4-ieee802.3bt
+  - name: eth1
+    type: 1000base-t
+  - name: wlan0
+    type: ieee802.11be
+    description: 2.4GHz
+  - name: wlan1
+    type: ieee802.11be
+    description: 5GHz
+  - name: wlan2
+    type: ieee802.11be
+    description: 6GHz
+  - name: wlan3
+    type: other-wireless
+    description: WIDS/WIPS

--- a/device-types/Juniper/AP36M.yaml
+++ b/device-types/Juniper/AP36M.yaml
@@ -8,9 +8,9 @@ u_height: 0
 airflow: passive
 weight: 1.53
 weight_unit: kg
-comments: "- Datasheet: [https://www.hpe.com/psnow/doc/a50014091enw](https://www.hpe.com/psnow/doc/a50014091enw)\r\
-  \n- IEEE Standards: 802.11a, 802.11ac, 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be\r\
-  \n- Low Power Indoor and Standard Power (US only)"
+comments: "- Datasheet: [https://www.hpe.com/psnow/doc/a50014091enw](https://www.hpe.com/psnow/doc/a50014091enw)\r\n\
+- IEEE Standards: 802.11a, 802.11ac, 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be\r\n\
+- Low Power Indoor and Standard Power (US only)"
 interfaces:
   - name: eth0
     type: 5gbase-t

--- a/device-types/Juniper/AP36M.yaml
+++ b/device-types/Juniper/AP36M.yaml
@@ -8,9 +8,9 @@ u_height: 0
 airflow: passive
 weight: 1.53
 weight_unit: kg
-comments: "- Datasheet: [https://www.hpe.com/psnow/doc/a50014091enw](https://www.hpe.com/psnow/doc/a50014091enw)\r\n\
-- IEEE Standards: 802.11a, 802.11ac, 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be\r\n\
-- Low Power Indoor and Standard Power (US only)"
+comments: "- Datasheet: [https://www.hpe.com/psnow/doc/a50014091enw](https://www.hpe.com/psnow/doc/a50014091enw)\r\n- \
+IEEE Standards: 802.11a, 802.11ac, 802.11ax, 802.11b, 802.11e, 802.11g, 802.11h, 802.11i, 802.11k, 802.11n, 802.11r, 802.11u, 802.11be\r\n- \
+Low Power Indoor and Standard Power (US only)"
 interfaces:
   - name: eth0
     type: 5gbase-t


### PR DESCRIPTION
I'm not sure if there is a preference between the -US or -WW (worldwide) versions. I'm adding the US version. 

The only difference between -US and -WW devices is the worldwide does not offer standard power. This relates to the comment "  \n- Low Power Indoor and Standard Power (US only)".