### PR TITLE
Adds Cisco P-LTEA7-EAL module type

### DIFF
--- a/module-types/Cisco/P-LTEA7-EAL.yaml
+++ b/module-types/Cisco/P-LTEA7-EAL.yaml
@@ -1,0 +1,10 @@
+---
+manufacturer: Cisco
+model: P-LTEA7-EAL
+part_number: P-LTEA7-EAL
+comments: '[Cisco Wireless WAN Routers and Modules Data Sheet](https://www.cisco.com/c/en/us/solutions/collateral/enterprise-networks/4g-lte-solutions/datasheet-c78-743503.html)'
+interfaces:
+  - name: Cellular{module}/0
+    type: lte
+  - name: Cellular{module}/1
+    type: lte


### PR DESCRIPTION
This PR adds a new definition for the current line-up of Cisco LTE modules, the P-LTEA7-EAL.