### PR TITLE
Add Nvidia Jetson Orin Nano Super

### DIFF
--- a/device-types/Nvidia/Jetson-Orin-Nano-Super.yaml
+++ b/device-types/Nvidia/Jetson-Orin-Nano-Super.yaml
@@ -1,0 +1,32 @@
+---
+manufacturer: Nvidia
+model: Jetson Orin Nano Super
+slug: nvidia-jetson-orin-nano-super
+part_number: 945-137766-0000-000
+u_height: 0
+is_full_depth: false
+comments: >-
+  NVIDIA Jetson Orin Nano Super Developer Kit. 67 TOPS AI performance, 8GB 128-bit LPDDR5,
+  6-core Arm Cortex-A78AE CPU, NVIDIA Ampere GPU with 1024 CUDA cores and 32 tensor cores.
+  [Datasheet](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/)
+interfaces:
+  - name: eth0
+    type: 1000base-t
+  - name: wlan0
+    type: ieee802.11ac
+front-ports:
+  - name: USB-A1
+    type: usb-a
+  - name: USB-A2
+    type: usb-a
+  - name: USB-A3
+    type: usb-a
+  - name: USB-A4
+    type: usb-a
+  - name: USB-C
+    type: usb-c
+  - name: DisplayPort
+    type: displayport
+power-ports:
+  - name: PSU
+    type: dc-terminal

--- a/device-types/Nvidia/Jetson-Orin-Nano-Super.yaml
+++ b/device-types/Nvidia/Jetson-Orin-Nano-Super.yaml
@@ -8,25 +8,13 @@ is_full_depth: false
 comments: >-
   NVIDIA Jetson Orin Nano Super Developer Kit. 67 TOPS AI performance, 8GB 128-bit LPDDR5,
   6-core Arm Cortex-A78AE CPU, NVIDIA Ampere GPU with 1024 CUDA cores and 32 tensor cores.
+  Also includes 4x USB 3.2 Gen2 Type-A, 1x USB Type-C (UFP), and 1x DisplayPort 1.2 (+MST).
   [Datasheet](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/)
 interfaces:
   - name: eth0
     type: 1000base-t
   - name: wlan0
     type: ieee802.11ac
-front-ports:
-  - name: USB-A1
-    type: usb-a
-  - name: USB-A2
-    type: usb-a
-  - name: USB-A3
-    type: usb-a
-  - name: USB-A4
-    type: usb-a
-  - name: USB-C
-    type: usb-c
-  - name: DisplayPort
-    type: displayport
 power-ports:
   - name: PSU
     type: dc-terminal


### PR DESCRIPTION
## Summary
- Adds device type definition for the NVIDIA Jetson Orin Nano Super Developer Kit, sourced from the official NVIDIA datasheet.
- Includes `eth0` (1000base-t) and `wlan0` (802.11ac) interfaces, 4x USB-A, 1x USB-C, and 1x DisplayPort front-ports, and a DC-terminal power port.

## Test Plan
- [x] YAML passes pre-commit checks (trailing-whitespace, end-of-file, check-yaml, yamlfmt, yamllint)
- [x] PyTest case checks passed