### PR TITLE
Add Moxa NPort 5100 series

### DIFF
--- a/device-types/Moxa/NPort-5110.yaml
+++ b/device-types/Moxa/NPort-5110.yaml
@@ -1,3 +1,4 @@
+---
 manufacturer: Moxa
 model: NPort 5110
 slug: moxa-nport-5110

--- a/device-types/Moxa/NPort-5110.yaml
+++ b/device-types/Moxa/NPort-5110.yaml
@@ -8,18 +8,18 @@ airflow: passive
 weight: 340.0
 weight_unit: g
 console-server-ports:
-- name: P1
-  type: de-9
-  label: Port 1
-  description: RS-232
+  - name: P1
+    type: de-9
+    label: Port 1
+    description: RS-232
 power-ports:
-- name: Vin
-  type: dc-terminal
-  allocated_draw: 3
-  label: 12-48 VDC
+  - name: Vin
+    type: dc-terminal
+    allocated_draw: 3
+    label: 12-48 VDC
 interfaces:
-- name: Ethernet
-  type: 100base-tx
-  enabled: true
-  mgmt_only: false
-  label: LAN
+  - name: Ethernet
+    type: 100base-tx
+    enabled: true
+    mgmt_only: false
+    label: LAN

--- a/device-types/Moxa/NPort-5110.yaml
+++ b/device-types/Moxa/NPort-5110.yaml
@@ -1,0 +1,24 @@
+manufacturer: Moxa
+model: NPort 5110
+slug: moxa-nport-5110
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+weight: 340.0
+weight_unit: g
+console-server-ports:
+- name: P1
+  type: de-9
+  label: Port 1
+  description: RS-232
+power-ports:
+- name: Vin
+  type: dc-terminal
+  allocated_draw: 3
+  label: 12-48 VDC
+interfaces:
+- name: Ethernet
+  type: 100base-tx
+  enabled: true
+  mgmt_only: false
+  label: LAN

--- a/device-types/Moxa/NPort-5130.yaml
+++ b/device-types/Moxa/NPort-5130.yaml
@@ -1,0 +1,24 @@
+manufacturer: Moxa
+model: NPort 5130
+slug: moxa-nport-5130
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+weight: 340.0
+weight_unit: g
+console-server-ports:
+- name: P1
+  type: de-9
+  label: Port 1
+  description: RS-422/485
+power-ports:
+- name: Vin
+  type: dc-terminal
+  allocated_draw: 3
+  label: 12-48 VDC
+interfaces:
+- name: Ethernet
+  type: 100base-tx
+  enabled: true
+  mgmt_only: false
+  label: LAN

--- a/device-types/Moxa/NPort-5130.yaml
+++ b/device-types/Moxa/NPort-5130.yaml
@@ -8,18 +8,18 @@ airflow: passive
 weight: 340.0
 weight_unit: g
 console-server-ports:
-- name: P1
-  type: de-9
-  label: Port 1
-  description: RS-422/485
+  - name: P1
+    type: de-9
+    label: Port 1
+    description: RS-422/485
 power-ports:
-- name: Vin
-  type: dc-terminal
-  allocated_draw: 3
-  label: 12-48 VDC
+  - name: Vin
+    type: dc-terminal
+    allocated_draw: 3
+    label: 12-48 VDC
 interfaces:
-- name: Ethernet
-  type: 100base-tx
-  enabled: true
-  mgmt_only: false
-  label: LAN
+  - name: Ethernet
+    type: 100base-tx
+    enabled: true
+    mgmt_only: false
+    label: LAN

--- a/device-types/Moxa/NPort-5130.yaml
+++ b/device-types/Moxa/NPort-5130.yaml
@@ -1,3 +1,4 @@
+---
 manufacturer: Moxa
 model: NPort 5130
 slug: moxa-nport-5130

--- a/device-types/Moxa/NPort-5150.yaml
+++ b/device-types/Moxa/NPort-5150.yaml
@@ -1,3 +1,4 @@
+---
 manufacturer: Moxa
 model: NPort 5150
 slug: moxa-nport-5150

--- a/device-types/Moxa/NPort-5150.yaml
+++ b/device-types/Moxa/NPort-5150.yaml
@@ -8,18 +8,18 @@ airflow: passive
 weight: 340.0
 weight_unit: g
 console-server-ports:
-- name: P1
-  type: de-9
-  label: Port 1
-  description: RS-232/422/485
+  - name: P1
+    type: de-9
+    label: Port 1
+    description: RS-232/422/485
 power-ports:
-- name: Vin
-  type: dc-terminal
-  allocated_draw: 3
-  label: 12-48 VDC
+  - name: Vin
+    type: dc-terminal
+    allocated_draw: 3
+    label: 12-48 VDC
 interfaces:
-- name: Ethernet
-  type: 100base-tx
-  enabled: true
-  mgmt_only: false
-  label: LAN
+  - name: Ethernet
+    type: 100base-tx
+    enabled: true
+    mgmt_only: false
+    label: LAN

--- a/device-types/Moxa/NPort-5150.yaml
+++ b/device-types/Moxa/NPort-5150.yaml
@@ -1,0 +1,24 @@
+manufacturer: Moxa
+model: NPort 5150
+slug: moxa-nport-5150
+u_height: 0.0
+is_full_depth: false
+airflow: passive
+weight: 340.0
+weight_unit: g
+console-server-ports:
+- name: P1
+  type: de-9
+  label: Port 1
+  description: RS-232/422/485
+power-ports:
+- name: Vin
+  type: dc-terminal
+  allocated_draw: 3
+  label: 12-48 VDC
+interfaces:
+- name: Ethernet
+  type: 100base-tx
+  enabled: true
+  mgmt_only: false
+  label: LAN


### PR DESCRIPTION
Adding the Moxa NPort 5100 series devices. See: https://www.moxa.com/getmedia/cde84d37-8759-417c-a21c-0031d015cd94/moxa-nport-5100-series-datasheet-v2.1.pdf
This is my first contribution to the devicetype-library, Any feedback is appreciated.