### PR TITLE
Add NetApp AFF A90 chassis and controller

### DIFF
--- a/device-types/NetApp/AFF-A90-Chassis.yaml
+++ b/device-types/NetApp/AFF-A90-Chassis.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: NetApp
+model: AFF A90 Chassis
+slug: netapp-aff-a90-chassis
+description: AFF A90 HA System Chassis
+u_height: 4
+is_full_depth: true
+subdevice_role: parent
+airflow: front-to-rear
+weight: 53.5
+weight_unit: kg
+comments: |
+  NetApp AFF A90 4U chassis housing two hot-swappable controller modules and 48
+  internal NVMe SSD slots. The four power supplies install into the controller
+  modules (two each) rather than the chassis, so the chassis itself has no power
+  inlet; see the AFF A90 Controller definition.
+  Specifications: https://docs.netapp.com/us-en/ontap-systems/a70-90/aff-a-series-affa90-overview.html
+is_powered: false
+device-bays:
+  - name: controller-a
+    description: Controller A
+  - name: controller-b
+    description: Controller B

--- a/device-types/NetApp/AFF-A90-Controller.yaml
+++ b/device-types/NetApp/AFF-A90-Controller.yaml
@@ -1,0 +1,59 @@
+---
+manufacturer: NetApp
+model: AFF A90 Controller
+slug: netapp-aff-a90-controller
+description: AFF A90 HA System Controller
+u_height: 0
+is_full_depth: true
+subdevice_role: child
+comments: |
+  NetApp AFF A70/A90 controller module. There are no onboard data ports; all data
+  connectivity is via PCIe slots. In a typical population slots 1 and 7 hold dual-port
+  ConnectX-6 Dx (40/100GbE), slots 6 and 11 hold dual-port ConnectX-7 (up to
+  400GbE), slot 4 holds NVRAM. The e0M management port and the BMC share a single
+  1GbE RJ45 wrench port via NC-SI sideband.
+  Specifications: https://docs.netapp.com/us-en/ontap-systems/a70-90/aff-a-series-affa90-overview.html
+console-ports:
+  - name: console
+    type: rj-45
+module-bays:
+  - name: PSU 1
+    label: PSU Slot 1
+    position: '1'
+  - name: PSU 2
+    label: PSU Slot 2
+    position: '2'
+interfaces:
+  - name: e0M
+    type: 1000base-t
+    mgmt_only: true
+    label: wrench
+    description: Onboard management port
+  - name: bmc
+    type: virtual
+    mgmt_only: true
+    description: Service processor, NC-SI sideband sharing the e0M port
+  - name: e1a
+    type: 100gbase-x-qsfp28
+    description: Slot 1 ConnectX-6 Dx
+  - name: e1b
+    type: 100gbase-x-qsfp28
+    description: Slot 1 ConnectX-6 Dx
+  - name: e7a
+    type: 100gbase-x-qsfp28
+    description: Slot 7 ConnectX-6 Dx
+  - name: e7b
+    type: 100gbase-x-qsfp28
+    description: Slot 7 ConnectX-6 Dx
+  - name: e6a
+    type: 400gbase-x-qsfp112
+    description: Slot 6 ConnectX-7
+  - name: e6b
+    type: 400gbase-x-qsfp112
+    description: Slot 6 ConnectX-7
+  - name: e11a
+    type: 400gbase-x-qsfp112
+    description: Slot 11 ConnectX-7
+  - name: e11b
+    type: 400gbase-x-qsfp112
+    description: Slot 11 ConnectX-7


### PR DESCRIPTION
Adds the NetApp AFF A90, following the chassis + controller split already used by the existing `AFF-C60-Chassis` / `AFF-C60-Controller` definitions.

- **AFF A90 Chassis** — 4U, parent, two controller bays.
- **AFF A90 Controller** — child, console port, 2 PSU bays, and the PCIe-slot network ports.

### Two choices worth a reviewer eye

1. **PSU placement.** NetApp's documentation is explicit that the four power supplies install *into the controller modules* (two each), not into the chassis, so the PSU module bays sit on the controller and the chassis is marked `is_powered: false`. This differs from `AFF-C60-Chassis`, which carries its PSU bays on the chassis. Happy to move them if you would prefer consistency with the C60.
2. **`bmc` is a virtual interface.** On the A90 the BMC and the `e0M` management port share a single physical RJ45 (the wrench port) over an NC-SI sideband. Modelling the BMC as a `virtual` interface keeps both endpoints addressable without implying a second physical port. Happy to drop it if the library prefers modelling only physical ports.

Note that the A90 has 18 PCIe slots and no onboard data ports; the slot population in the definition (ConnectX-6 Dx in slots 1 and 7, ConnectX-7 in slots 6 and 11) is one common configuration, and the comment says so.

Specifications: https://docs.netapp.com/us-en/ontap-systems/a70-90/aff-a-series-affa90-overview.html

### Validation

`yamllint` and `pytest tests/definitions_test.py` both pass locally.