### PR TITLE
Smartoptics DCP-404: name interfaces as the device does

### DIFF
--- a/module-types/Smartoptics/DCP-404.yaml
+++ b/module-types/Smartoptics/DCP-404.yaml
@@ -6,13 +6,18 @@ weight: 1.8
 weight_unit: kg
 comments: '[DCP-404 Datasheet](https://smartoptics.com/wp-content/uploads/2024/07/so-ds-dcp-404-r1.9.pdf)'
 interfaces:
-  - name: Line/{module}/1
+  - name: if-1/{module}/1
+    type: 100gbase-x-qsfp28
+    label: Client 1
+  - name: if-1/{module}/2
+    type: 100gbase-x-qsfp28
+    label: Client 2
+  - name: if-1/{module}/3
+    type: 100gbase-x-qsfp28
+    label: Client 3
+  - name: if-1/{module}/4
+    type: 100gbase-x-qsfp28
+    label: Client 4
+  - name: if-1/{module}/5
     type: 400gbase-x-qsfpdd
-  - name: Client/{module}/1
-    type: 100gbase-x-qsfp28
-  - name: Client/{module}/2
-    type: 100gbase-x-qsfp28
-  - name: Client/{module}/3
-    type: 100gbase-x-qsfp28
-  - name: Client/{module}/4
-    type: 100gbase-x-qsfp28
+    label: Line 1


### PR DESCRIPTION
### Summary

Renames the DCP-404's interfaces to match what the device reports, and corrects the client/line port ordering.

### Changes

- Interfaces were `Line/{module}/1` and `Client/{module}/1`–`4`. The device names them `if-1/<slot>/1` through `if-1/<slot>/5`, so the `{module}` token now renders `if-1/1/N` in `slot-1/1` and `if-1/2/N` in `slot-1/2`, per the CONTRIBUTING guidance to name components as they appear in the device's OS.
- **The line port is `/5`, not `/1`.** Clients occupy `/1`–`/4` and the 400G line port is last. The previous definition had this inverted.
- `Line` / `Client` roles are retained in the `label` field.

### Evidence

```
admin@host> show interface
              Port     Status           Rx power  Tx power                      Channel  Admin
  Interface   Type     [Rx/Tx]  Alarm   [dBm]     [dBm]     Format    FEC       Id       status
  ----------  -------  -------  ------  --------  --------  --------  --------  -------  --------
  slot-1/1:   DCP-404
   if-1/1/1   client   up/up    ok           6.5       6.8  100G      disabled  n/a      up
   if-1/1/2   client   n/a      ok           n/a       n/a  100G      disabled  n/a      up
   if-1/1/3   client   n/a      ok           n/a       n/a  100G      disabled  n/a      up
   if-1/1/4   client   n/a      ok           n/a       n/a  100G      disabled  n/a      up
   if-1/1/5   line     up/up    ok         -13.8     -11.8  4x100GbE  enabled   <ch>     up
  slot-1/2:   DCP-404
   if-1/2/1   client   up/up    ok           6.0       7.6  100G      disabled  n/a      up
   if-1/2/5   line     up/up    ok         -13.7       0.0  1x100GbE  enabled   <ch>     up
```

### Note

This changes an existing definition, so anyone already using it will see different interface names on newly-created modules. Flagging in case maintainers would prefer it handled differently.