### PR TITLE
Smartoptics: add DCP-1610 module type

### DIFF
--- a/module-types/Smartoptics/DCP-1610.yaml
+++ b/module-types/Smartoptics/DCP-1610.yaml
@@ -1,0 +1,66 @@
+---
+manufacturer: Smartoptics
+model: DCP-1610
+part_number: DCP-1610
+comments: 10 x SFP+ to SFP+ transponders, 1G-16G. Odd interfaces are DWDM line, even are grey client.
+interfaces:
+  - name: if-1/{module}/1
+    type: 10gbase-x-sfpp
+    label: Line 1
+  - name: if-1/{module}/2
+    type: 10gbase-x-sfpp
+    label: Client 1
+  - name: if-1/{module}/3
+    type: 10gbase-x-sfpp
+    label: Line 2
+  - name: if-1/{module}/4
+    type: 10gbase-x-sfpp
+    label: Client 2
+  - name: if-1/{module}/5
+    type: 10gbase-x-sfpp
+    label: Line 3
+  - name: if-1/{module}/6
+    type: 10gbase-x-sfpp
+    label: Client 3
+  - name: if-1/{module}/7
+    type: 10gbase-x-sfpp
+    label: Line 4
+  - name: if-1/{module}/8
+    type: 10gbase-x-sfpp
+    label: Client 4
+  - name: if-1/{module}/9
+    type: 10gbase-x-sfpp
+    label: Line 5
+  - name: if-1/{module}/10
+    type: 10gbase-x-sfpp
+    label: Client 5
+  - name: if-1/{module}/11
+    type: 10gbase-x-sfpp
+    label: Line 6
+  - name: if-1/{module}/12
+    type: 10gbase-x-sfpp
+    label: Client 6
+  - name: if-1/{module}/13
+    type: 10gbase-x-sfpp
+    label: Line 7
+  - name: if-1/{module}/14
+    type: 10gbase-x-sfpp
+    label: Client 7
+  - name: if-1/{module}/15
+    type: 10gbase-x-sfpp
+    label: Line 8
+  - name: if-1/{module}/16
+    type: 10gbase-x-sfpp
+    label: Client 8
+  - name: if-1/{module}/17
+    type: 10gbase-x-sfpp
+    label: Line 9
+  - name: if-1/{module}/18
+    type: 10gbase-x-sfpp
+    label: Client 9
+  - name: if-1/{module}/19
+    type: 10gbase-x-sfpp
+    label: Line 10
+  - name: if-1/{module}/20
+    type: 10gbase-x-sfpp
+    label: Client 10


### PR DESCRIPTION
### Summary

Adds the Smartoptics DCP-1610, a 10-transponder SFP+ module for the DCP-2 chassis.

### Details

20 x SFP+ interfaces forming 10 transponder pairs. Odd-numbered interfaces are DWDM line side, even-numbered are grey client side, as reported by the device.

Interface names use the `{module}` token so they render as `if-1/1/N` when installed in `slot-1/1` and `if-1/2/N` in `slot-1/2`, matching the device's own naming. The `Line N` / `Client N` roles are carried in the `label` field.

### Evidence

```
admin@host> show interface
              Port      Status           Rx power  Tx power                 Channel  Admin
  Interface   Type      [Rx/Tx]  Alarm   [dBm]     [dBm]     Format   FEC   Id       status
  ----------  --------  -------  ------  --------  --------  -------  ----  -------  ------
  slot-1/1:   DCP-1610
   if-1/1/1   line      up/up    ok         -10.9       1.0  10GbE    n/a   <ch>     up
   if-1/1/2   client    up/up    ok          -3.9      -3.2  10GbE    n/a   <ch>     up
   if-1/1/3   line      up/up    ok         -16.5       1.2  10GbE    n/a   <ch>     up
   if-1/1/4   client    up/up    ok          -3.3      -1.7  10GbE    n/a   <ch>     up
   ...
   if-1/1/19  line      n/a      ok           n/a       n/a  10GbE    n/a   n/a      up
   if-1/1/20  client    n/a      ok           n/a       n/a  10GbE    n/a   n/a      up
```

### Notes

`weight` and `weight_unit` are omitted as I have not been able to verify them from the datasheet.