### PR TITLE
Add switch BDCOM S2900-24S8C4X

### DIFF
--- a/device-types/BDCOM/S2900-24S8C4X.yaml
+++ b/device-types/BDCOM/S2900-24S8C4X.yaml
@@ -1,0 +1,89 @@
+---
+manufacturer: BDCOM
+model: S2900-24S8C4X
+slug: bdcom-s2900-24s8c4x
+description: Switch BDCOM S2900-24S8C4X
+u_height: 1.0
+is_full_depth: false
+airflow: left-to-right
+weight: 4.0
+weight_unit: kg
+comments: See [Product documentation](https://bdcomnetworks.com/S2900_24S8C4X/).
+console-ports:
+  - name: Console
+    type: rj-45
+    label: CLI
+power-ports:
+  - name: PSU
+    type: iec-60320-c14
+    maximum_draw: 45
+    description: 'AC: 100V-240V'
+interfaces:
+  - name: GigaEthernet0/1
+    type: 1000base-x-sfp
+    description: Combo port (RJ-45/SFP)
+  - name: GigaEthernet0/2
+    type: 1000base-x-sfp
+    description: Combo port (RJ-45/SFP)
+  - name: GigaEthernet0/3
+    type: 1000base-x-sfp
+    description: Combo port (RJ-45/SFP)
+  - name: GigaEthernet0/4
+    type: 1000base-x-sfp
+    description: Combo port (RJ-45/SFP)
+  - name: GigaEthernet0/5
+    type: 1000base-x-sfp
+    description: Combo port (RJ-45/SFP)
+  - name: GigaEthernet0/6
+    type: 1000base-x-sfp
+    description: Combo port (RJ-45/SFP)
+  - name: GigaEthernet0/7
+    type: 1000base-x-sfp
+    description: Combo port (RJ-45/SFP)
+  - name: GigaEthernet0/8
+    type: 1000base-x-sfp
+    description: Combo port (RJ-45/SFP)
+  - name: GigaEthernet0/9
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/10
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/11
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/12
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/13
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/14
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/15
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/16
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/17
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/18
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/19
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/20
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/21
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/22
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/23
+    type: 1000base-x-sfp
+  - name: GigaEthernet0/24
+    type: 1000base-x-sfp
+  - name: TGigaEthernet0/1
+    type: 10gbase-x-sfpp
+    label: TE1
+  - name: TGigaEthernet0/2
+    type: 10gbase-x-sfpp
+    label: TE2
+  - name: TGigaEthernet0/3
+    type: 10gbase-x-sfpp
+    label: TE3
+  - name: TGigaEthernet0/4
+    type: 10gbase-x-sfpp
+    label: TE4


### PR DESCRIPTION
S2900 L3-lite Series is an aggregation 10GE switch introduced by BDCOM.

- 16-Port Gigabit SFP
- 8-Port Gigabit SFP/RJ45 combo
- 4-Port 10G/GE SFP+