### PR TITLE
Create device type for HPE ProLiant DL380 Gen12

### DIFF
--- a/device-types/HPE/ProLiant-Compute-DL380-Gen12.yaml
+++ b/device-types/HPE/ProLiant-Compute-DL380-Gen12.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: HPE
+model: ProLiant Compute DL380 Gen12
+slug: hpe-proliant-compute-dl380-gen12
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+comments: '[HPE ProLiant Compute DL380 Gen12](https://www.hpe.com/us/en/compute/hpe-proliant-compute/dl380-gen12.html)'
+power-ports:
+  - name: PSU1
+    type: iec-60320-c14
+  - name: PSU2
+    type: iec-60320-c14

--- a/device-types/HPE/ProLiant-Compute-DL380-Gen12.yaml
+++ b/device-types/HPE/ProLiant-Compute-DL380-Gen12.yaml
@@ -5,9 +5,35 @@ slug: hpe-proliant-compute-dl380-gen12
 u_height: 2
 is_full_depth: true
 airflow: front-to-rear
+weight: 18
+weight_unit: kg
 comments: '[HPE ProLiant Compute DL380 Gen12](https://www.hpe.com/us/en/compute/hpe-proliant-compute/dl380-gen12.html)'
-power-ports:
+module-bays:
   - name: PSU1
-    type: iec-60320-c14
+    position: PSU1
   - name: PSU2
-    type: iec-60320-c14
+    position: PSU2
+  - name: PCIe1
+    position: PCIe1
+  - name: PCIe2
+    position: PCIe2
+  - name: PCIe3
+    position: PCIe3
+  - name: PCIe4
+    position: PCIe4
+  - name: PCIe5
+    position: PCIe5
+  - name: PCIe6
+    position: PCIe6
+  - name: PCIe7
+    position: PCIe7
+  - name: PCIe8
+    position: PCIe8
+  - name: OCPA
+    position: OCPA
+  - name: OCPB
+    position: OCPB
+interfaces:
+  - name: iLO
+    type: 1000base-t
+    mgmt_only: true


### PR DESCRIPTION
Added YAML configuration for HPE ProLiant Compute DL380 Gen12.