### PR TITLE
Add HPE ProLiant Compute ML350 Gen12 device type

### DIFF
--- a/device-types/HPE/ProLiant-Compute-ML350-Gen12.yaml
+++ b/device-types/HPE/ProLiant-Compute-ML350-Gen12.yaml
@@ -2,12 +2,42 @@
 manufacturer: HPE
 model: ProLiant Compute ML350 Gen12
 slug: hpe-proliant-compute-ml350-gen12
-u_height: 5
+u_height: 4
 is_full_depth: true
 airflow: front-to-rear
+weight: 23.96
+weight_unit: kg
 comments: '[HPE ProLiant Compute ML350 Gen12](https://www.hpe.com/us/en/compute/hpe-proliant-compute.html)'
-power-ports:
+module-bays:
   - name: PSU1
-    type: iec-60320-c14
+    position: PSU1
   - name: PSU2
-    type: iec-60320-c14
+    position: PSU2
+  - name: PCIe1
+    position: PCIe1
+  - name: PCIe2
+    position: PCIe2
+  - name: PCIe3
+    position: PCIe3
+  - name: PCIe4
+    position: PCIe4
+  - name: PCIe5
+    position: PCIe5
+  - name: PCIe6
+    position: PCIe6
+  - name: PCIe7
+    position: PCIe7
+  - name: PCIe8
+    position: PCIe8
+  - name: PCIe9
+    position: PCIe9
+  - name: PCIe10
+    position: PCIe10
+  - name: OCPA
+    position: OCPA
+  - name: OCPB
+    position: OCPB
+interfaces:
+  - name: iLO
+    type: 1000base-t
+    mgmt_only: true

--- a/device-types/HPE/ProLiant-Compute-ML350-Gen12.yaml
+++ b/device-types/HPE/ProLiant-Compute-ML350-Gen12.yaml
@@ -1,0 +1,13 @@
+---
+manufacturer: HPE
+model: ProLiant Compute ML350 Gen12
+slug: hpe-proliant-compute-ml350-gen12
+u_height: 5
+is_full_depth: true
+airflow: front-to-rear
+comments: '[HPE ProLiant Compute ML350 Gen12](https://www.hpe.com/us/en/compute/hpe-proliant-compute.html)'
+power-ports:
+  - name: PSU1
+    type: iec-60320-c14
+  - name: PSU2
+    type: iec-60320-c14


### PR DESCRIPTION
Added manufacturer, model, slug, height, airflow, comments, and power ports for HPE ProLiant Compute ML350 Gen12.