### PR TITLE
feat(dell): add PowerEdge R670 device type

### DIFF
--- a/device-types/Dell/PowerEdge-R670.yaml
+++ b/device-types/Dell/PowerEdge-R670.yaml
@@ -13,9 +13,9 @@ comments: >-
   P-cores) and 32 DDR5 DIMM slots. Front bays support up to 20x EDSFF E3.S Gen5
   NVMe or up to 10x 2.5-inch drives. Available in rear I/O (hot aisle) and front
   I/O (cold aisle) configurations. Hot swap redundant power supplies from 800 W
-  to 1800 W. Up to two OCP NIC 3.0 cards. In addition to the rear riser slots
-  modelled here, the front riser can carry PCIe slots 31 and 32. BOSS-N1 occupies
-  slot 34 (front) or slot 3 (rear). Dimensions: 42.8 mm x 482 mm x 815.14 mm
+  to 1800 W. The rear I/O configuration modelled here has PCIe slots 1 and 4 and
+  OCP NIC 3.0 slots 2 and 5. The front riser can carry PCIe slots 31 and 32.
+  BOSS-N1 occupies slot 34 (front) or slot 3 (rear). Dimensions: 42.8 mm x 482 mm x 815.14 mm
   (rear I/O, without bezel).
   [Specification Sheet](https://www.delltechnologies.com/asset/en-us/products/servers/technical-support/poweredge-r670-spec-sheet.pdf)
 console-ports:
@@ -26,10 +26,12 @@ interfaces:
     type: 1000base-t
     mgmt_only: true
 module-bays:
-  - name: OCP 1 (3.0)
-    position: OCP-1
-  - name: OCP 2 (3.0)
-    position: OCP-2
+  - name: OCP NIC Slot 2 (3.0)
+    label: '2'
+    position: PCIe-2
+  - name: OCP NIC Slot 5 (3.0)
+    label: '5'
+    position: PCIe-5
   - name: PSU-1
     label: '1'
     position: PSU-1
@@ -39,9 +41,6 @@ module-bays:
   - name: PCIe Slot 1
     label: '1'
     position: PCIe-1
-  - name: PCIe Slot 2
-    label: '2'
-    position: PCIe-2
   - name: PCIe Slot 4
     label: '4'
     position: PCIe-4

--- a/device-types/Dell/PowerEdge-R670.yaml
+++ b/device-types/Dell/PowerEdge-R670.yaml
@@ -1,0 +1,47 @@
+---
+manufacturer: Dell
+model: PowerEdge R670
+slug: dell-poweredge-r670
+u_height: 1
+is_full_depth: true
+airflow: front-to-rear
+weight: 20.42
+weight_unit: kg
+description: Dell PowerEdge R670 1U Rack Server
+comments: >-
+  1U dual-socket rack server with two Intel Xeon 6 processors (E-cores or
+  P-cores) and 32 DDR5 DIMM slots. Front bays support up to 20x EDSFF E3.S Gen5
+  NVMe or up to 10x 2.5-inch drives. Available in rear I/O (hot aisle) and front
+  I/O (cold aisle) configurations. Hot swap redundant power supplies from 800 W
+  to 1800 W. Up to two OCP NIC 3.0 cards. In addition to the rear riser slots
+  modelled here, the front riser can carry PCIe slots 31 and 32. BOSS-N1 occupies
+  slot 34 (front) or slot 3 (rear). Dimensions: 42.8 mm x 482 mm x 815.14 mm
+  (rear I/O, without bezel).
+  [Specification Sheet](https://www.delltechnologies.com/asset/en-us/products/servers/technical-support/poweredge-r670-spec-sheet.pdf)
+console-ports:
+  - name: iDRAC Direct
+    type: usb-c
+interfaces:
+  - name: iDRAC
+    type: 1000base-t
+    mgmt_only: true
+module-bays:
+  - name: OCP 1 (3.0)
+    position: OCP-1
+  - name: OCP 2 (3.0)
+    position: OCP-2
+  - name: PSU-1
+    label: '1'
+    position: PSU-1
+  - name: PSU-2
+    label: '2'
+    position: PSU-2
+  - name: PCIe Slot 1
+    label: '1'
+    position: PCIe-1
+  - name: PCIe Slot 2
+    label: '2'
+    position: PCIe-2
+  - name: PCIe Slot 4
+    label: '4'
+    position: PCIe-4


### PR DESCRIPTION
Adds the Dell PowerEdge R670, the 1U Intel Xeon 6 model of the 17th generation. Its 2U sibling `PowerEdge R770` is already in the library, as are the AMD counterparts `R6715`/`R7715`.

## Source

All values come from the official Dell PowerEdge R670 Specification Sheet:
https://www.delltechnologies.com/asset/en-us/products/servers/technical-support/poweredge-r670-spec-sheet.pdf

## Specifications

- 1U, dual-socket Intel Xeon 6, 32 DDR5 DIMM slots
- Weight 20.42 kg (45.02 lb); rear-I/O dimensions 42.8 mm x 482 mm x 815.14 mm without bezel
- Hot-swap redundant PSUs from 800 W to 1800 W
- Dedicated Ethernet port for iDRAC management

The definition selects a concrete rear-I/O configuration: PCIe slots 1 and 4 plus OCP NIC 3.0 slots 2 and 5. This avoids modelling PCIe slot 2 and its alternative OCP use as independent, simultaneously usable bays. The front-riser slots 31 and 32 and the mutually exclusive BOSS-N1 positions are retained in `comments`.

The USB-C iDRAC Direct port is modelled as a console port, consistent with its service-access role.

## Notes

- The chassis is available in both rear-I/O (hot aisle) and front-I/O (cold aisle) variants; this definition represents rear I/O.
- PSU positions are module bays, following the existing PowerEdge R6715 convention.

## Validation

- `yamllint` passes for the updated file.
- `pytest tests/definitions_test.py --tb=short -v` passes (the new device definition).