### PR TITLE
Added management interface for Cisco C9200L-24T-4G-E

### DIFF
--- a/device-types/Cisco/C9200L-24T-4G-E.yaml
+++ b/device-types/Cisco/C9200L-24T-4G-E.yaml
@@ -20,6 +20,9 @@ module-bays:
   - name: PSU 2
     position: '2'
 interfaces:
+  - name: GigabitEthernet0/0
+    type: 1000base-t
+    mgmt_only: true
   - name: GigabitEthernet1/0/1
     type: 1000base-t
   - name: GigabitEthernet1/0/2


### PR DESCRIPTION
The definition for the management interface of the switch is missing (GigabitEthernet0/0)