### PR TITLE
Add Nvidia Q3400-RA, SN5610 and NVLink 5 switch; complete the QM9700 port list

### DIFF
--- a/device-types/Nvidia/NVLink-5-Switch.yaml
+++ b/device-types/Nvidia/NVLink-5-Switch.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: Nvidia
+model: NVLink 5 Switch
+slug: nvidia-nvlink-5-switch
+u_height: 1
+is_full_depth: true
+comments: |
+  NVIDIA fifth-generation NVLink switch tray, as deployed in GB200/GB300 NVL72
+  racks (9 trays per rack). Only the out-of-band management interfaces are
+  modelled: the NVLink ports themselves are backplane cartridge connections to
+  the compute trays rather than field-cabled ports.
+  The tray is fed by the NVL72 rack busbar and has no power inlet of its own.
+is_powered: false
+interfaces:
+  - name: bmc
+    type: 1000base-t
+    mgmt_only: true
+  - name: eth0
+    type: 1000base-t
+  - name: eth1
+    type: 1000base-t

--- a/device-types/Nvidia/Q3400-RA.yaml
+++ b/device-types/Nvidia/Q3400-RA.yaml
@@ -1,0 +1,341 @@
+---
+manufacturer: Nvidia
+model: Q3400-RA
+slug: nvidia-q3400-ra
+part_number: 920-9B36F-00RX-8S0
+u_height: 4
+is_full_depth: true
+airflow: front-to-rear
+weight: 60
+weight_unit: kg
+comments: |
+  NVIDIA Quantum-X800 Q3400-RA. 144x 800Gb/s XDR InfiniBand ports over 72 twin-port
+  OSFP cages, powered by the Quantum-3 ASIC. fnm1 is the dedicated in-band fabric
+  node management port used by NVIDIA UFM.
+  Product page: https://www.nvidia.com/en-us/networking/products/infiniband/quantum-x800/
+  User manual: https://networking-docs.nvidia.com/xdrswitcheshw/introduction
+console-ports:
+  - name: uart
+    type: rj-45
+power-ports:
+  - name: PSU1
+    type: iec-60320-c20
+    maximum_draw: 875
+  - name: PSU2
+    type: iec-60320-c20
+    maximum_draw: 875
+  - name: PSU3
+    type: iec-60320-c20
+    maximum_draw: 875
+  - name: PSU4
+    type: iec-60320-c20
+    maximum_draw: 875
+  - name: PSU5
+    type: iec-60320-c20
+    maximum_draw: 875
+  - name: PSU6
+    type: iec-60320-c20
+    maximum_draw: 875
+  - name: PSU7
+    type: iec-60320-c20
+    maximum_draw: 875
+  - name: PSU8
+    type: iec-60320-c20
+    maximum_draw: 875
+interfaces:
+  - name: eth0
+    type: 1000base-t
+    mgmt_only: true
+  - name: eth1
+    type: 1000base-t
+  - name: fnm1
+    type: infiniband-xdr
+    description: In-band fabric node management (UFM)
+  - name: sw1p1
+    type: infiniband-xdr
+  - name: sw1p2
+    type: infiniband-xdr
+  - name: sw2p1
+    type: infiniband-xdr
+  - name: sw2p2
+    type: infiniband-xdr
+  - name: sw3p1
+    type: infiniband-xdr
+  - name: sw3p2
+    type: infiniband-xdr
+  - name: sw4p1
+    type: infiniband-xdr
+  - name: sw4p2
+    type: infiniband-xdr
+  - name: sw5p1
+    type: infiniband-xdr
+  - name: sw5p2
+    type: infiniband-xdr
+  - name: sw6p1
+    type: infiniband-xdr
+  - name: sw6p2
+    type: infiniband-xdr
+  - name: sw7p1
+    type: infiniband-xdr
+  - name: sw7p2
+    type: infiniband-xdr
+  - name: sw8p1
+    type: infiniband-xdr
+  - name: sw8p2
+    type: infiniband-xdr
+  - name: sw9p1
+    type: infiniband-xdr
+  - name: sw9p2
+    type: infiniband-xdr
+  - name: sw10p1
+    type: infiniband-xdr
+  - name: sw10p2
+    type: infiniband-xdr
+  - name: sw11p1
+    type: infiniband-xdr
+  - name: sw11p2
+    type: infiniband-xdr
+  - name: sw12p1
+    type: infiniband-xdr
+  - name: sw12p2
+    type: infiniband-xdr
+  - name: sw13p1
+    type: infiniband-xdr
+  - name: sw13p2
+    type: infiniband-xdr
+  - name: sw14p1
+    type: infiniband-xdr
+  - name: sw14p2
+    type: infiniband-xdr
+  - name: sw15p1
+    type: infiniband-xdr
+  - name: sw15p2
+    type: infiniband-xdr
+  - name: sw16p1
+    type: infiniband-xdr
+  - name: sw16p2
+    type: infiniband-xdr
+  - name: sw17p1
+    type: infiniband-xdr
+  - name: sw17p2
+    type: infiniband-xdr
+  - name: sw18p1
+    type: infiniband-xdr
+  - name: sw18p2
+    type: infiniband-xdr
+  - name: sw19p1
+    type: infiniband-xdr
+  - name: sw19p2
+    type: infiniband-xdr
+  - name: sw20p1
+    type: infiniband-xdr
+  - name: sw20p2
+    type: infiniband-xdr
+  - name: sw21p1
+    type: infiniband-xdr
+  - name: sw21p2
+    type: infiniband-xdr
+  - name: sw22p1
+    type: infiniband-xdr
+  - name: sw22p2
+    type: infiniband-xdr
+  - name: sw23p1
+    type: infiniband-xdr
+  - name: sw23p2
+    type: infiniband-xdr
+  - name: sw24p1
+    type: infiniband-xdr
+  - name: sw24p2
+    type: infiniband-xdr
+  - name: sw25p1
+    type: infiniband-xdr
+  - name: sw25p2
+    type: infiniband-xdr
+  - name: sw26p1
+    type: infiniband-xdr
+  - name: sw26p2
+    type: infiniband-xdr
+  - name: sw27p1
+    type: infiniband-xdr
+  - name: sw27p2
+    type: infiniband-xdr
+  - name: sw28p1
+    type: infiniband-xdr
+  - name: sw28p2
+    type: infiniband-xdr
+  - name: sw29p1
+    type: infiniband-xdr
+  - name: sw29p2
+    type: infiniband-xdr
+  - name: sw30p1
+    type: infiniband-xdr
+  - name: sw30p2
+    type: infiniband-xdr
+  - name: sw31p1
+    type: infiniband-xdr
+  - name: sw31p2
+    type: infiniband-xdr
+  - name: sw32p1
+    type: infiniband-xdr
+  - name: sw32p2
+    type: infiniband-xdr
+  - name: sw33p1
+    type: infiniband-xdr
+  - name: sw33p2
+    type: infiniband-xdr
+  - name: sw34p1
+    type: infiniband-xdr
+  - name: sw34p2
+    type: infiniband-xdr
+  - name: sw35p1
+    type: infiniband-xdr
+  - name: sw35p2
+    type: infiniband-xdr
+  - name: sw36p1
+    type: infiniband-xdr
+  - name: sw36p2
+    type: infiniband-xdr
+  - name: sw37p1
+    type: infiniband-xdr
+  - name: sw37p2
+    type: infiniband-xdr
+  - name: sw38p1
+    type: infiniband-xdr
+  - name: sw38p2
+    type: infiniband-xdr
+  - name: sw39p1
+    type: infiniband-xdr
+  - name: sw39p2
+    type: infiniband-xdr
+  - name: sw40p1
+    type: infiniband-xdr
+  - name: sw40p2
+    type: infiniband-xdr
+  - name: sw41p1
+    type: infiniband-xdr
+  - name: sw41p2
+    type: infiniband-xdr
+  - name: sw42p1
+    type: infiniband-xdr
+  - name: sw42p2
+    type: infiniband-xdr
+  - name: sw43p1
+    type: infiniband-xdr
+  - name: sw43p2
+    type: infiniband-xdr
+  - name: sw44p1
+    type: infiniband-xdr
+  - name: sw44p2
+    type: infiniband-xdr
+  - name: sw45p1
+    type: infiniband-xdr
+  - name: sw45p2
+    type: infiniband-xdr
+  - name: sw46p1
+    type: infiniband-xdr
+  - name: sw46p2
+    type: infiniband-xdr
+  - name: sw47p1
+    type: infiniband-xdr
+  - name: sw47p2
+    type: infiniband-xdr
+  - name: sw48p1
+    type: infiniband-xdr
+  - name: sw48p2
+    type: infiniband-xdr
+  - name: sw49p1
+    type: infiniband-xdr
+  - name: sw49p2
+    type: infiniband-xdr
+  - name: sw50p1
+    type: infiniband-xdr
+  - name: sw50p2
+    type: infiniband-xdr
+  - name: sw51p1
+    type: infiniband-xdr
+  - name: sw51p2
+    type: infiniband-xdr
+  - name: sw52p1
+    type: infiniband-xdr
+  - name: sw52p2
+    type: infiniband-xdr
+  - name: sw53p1
+    type: infiniband-xdr
+  - name: sw53p2
+    type: infiniband-xdr
+  - name: sw54p1
+    type: infiniband-xdr
+  - name: sw54p2
+    type: infiniband-xdr
+  - name: sw55p1
+    type: infiniband-xdr
+  - name: sw55p2
+    type: infiniband-xdr
+  - name: sw56p1
+    type: infiniband-xdr
+  - name: sw56p2
+    type: infiniband-xdr
+  - name: sw57p1
+    type: infiniband-xdr
+  - name: sw57p2
+    type: infiniband-xdr
+  - name: sw58p1
+    type: infiniband-xdr
+  - name: sw58p2
+    type: infiniband-xdr
+  - name: sw59p1
+    type: infiniband-xdr
+  - name: sw59p2
+    type: infiniband-xdr
+  - name: sw60p1
+    type: infiniband-xdr
+  - name: sw60p2
+    type: infiniband-xdr
+  - name: sw61p1
+    type: infiniband-xdr
+  - name: sw61p2
+    type: infiniband-xdr
+  - name: sw62p1
+    type: infiniband-xdr
+  - name: sw62p2
+    type: infiniband-xdr
+  - name: sw63p1
+    type: infiniband-xdr
+  - name: sw63p2
+    type: infiniband-xdr
+  - name: sw64p1
+    type: infiniband-xdr
+  - name: sw64p2
+    type: infiniband-xdr
+  - name: sw65p1
+    type: infiniband-xdr
+  - name: sw65p2
+    type: infiniband-xdr
+  - name: sw66p1
+    type: infiniband-xdr
+  - name: sw66p2
+    type: infiniband-xdr
+  - name: sw67p1
+    type: infiniband-xdr
+  - name: sw67p2
+    type: infiniband-xdr
+  - name: sw68p1
+    type: infiniband-xdr
+  - name: sw68p2
+    type: infiniband-xdr
+  - name: sw69p1
+    type: infiniband-xdr
+  - name: sw69p2
+    type: infiniband-xdr
+  - name: sw70p1
+    type: infiniband-xdr
+  - name: sw70p2
+    type: infiniband-xdr
+  - name: sw71p1
+    type: infiniband-xdr
+  - name: sw71p2
+    type: infiniband-xdr
+  - name: sw72p1
+    type: infiniband-xdr
+  - name: sw72p2
+    type: infiniband-xdr

--- a/device-types/Nvidia/QM9700.yaml
+++ b/device-types/Nvidia/QM9700.yaml
@@ -7,136 +7,151 @@ is_full_depth: true
 airflow: rear-to-front
 weight: 14.8
 weight_unit: kg
+comments: |
+  NVIDIA Quantum-2 QM9700 managed InfiniBand switch. 64x 400Gb/s NDR ports over 32
+  twin-port OSFP cages, 1+1 redundant hot-swap power supplies.
+  Data sheet: https://nvdam.widen.net/s/gnkmlxwwmg/infiniband-qm9700-series-switch-datasheet
 console-ports:
+  - name: console
+    type: rj-45
   - name: uart
     type: rj-45
+  - name: mini-usb
+    type: usb-mini-b
 module-bays:
   - name: PSU1
     position: PSU1
   - name: PSU2
     position: PSU2
 interfaces:
-  - name: P0.0
-    type: 400gbase-x-osfp
-  - name: P0.1
-    type: 400gbase-x-osfp
-  - name: P1.0
-    type: 400gbase-x-osfp
-  - name: P1.1
-    type: 400gbase-x-osfp
-  - name: P2.0
-    type: 400gbase-x-osfp
-  - name: P2.1
-    type: 400gbase-x-osfp
-  - name: P3.0
-    type: 400gbase-x-osfp
-  - name: P3.1
-    type: 400gbase-x-osfp
-  - name: P4.0
-    type: 400gbase-x-osfp
-  - name: P4.1
-    type: 400gbase-x-osfp
-  - name: P5.0
-    type: 400gbase-x-osfp
-  - name: P5.1
-    type: 400gbase-x-osfp
-  - name: P6.0
-    type: 400gbase-x-osfp
-  - name: P6.1
-    type: 400gbase-x-osfp
-  - name: P7.0
-    type: 400gbase-x-osfp
-  - name: P7.1
-    type: 400gbase-x-osfp
-  - name: P8.0
-    type: 400gbase-x-osfp
-  - name: P8.1
-    type: 400gbase-x-osfp
-  - name: P9.0
-    type: 400gbase-x-osfp
-  - name: P9.1
-    type: 400gbase-x-osfp
-  - name: P10.0
-    type: 400gbase-x-osfp
-  - name: P10.1
-    type: 400gbase-x-osfp
-  - name: P11.0
-    type: 400gbase-x-osfp
-  - name: P11.1
-    type: 400gbase-x-osfp
-  - name: P12.0
-    type: 400gbase-x-osfp
-  - name: P12.1
-    type: 400gbase-x-osfp
-  - name: P13.0
-    type: 400gbase-x-osfp
-  - name: P13.1
-    type: 400gbase-x-osfp
-  - name: P14.0
-    type: 400gbase-x-osfp
-  - name: P14.1
-    type: 400gbase-x-osfp
-  - name: P15.0
-    type: 400gbase-x-osfp
-  - name: P15.1
-    type: 400gbase-x-osfp
-  - name: P16.0
-    type: 400gbase-x-osfp
-  - name: P16.1
-    type: 400gbase-x-osfp
-  - name: P17.0
-    type: 400gbase-x-osfp
-  - name: P17.1
-    type: 400gbase-x-osfp
-  - name: P18.0
-    type: 400gbase-x-osfp
-  - name: P18.1
-    type: 400gbase-x-osfp
-  - name: P19.0
-    type: 400gbase-x-osfp
-  - name: P19.1
-    type: 400gbase-x-osfp
-  - name: P20.0
-    type: 400gbase-x-osfp
-  - name: P20.1
-    type: 400gbase-x-osfp
-  - name: P21.0
-    type: 400gbase-x-osfp
-  - name: P21.1
-    type: 400gbase-x-osfp
-  - name: P22.0
-    type: 400gbase-x-osfp
-  - name: P23.1
-    type: 400gbase-x-osfp
-  - name: P24.0
-    type: 400gbase-x-osfp
-  - name: P24.1
-    type: 400gbase-x-osfp
-  - name: P25.0
-    type: 400gbase-x-osfp
-  - name: P25.1
-    type: 400gbase-x-osfp
-  - name: P26.0
-    type: 400gbase-x-osfp
-  - name: P26.1
-    type: 400gbase-x-osfp
-  - name: P27.0
-    type: 400gbase-x-osfp
-  - name: P27.1
-    type: 400gbase-x-osfp
-  - name: P28.0
-    type: 400gbase-x-osfp
-  - name: P28.1
-    type: 400gbase-x-osfp
-  - name: P29.0
-    type: 400gbase-x-osfp
-  - name: P29.1
-    type: 400gbase-x-osfp
-  - name: P30.0
-    type: 400gbase-x-osfp
-  - name: P30.1
-    type: 400gbase-x-osfp
-  - name: P31.0
-    type: 400gbase-x-osfp
-  - name: P31.1
-    type: 400gbase-x-osfp
+  - name: mgmt0
+    type: 1000base-t
+    mgmt_only: true
+  - name: IB1/1/1
+    type: infiniband-ndr
+  - name: IB1/1/2
+    type: infiniband-ndr
+  - name: IB1/2/1
+    type: infiniband-ndr
+  - name: IB1/2/2
+    type: infiniband-ndr
+  - name: IB1/3/1
+    type: infiniband-ndr
+  - name: IB1/3/2
+    type: infiniband-ndr
+  - name: IB1/4/1
+    type: infiniband-ndr
+  - name: IB1/4/2
+    type: infiniband-ndr
+  - name: IB1/5/1
+    type: infiniband-ndr
+  - name: IB1/5/2
+    type: infiniband-ndr
+  - name: IB1/6/1
+    type: infiniband-ndr
+  - name: IB1/6/2
+    type: infiniband-ndr
+  - name: IB1/7/1
+    type: infiniband-ndr
+  - name: IB1/7/2
+    type: infiniband-ndr
+  - name: IB1/8/1
+    type: infiniband-ndr
+  - name: IB1/8/2
+    type: infiniband-ndr
+  - name: IB1/9/1
+    type: infiniband-ndr
+  - name: IB1/9/2
+    type: infiniband-ndr
+  - name: IB1/10/1
+    type: infiniband-ndr
+  - name: IB1/10/2
+    type: infiniband-ndr
+  - name: IB1/11/1
+    type: infiniband-ndr
+  - name: IB1/11/2
+    type: infiniband-ndr
+  - name: IB1/12/1
+    type: infiniband-ndr
+  - name: IB1/12/2
+    type: infiniband-ndr
+  - name: IB1/13/1
+    type: infiniband-ndr
+  - name: IB1/13/2
+    type: infiniband-ndr
+  - name: IB1/14/1
+    type: infiniband-ndr
+  - name: IB1/14/2
+    type: infiniband-ndr
+  - name: IB1/15/1
+    type: infiniband-ndr
+  - name: IB1/15/2
+    type: infiniband-ndr
+  - name: IB1/16/1
+    type: infiniband-ndr
+  - name: IB1/16/2
+    type: infiniband-ndr
+  - name: IB1/17/1
+    type: infiniband-ndr
+  - name: IB1/17/2
+    type: infiniband-ndr
+  - name: IB1/18/1
+    type: infiniband-ndr
+  - name: IB1/18/2
+    type: infiniband-ndr
+  - name: IB1/19/1
+    type: infiniband-ndr
+  - name: IB1/19/2
+    type: infiniband-ndr
+  - name: IB1/20/1
+    type: infiniband-ndr
+  - name: IB1/20/2
+    type: infiniband-ndr
+  - name: IB1/21/1
+    type: infiniband-ndr
+  - name: IB1/21/2
+    type: infiniband-ndr
+  - name: IB1/22/1
+    type: infiniband-ndr
+  - name: IB1/22/2
+    type: infiniband-ndr
+  - name: IB1/23/1
+    type: infiniband-ndr
+  - name: IB1/23/2
+    type: infiniband-ndr
+  - name: IB1/24/1
+    type: infiniband-ndr
+  - name: IB1/24/2
+    type: infiniband-ndr
+  - name: IB1/25/1
+    type: infiniband-ndr
+  - name: IB1/25/2
+    type: infiniband-ndr
+  - name: IB1/26/1
+    type: infiniband-ndr
+  - name: IB1/26/2
+    type: infiniband-ndr
+  - name: IB1/27/1
+    type: infiniband-ndr
+  - name: IB1/27/2
+    type: infiniband-ndr
+  - name: IB1/28/1
+    type: infiniband-ndr
+  - name: IB1/28/2
+    type: infiniband-ndr
+  - name: IB1/29/1
+    type: infiniband-ndr
+  - name: IB1/29/2
+    type: infiniband-ndr
+  - name: IB1/30/1
+    type: infiniband-ndr
+  - name: IB1/30/2
+    type: infiniband-ndr
+  - name: IB1/31/1
+    type: infiniband-ndr
+  - name: IB1/31/2
+    type: infiniband-ndr
+  - name: IB1/32/1
+    type: infiniband-ndr
+  - name: IB1/32/2
+    type: infiniband-ndr

--- a/device-types/Nvidia/SN5610.yaml
+++ b/device-types/Nvidia/SN5610.yaml
@@ -1,0 +1,159 @@
+---
+manufacturer: Nvidia
+model: SN5610
+slug: nvidia-sn5610
+u_height: 2
+is_full_depth: true
+airflow: rear-to-front
+weight: 26.9
+weight_unit: kg
+comments: |
+  NVIDIA Spectrum-4 SN5610 Ethernet switch. 64x 800GbE OSFP ports, 51.2Tb/s.
+  Power-optimised variant of the SN5600 with an octa-core AMD CPU.
+  Ports are splittable with breakout cables; only the 64 physical cages are
+  modelled here.
+  Data sheet: https://resource.naddod.com/files/2025-09-17/nvidia-spectrum-4-sn5000-series-datasheet-012314.pdf
+console-ports:
+  - name: con0
+    type: rj-45
+module-bays:
+  - name: PSU1
+    position: PSU1
+  - name: PSU2
+    position: PSU2
+  - name: PSU3
+    position: PSU3
+  - name: PSU4
+    position: PSU4
+interfaces:
+  - name: eth0
+    type: 1000base-t
+    mgmt_only: true
+  - name: swp1
+    type: 800gbase-x-osfp
+  - name: swp2
+    type: 800gbase-x-osfp
+  - name: swp3
+    type: 800gbase-x-osfp
+  - name: swp4
+    type: 800gbase-x-osfp
+  - name: swp5
+    type: 800gbase-x-osfp
+  - name: swp6
+    type: 800gbase-x-osfp
+  - name: swp7
+    type: 800gbase-x-osfp
+  - name: swp8
+    type: 800gbase-x-osfp
+  - name: swp9
+    type: 800gbase-x-osfp
+  - name: swp10
+    type: 800gbase-x-osfp
+  - name: swp11
+    type: 800gbase-x-osfp
+  - name: swp12
+    type: 800gbase-x-osfp
+  - name: swp13
+    type: 800gbase-x-osfp
+  - name: swp14
+    type: 800gbase-x-osfp
+  - name: swp15
+    type: 800gbase-x-osfp
+  - name: swp16
+    type: 800gbase-x-osfp
+  - name: swp17
+    type: 800gbase-x-osfp
+  - name: swp18
+    type: 800gbase-x-osfp
+  - name: swp19
+    type: 800gbase-x-osfp
+  - name: swp20
+    type: 800gbase-x-osfp
+  - name: swp21
+    type: 800gbase-x-osfp
+  - name: swp22
+    type: 800gbase-x-osfp
+  - name: swp23
+    type: 800gbase-x-osfp
+  - name: swp24
+    type: 800gbase-x-osfp
+  - name: swp25
+    type: 800gbase-x-osfp
+  - name: swp26
+    type: 800gbase-x-osfp
+  - name: swp27
+    type: 800gbase-x-osfp
+  - name: swp28
+    type: 800gbase-x-osfp
+  - name: swp29
+    type: 800gbase-x-osfp
+  - name: swp30
+    type: 800gbase-x-osfp
+  - name: swp31
+    type: 800gbase-x-osfp
+  - name: swp32
+    type: 800gbase-x-osfp
+  - name: swp33
+    type: 800gbase-x-osfp
+  - name: swp34
+    type: 800gbase-x-osfp
+  - name: swp35
+    type: 800gbase-x-osfp
+  - name: swp36
+    type: 800gbase-x-osfp
+  - name: swp37
+    type: 800gbase-x-osfp
+  - name: swp38
+    type: 800gbase-x-osfp
+  - name: swp39
+    type: 800gbase-x-osfp
+  - name: swp40
+    type: 800gbase-x-osfp
+  - name: swp41
+    type: 800gbase-x-osfp
+  - name: swp42
+    type: 800gbase-x-osfp
+  - name: swp43
+    type: 800gbase-x-osfp
+  - name: swp44
+    type: 800gbase-x-osfp
+  - name: swp45
+    type: 800gbase-x-osfp
+  - name: swp46
+    type: 800gbase-x-osfp
+  - name: swp47
+    type: 800gbase-x-osfp
+  - name: swp48
+    type: 800gbase-x-osfp
+  - name: swp49
+    type: 800gbase-x-osfp
+  - name: swp50
+    type: 800gbase-x-osfp
+  - name: swp51
+    type: 800gbase-x-osfp
+  - name: swp52
+    type: 800gbase-x-osfp
+  - name: swp53
+    type: 800gbase-x-osfp
+  - name: swp54
+    type: 800gbase-x-osfp
+  - name: swp55
+    type: 800gbase-x-osfp
+  - name: swp56
+    type: 800gbase-x-osfp
+  - name: swp57
+    type: 800gbase-x-osfp
+  - name: swp58
+    type: 800gbase-x-osfp
+  - name: swp59
+    type: 800gbase-x-osfp
+  - name: swp60
+    type: 800gbase-x-osfp
+  - name: swp61
+    type: 800gbase-x-osfp
+  - name: swp62
+    type: 800gbase-x-osfp
+  - name: swp63
+    type: 800gbase-x-osfp
+  - name: swp64
+    type: 800gbase-x-osfp


### PR DESCRIPTION
Adds three NVIDIA switch definitions and fixes an existing one. Component lists were verified against running hardware and cross-checked with vendor datasheets; anything neither source states has been omitted rather than guessed.

### New definitions

- **Q3400-RA** — Quantum-X800, 4U, 144x 800Gb/s XDR over 72 twin-port OSFP cages. Port names follow NVOS (`swNpM`). `fnm1` is the dedicated in-band fabric-node management port used by UFM. 8x C20 PSUs at 875W. PN `920-9B36F-00RX-8S0`.
- **SN5610** — Spectrum-4, 2U, 64x 800GbE OSFP. Power-optimised variant of the SN5600, with 4 PSU bays per the HPE SKU. Breakout sub-ports are deliberately **not** modelled, as splitting is a deployment choice rather than fixed hardware.
- **NVLink 5 Switch** — the NVL72 NVLink switch tray (9 per rack). A deliberately thin definition: only the out-of-band management ports are modelled, because the NVLink ports are blind-mate backplane connections to the compute trays rather than field-cabled ports. Fed by the rack busbar, hence `is_powered: false`. **Happy to drop this one if you would rather not carry a definition with no data ports.**

### Fix to the existing QM9700

The current `Nvidia/QM9700.yaml` has a few problems, which this PR corrects:

1. **Two ports are missing.** It defines 62 interfaces, but the QM9700 has 64 (32 twin-port OSFP cages x 2). `P22.1` and `P23.0` are absent.
2. **No management interface** is defined.
3. **Ports are typed as Ethernet** (`400gbase-x-osfp`) on a switch that is InfiniBand-only.
4. **Port names do not match the OS.** MLNX-OS presents the ports as `IB1/<cage>/<port>`, not `P<n>.<n>`.

The replacement defines all 64 ports as `infiniband-ndr` named `IB1/1/1` through `IB1/32/2`, plus `mgmt0`, and keeps the existing chassis attributes, PSU bays and console port. Since this renames interfaces, it is a breaking change for anyone who has already instantiated the old definition — happy to split it into its own PR, or drop it, if you would prefer.

Note: I had also prepared an SN5600 definition but it turned out to be functionally identical to the one already in the library, so it is not included here.

### Validation

`yamllint` and `pytest tests/definitions_test.py` both pass locally against current `master`.