### PR TITLE
Change legacy cisco management interface format

### DIFF
--- a/device-types/Cisco/C9200-24T.yaml
+++ b/device-types/Cisco/C9200-24T.yaml
@@ -69,7 +69,7 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true
 module-bays:

--- a/device-types/Cisco/C9200-48T.yaml
+++ b/device-types/Cisco/C9200-48T.yaml
@@ -115,7 +115,7 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true
 module-bays:

--- a/device-types/Cisco/C9200L-24P-4G.yaml
+++ b/device-types/Cisco/C9200L-24P-4G.yaml
@@ -132,6 +132,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/C9200L-24P-4X.yaml
+++ b/device-types/Cisco/C9200L-24P-4X.yaml
@@ -131,6 +131,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/C9200L-24T-4G.yaml
+++ b/device-types/Cisco/C9200L-24T-4G.yaml
@@ -77,6 +77,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/C9200L-24T-4X.yaml
+++ b/device-types/Cisco/C9200L-24T-4X.yaml
@@ -77,6 +77,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/C9200L-48P-4G.yaml
+++ b/device-types/Cisco/C9200L-48P-4G.yaml
@@ -223,6 +223,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/C9200L-48P-4X.yaml
+++ b/device-types/Cisco/C9200L-48P-4X.yaml
@@ -223,6 +223,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/C9200L-48PL-4G.yaml
+++ b/device-types/Cisco/C9200L-48PL-4G.yaml
@@ -125,6 +125,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/C9200L-48T-4G.yaml
+++ b/device-types/Cisco/C9200L-48T-4G.yaml
@@ -125,6 +125,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true

--- a/device-types/Cisco/C9200L-48T-4X.yaml
+++ b/device-types/Cisco/C9200L-48T-4X.yaml
@@ -125,6 +125,6 @@ interfaces:
     type: cisco-stackwise
   - name: StackPort1/2
     type: cisco-stackwise
-  - name: GigabitEthernet0
+  - name: GigabitEthernet0/0
     type: 1000base-t
     mgmt_only: true


### PR DESCRIPTION
Changed `GigabitEthernet0` to `GigabitEthernet0/0` in 11 left over files.

Some of the 9200 and 9200L files still had the former format.