### PR TITLE
Add Supermicro ARS-121GL-NB3-LCC-R1 GB300 NVL72 compute tray

### DIFF
--- a/device-types/Supermicro/ARS-121GL-NB3-LCC-R1.yaml
+++ b/device-types/Supermicro/ARS-121GL-NB3-LCC-R1.yaml
@@ -1,0 +1,46 @@
+---
+manufacturer: Supermicro
+model: ARS-121GL-NB3-LCC-R1
+slug: supermicro-ars-121gl-nb3-lcc-r1
+part_number: ARS-121GL-NB3-LCC-R1
+u_height: 1
+is_full_depth: true
+weight: 32
+weight_unit: kg
+comments: |
+  Liquid-cooled 1U GB300 compute tray for the Supermicro SRS-GB300-NVL72 rack
+  (18 trays per rack). Each tray carries 2x NVIDIA GB300 Grace Blackwell
+  Superchips (2x 72-core Grace CPU, 4x B300 GPU), 4x ConnectX-8 800Gb/s HCAs and
+  1x BlueField-3 DPU. Power is supplied by the rack power shelves, so the tray
+  has no individual power inlets.
+  Data sheet: https://www.supermicro.com/datasheet/datasheet_SuperCluster_GB300_NVL72.pdf
+is_powered: false
+interfaces:
+  - name: bmc
+    type: 1000base-t
+    mgmt_only: true
+  - name: bmc-bf3
+    type: 1000base-t
+    mgmt_only: true
+    description: BlueField-3 DPU BMC
+  - name: enP5p9s0
+    type: 1000base-t
+    description: ConnectX-8 1GbE management NIC
+  - name: enP22s22f0np0
+    type: 400gbase-x-qsfp112
+    description: BlueField-3 port 0
+  - name: enP22s22f1np1
+    type: 400gbase-x-qsfp112
+    description: BlueField-3 port 1
+  - name: ibp3s0
+    type: infiniband-xdr
+    description: ConnectX-8 XDR InfiniBand
+  - name: ibP2p3s0
+    type: infiniband-xdr
+    description: ConnectX-8 XDR InfiniBand
+  - name: ibP16p3s0
+    type: infiniband-xdr
+    description: ConnectX-8 XDR InfiniBand
+  - name: ibP18p3s0
+    type: infiniband-xdr
+    description: ConnectX-8 XDR InfiniBand


### PR DESCRIPTION
Adds the liquid-cooled 1U GB300 compute tray used in the Supermicro `SRS-GB300-NVL72` rack (18 trays per rack).

Each tray carries 2x NVIDIA GB300 Grace Blackwell Superchips (2x 72-core Grace CPU, 4x B300 GPU), 4x ConnectX-8 800Gb/s HCAs and 1x BlueField-3 DPU.

### Notes

- The nine interfaces were verified against running hardware and are consistent across every tray checked.
- `is_powered: false` — the tray draws from the rack power shelves over the busbar and has no power inlet of its own.
- Interface names are as the OS presents them (`ibp3s0`, `ibP2p3s0`, `ibP16p3s0`, `ibP18p3s0` for the ConnectX-8 XDR HCAs; `enP22s22f0np0`/`f1np1` for the BlueField-3 ports).
- Weight is 32 kg; Supermicro does not publish a per-tray weight in the rack datasheet.

Data sheet: https://www.supermicro.com/datasheet/datasheet_SuperCluster_GB300_NVL72.pdf

### Validation

`yamllint` and `pytest tests/definitions_test.py` both pass locally.