### PR TITLE
Add Hitron HT-EM5

### DIFF
--- a/device-types/Hitron/HT-EM5.yaml
+++ b/device-types/Hitron/HT-EM5.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Hitron
+model: HT-EM5
+slug: hitron-ht-em5
+part_number: 860009155343
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 110
+weight_unit: g
+front_image: false
+rear_image: false
+description: Hitron MoCA 2.5 Coax to Ethernet Adapter
+comments: '[Hitron HT-EM5](https://us.hitrontech.com/products/consumers/htem5-moca-2-5-coax-to-ethernet-adapter/)'
+power-ports:
+  - name: 12V DC
+    type: dc-terminal
+    maximum_draw: 5
+interfaces:
+  - name: Ethernet 1
+    type: 2.5gbase-t
+  - name: Coax
+    type: moca

--- a/device-types/Hitron/HT-EM5.yaml
+++ b/device-types/Hitron/HT-EM5.yaml
@@ -2,7 +2,7 @@
 manufacturer: Hitron
 model: HT-EM5
 slug: hitron-ht-em5
-part_number: 860009155343
+part_number: '860009155343'
 u_height: 0
 is_full_depth: false
 airflow: passive


### PR DESCRIPTION
## Summary
- Adds the Hitron HT-EM5, a MoCA 2.5 Coax to Ethernet Adapter
- Includes power port (12V DC, 5W max draw per datasheet), 2.5GBASE-T Ethernet interfaces, and MoCA coax interface

## Test Plan
- [x] YAML passes pre-commit checks (trailing-whitespace, end-of-file, check-yaml, yamlfmt, yamllint)
- [x] PyTest case checks passed