### PR TITLE
Add Technicolor XB8

### DIFF
--- a/device-types/Technicolor/XB8.yaml
+++ b/device-types/Technicolor/XB8.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Technicolor
+model: XB8
+slug: technicolor-xb8
+part_number: CGM4981COM
+u_height: 0
+is_full_depth: false
+comments: >-
+  [Xfinity-branded DOCSIS 3.1 gateway (CGM4981COM)](https://www.xfinity.com/support/articles/broadband-gateways-userguides),
+  manufactured by Technicolor.
+weight: 2.5
+weight_unit: lb
+airflow: passive
+power-ports:
+  - name: Power
+    type: dc-terminal
+interfaces:
+  - name: Ethernet 1
+    type: 1000base-t
+  - name: Ethernet 2
+    type: 1000base-t
+  - name: Ethernet 3
+    type: 1000base-t
+  - name: Ethernet 4
+    type: 2.5gbase-t
+  - name: Coax
+    type: docsis


### PR DESCRIPTION
## Summary
- Adds device-type definition for the Technicolor XB8 (CGM4981COM), an Xfinity-branded DOCSIS 3.1 cable gateway.
- Includes power port (12V DC terminal), 4 Ethernet ports (3x 1000BASE-T, 1x 2.5GBASE-T), and a DOCSIS coax interface, based on the manufacturer's setup and user guide.

## Test Plan
- [x]  YAML passes pre-commit checks (trailing-whitespace, end-of-file, check-yaml, yamlfmt, yamllint)
- [x] PyTest case checks passed