### PR TITLE
feat(synology): add RS2423+ and RS2423RP+II device types

### DIFF
--- a/device-types/Synology/RS2423+.yaml
+++ b/device-types/Synology/RS2423+.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Synology
+model: RS2423+
+slug: synology-rs2423-plus
+part_number: RS2423+
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+weight: 11.5
+weight_unit: kg
+comments: |-
+  12-bay 2U RackStation, expandable to 24 bays with one RX1223RP expansion unit.
+  Physical dimensions: 88 mm x 482 mm x 552 mm.
+  Single 500 W power supply unit (non-redundant); the RS2423RP+II offers redundant PSUs.
+  [Hardware Specifications](https://www.synology.com/en-us/products/RS2423+#specs)
+power-ports:
+  - name: PSU 1
+    type: iec-60320-c14
+interfaces:
+  - name: LAN1
+    type: 1000base-t
+  - name: LAN2
+    type: 1000base-t
+  - name: LAN3
+    type: 10gbase-t
+module-bays:
+  - name: PCIe Slot 1
+    position: '1'

--- a/device-types/Synology/RS2423RP+II.yaml
+++ b/device-types/Synology/RS2423RP+II.yaml
@@ -1,0 +1,30 @@
+---
+manufacturer: Synology
+model: RS2423RP+II
+slug: synology-rs2423rp-plus-ii
+part_number: RS2423RP+II
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+weight: 11.9
+weight_unit: kg
+comments: |-
+  12-bay 2U RackStation with redundant power supplies, expandable to 24 bays with one RX1223RP expansion unit.
+  Physical dimensions: 88 mm x 482 mm x 578 mm.
+  Two 550 W power supply units; ships with two AC power cords.
+  [Hardware Specifications](https://www.synology.com/en-us/products/RS2423+#specs)
+power-ports:
+  - name: PSU 1
+    type: iec-60320-c14
+  - name: PSU 2
+    type: iec-60320-c14
+interfaces:
+  - name: LAN1
+    type: 1000base-t
+  - name: LAN2
+    type: 1000base-t
+  - name: LAN3
+    type: 10gbase-t
+module-bays:
+  - name: PCIe Slot 1
+    position: '1'

--- a/device-types/Synology/RS2423RP+II.yaml
+++ b/device-types/Synology/RS2423RP+II.yaml
@@ -13,11 +13,6 @@ comments: |-
   Physical dimensions: 88 mm x 482 mm x 578 mm.
   Two 550 W power supply units; ships with two AC power cords.
   [Hardware Specifications](https://www.synology.com/en-us/products/RS2423+#specs)
-power-ports:
-  - name: PSU 1
-    type: iec-60320-c14
-  - name: PSU 2
-    type: iec-60320-c14
 interfaces:
   - name: LAN1
     type: 1000base-t
@@ -26,5 +21,11 @@ interfaces:
   - name: LAN3
     type: 10gbase-t
 module-bays:
+  - name: PSU-1
+    label: '1'
+    position: PSU-1
+  - name: PSU-2
+    label: '2'
+    position: PSU-2
   - name: PCIe Slot 1
     position: '1'

--- a/module-types/Synology/PSU 550W-RP Module_1.yml
+++ b/module-types/Synology/PSU 550W-RP Module_1.yml
@@ -8,7 +8,7 @@ weight_unit: kg
 comments: |
   [PSU 550W-RP Redundant Power Module 550W](https://www.synology.com/de-de/products/spare_parts?search_by=category&category=PSU)
 
-  for FS3410, SA6400, SA3610, SA3410, RS4021xs+, RS3621xs+, RS3621RPxs, RS2821RP+, RX1223RP.
+  for FS3410, SA6400, SA3610, SA3410, RS4021xs+, RS3621xs+, RS3621RPxs, RS2821RP+, RS2423RP+II, RX1223RP.
 power-ports:
   - name: '{module}'
     type: iec-60320-c14


### PR DESCRIPTION
Adds two 12-bay 2U Synology RackStation models that are not yet in the library.

## Source

All values come from the official Synology hardware specification page, which lists both models side by side:
https://www.synology.com/en-us/products/RS2423%2B#specs

The RS2423RP+II product manual identifies `PSU 550WRP Module_1` as the replaceable redundant 550 W power-supply module.

## Specifications

| | RS2423+ | RS2423RP+II |
|---|---|---|
| Form factor | 2U, 12 bays | 2U, 12 bays |
| 1GbE RJ-45 | 2 | 2 |
| 10GbE RJ-45 | 1 | 1 |
| PCIe | 1x Gen3 x8 (x4 link) | 1x Gen3 x8 (x4 link) |
| PSU | 1x 500 W | 2x 550 W (redundant, replaceable) |
| Weight | 11.5 kg | 11.9 kg |

`RS2423+` has **2x 1GbE + 1x 10GbE**, unlike the existing `RS2421+` definition with 4x 1GbE. Interfaces are named `LAN1`-`LAN3`, following the convention used by other Synology models with mixed-speed ports.

The fixed PSU in `RS2423+` is modelled as a power port. The two replaceable PSU slots in `RS2423RP+II` are module bays; the existing `PSU 550W-RP Module_1` module type now records compatibility with this model.

## Notes

- `airflow: front-to-rear` follows existing comparable Synology rack models; Synology does not state an airflow field on the specification page.
- The Mini-SAS HD expansion port is not modelled as an interface, matching `RS2421+`.

## Validation

- `yamllint` passes for the updated files.
- `pytest tests/definitions_test.py --tb=short -v` passes (2 definitions).