### PR TITLE
Add 1 Hanwha IP camera device type

### DIFF
--- a/device-types/Hanwha/QNP-6250R.yaml
+++ b/device-types/Hanwha/QNP-6250R.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Hanwha
+model: QNP-6250R
+slug: hanwha-qnp-6250r
+part_number: QNP-6250R
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 3100
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: PoE Class 4, max 25.5 W
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Hanwha QNP-6250R datasheet](https://www.hanwhavision.com/en/products/product-details/qnp-6250r) | [Specs on cctv-database.com](https://cctv-database.com/camera/hanwha-qnp-6250r)

--- a/device-types/Hanwha/QNP-6250R.yaml
+++ b/device-types/Hanwha/QNP-6250R.yaml
@@ -19,4 +19,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Hanwha QNP-6250R datasheet](https://www.hanwhavision.com/en/products/product-details/qnp-6250r) | [Specs on cctv-database.com](https://cctv-database.com/camera/hanwha-qnp-6250r)
+  [Hanwha QNP-6250R datasheet](https://www.hanwhavision.com/en/products/product-details/qnp-6250r)


### PR DESCRIPTION
Adds **1 Hanwha network camera** (QNP-6250R, a 2MP vandal-resistant outdoor PTZ).

### Included per device
- **PoE interface** — `100base-tx`, `poe_mode: pd` + `poe_type` from the datasheet's stated 802.3 standard.
- **microSD module bay** where present.
- **weight**, and a datasheet link in `comments`.

### Sourcing
All specs come from the official Hanwha product page and datasheet linked in each file's `comments`.

### Validation
`pytest tests/definitions_test.py`, `yamllint`, and `yamlfmt` all pass. No slug or filename collides with the Hanwha entries already in the library.

### Disclosure
Generated from [cctv-database.com](https://cctv-database.com), a CC0 camera-spec database I maintain where every entry is manually verified against the manufacturer datasheet.