### PR TITLE
Smartoptics DCP-2: correct slot numbering, add fan bay and PSU/fan module types

### DIFF
--- a/device-types/Smartoptics/DCP-2.yaml
+++ b/device-types/Smartoptics/DCP-2.yaml
@@ -8,7 +8,8 @@ weight: 2
 weight_unit: kg
 airflow: front-to-rear
 is_full_depth: true
-comments: '[Smartoptics Datasheet](https://smartoptics.com/wp-content/uploads/2023/01/so-ds-dcp-2-r4.3.pdf) 1U 2 slot chassis. Bay names match the Location column of "show inventory".'
+comments: '[Smartoptics Datasheet](https://smartoptics.com/wp-content/uploads/2023/01/so-ds-dcp-2-r4.3.pdf) 1U 2 slot chassis. Bay names match the Location
+  column of "show inventory".'
 console-ports:
   - name: Console
     type: rj-45

--- a/device-types/Smartoptics/DCP-2.yaml
+++ b/device-types/Smartoptics/DCP-2.yaml
@@ -8,8 +8,8 @@ weight: 2
 weight_unit: kg
 airflow: front-to-rear
 is_full_depth: true
-comments: '[Smartoptics Datasheet](https://smartoptics.com/wp-content/uploads/2023/01/so-ds-dcp-2-r4.3.pdf) 1U 2 slot chassis. Bay names match the Location
-  column of "show inventory".'
+comments: '[Smartoptics Datasheet](https://smartoptics.com/wp-content/uploads/2023/01/so-ds-dcp-2-r4.3.pdf) 1U 2 slot chassis. Bay and interface names match
+  the output of "show inventory" and "show network interfaces".'
 console-ports:
   - name: Console
     type: rj-45
@@ -33,10 +33,20 @@ interfaces:
   - name: eth0 / local
     type: 1000base-t
     mgmt_only: true
-  - name: eth2
+    description: Local craft port
+  - name: if-1/eth1
     type: 1000base-t
-  - name: eth3
+    mgmt_only: true
+    description: Management
+  - name: if-1/eth2
     type: 1000base-t
-  - name: eth4
+    mgmt_only: true
+    description: Management
+  - name: if-1/eth3
     type: 1000base-t
-# Eth4 also supports SFP.
+    mgmt_only: true
+    description: Management
+  - name: if-1/eth4
+    type: 1000base-t
+    mgmt_only: true
+    description: Management, also supports SFP

--- a/device-types/Smartoptics/DCP-2.yaml
+++ b/device-types/Smartoptics/DCP-2.yaml
@@ -8,19 +8,26 @@ weight: 2
 weight_unit: kg
 airflow: front-to-rear
 is_full_depth: true
-comments: '[Smartoptics Datasheet] (https://smartoptics.com/wp-content/uploads/2023/01/so-ds-dcp-2-r4.3.pdf) Base HW, DCP-2'
+comments: '[Smartoptics Datasheet](https://smartoptics.com/wp-content/uploads/2023/01/so-ds-dcp-2-r4.3.pdf) 1U 2 slot chassis. Bay names match the Location column of "show inventory".'
 console-ports:
   - name: Console
     type: rj-45
 module-bays:
-  - name: PSU 1
-    position: '0'
-  - name: PSU 2
+  - name: psu-1/1
     position: '1'
-  - name: DCP 1
-    position: '0'
-  - name: DCP 2
+    description: AC/DC power supply
+  - name: psu-1/2
+    position: '2'
+    description: AC/DC power supply
+  - name: fan-1/1
     position: '1'
+    description: Fan tray
+  - name: slot-1/1
+    position: '1'
+    description: DCP transponder/muxponder slot
+  - name: slot-1/2
+    position: '2'
+    description: DCP transponder/muxponder slot
 interfaces:
   - name: eth0 / local
     type: 1000base-t

--- a/module-types/Smartoptics/DCP-2-FAN-FB.yaml
+++ b/module-types/Smartoptics/DCP-2-FAN-FB.yaml
@@ -1,0 +1,6 @@
+---
+manufacturer: Smartoptics
+model: DCP-2-FAN-FB
+part_number: DCP-2-FAN-FB
+airflow: front-to-rear
+comments: Fan, front-to-back airflow

--- a/module-types/Smartoptics/DCP-2-PSU-AC-FB.yaml
+++ b/module-types/Smartoptics/DCP-2-PSU-AC-FB.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Smartoptics
+model: DCP-2-PSU-AC-FB
+part_number: DCP-2-PSU-AC-FB
+airflow: front-to-rear
+comments: AC power supply, front-to-back airflow
+power-ports:
+  - name: psu-1/{module}
+    type: iec-60320-c14


### PR DESCRIPTION
### Summary

Corrects the DCP-2 chassis definition against a live unit, and adds the two module types needed to populate its PSU and fan bays.

### Changes

- **Module bay positions were `0`/`1`; they are `1`/`2` on the hardware.** Because module interfaces use the `{module}` token, a DCP module installed in slot 1 previously rendered its interfaces as `Line/0/1` — off by one against the CLI.
- **Bay names now match the operating system** (`psu-1/1`, `psu-1/2`, `fan-1/1`, `slot-1/1`, `slot-1/2`), per the CONTRIBUTING guidance to name components as they appear in the device's OS.
- **Added the missing fan bay.** The chassis has a `fan-1/1` bay that the definition did not model.
- **Added `DCP-2-PSU-AC-FB` and `DCP-2-FAN-FB` module types.** Without a PSU module type the DCP-2 imports with no power ports at all and cannot be cabled to a PDU.

### Evidence

```
admin@host> show inventory
  Location    Part number       Description                             HW rev  FW rev      Serial number
  ----------  ----------------  --------------------------------------  ------  ----------  -------------
  chassis     DCP-2             1U 2 slot chassis                       R2A     n/a         <redacted>
   psu-1/1    DCP-2-PSU-AC-FB   AC power supply, front-to-back airflow  R00     n/a         <redacted>
   psu-1/2    DCP-2-PSU-AC-FB   AC power supply, front-to-back airflow  R00     n/a         <redacted>
   fan-1/1    DCP-2-FAN-FB      Fan, front-to-back airflow              R1B     n/a         n/a
   slot-1/1   DCP-1610          10 x SFP+ to SFP+ Transponders, 1G-16G  R3A     0x8a000111  <redacted>
```

### Notes

- The PSU inlet is modelled as `iec-60320-c14`; happy to correct if a maintainer knows otherwise.
- DC and back-to-front airflow variants exist but are not included here, as I have not been able to verify their part numbers on hardware.