### PR TITLE
Add DDN SFA400X3E/SFA400X3IE enclosures and SFA400X3 controller

### DIFF
--- a/device-types/DataDirect Networks/SFA400X3-Controller.yaml
+++ b/device-types/DataDirect Networks/SFA400X3-Controller.yaml
@@ -1,0 +1,29 @@
+---
+manufacturer: DataDirect Networks
+model: SFA400X3 Controller
+slug: datadirect-networks-sfa400x3-controller
+comments: |
+  Controller module for the DDN SFA400X3E / SFA400X3IE (AI400X3) enclosure.
+  halink is the inter-controller high-availability link.
+  Product page: https://www.ddn.com/products/ai400x3/
+u_height: 0
+is_full_depth: true
+airflow: front-to-rear
+subdevice_role: child
+interfaces:
+  - name: bmc
+    type: 1000base-t
+    mgmt_only: true
+  - name: halink
+    type: 1000base-t
+    description: Inter-controller HA link
+  - name: mgmt0
+    type: 10gbase-t
+    mgmt_only: true
+  - name: mgmt1
+    type: 10gbase-t
+    mgmt_only: true
+  - name: mlxen0
+    type: 400gbase-x-qsfp112
+  - name: mlxen1
+    type: 400gbase-x-qsfp112

--- a/device-types/DataDirect Networks/SFA400X3E-Enclosure.yaml
+++ b/device-types/DataDirect Networks/SFA400X3E-Enclosure.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: DataDirect Networks
+model: SFA400X3E Enclosure
+slug: datadirect-networks-sfa400x3e-enclosure
+comments: 2U dual-controller enclosure for the DDN SFA400X3E / AI400X3 all-NVMe appliance
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+subdevice_role: parent
+module-bays:
+  - name: PSU 1
+    label: PSU Slot 1
+    position: '1'
+  - name: PSU 2
+    label: PSU Slot 2
+    position: '2'
+device-bays:
+  - name: controller0
+    description: Controller 0
+  - name: controller1
+    description: Controller 1

--- a/device-types/DataDirect Networks/SFA400X3IE-Enclosure.yaml
+++ b/device-types/DataDirect Networks/SFA400X3IE-Enclosure.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: DataDirect Networks
+model: SFA400X3IE Enclosure
+slug: datadirect-networks-sfa400x3ie-enclosure
+comments: 2U dual-controller enclosure for the DDN SFA400X3IE all-NVMe appliance
+u_height: 2
+is_full_depth: true
+airflow: front-to-rear
+subdevice_role: parent
+module-bays:
+  - name: PSU 1
+    label: PSU Slot 1
+    position: '1'
+  - name: PSU 2
+    label: PSU Slot 2
+    position: '2'
+device-bays:
+  - name: controller0
+    description: Controller 0
+  - name: controller1
+    description: Controller 1


### PR DESCRIPTION
Adds the DDN SFA400X3 family (marketed as **AI400X3**), following the enclosure + controller split already used by the existing `SFA200NVX2-Enclosure` / `SFA200NVX2-Controller` definitions.

- **SFA400X3E Enclosure** — 2U, parent, two controller bays, two PSU bays.
- **SFA400X3IE Enclosure** — same chassis, the IE variant.
- **SFA400X3 Controller** — child; one definition shared by both enclosures, which take the same module.

### Notes

- Controller interfaces are as the appliance OS presents them: `mlxen0`/`mlxen1` are the 400G data ports, `mgmt0`/`mgmt1` the 10GBASE-T management ports, `halink` the inter-controller HA link, plus the BMC.
- PSU bay count follows the `SFA200NVX2-Enclosure` sibling (2). DDN publishes a system-level 2400W rating for the 2U appliance but does not state the PSU count or chassis weight, so weight is omitted rather than guessed.

Product page: https://www.ddn.com/products/ai400x3/

### Validation

`yamllint` and `pytest tests/definitions_test.py` both pass locally.