### PR TITLE
Add 2 Uniview IP camera device types

### DIFF
--- a/device-types/Uniview/IPC2125LB-SF2840-A.yaml
+++ b/device-types/Uniview/IPC2125LB-SF2840-A.yaml
@@ -21,4 +21,3 @@ power-ports:
     description: 12V DC
 comments: >
   [Uniview IPC2125LB-SF28(40)-A datasheet](https://ubox-eu.oss-eu-central-1.aliyuncs.com/datacenter/doc/1cfcd34a-a0c4-4442-aecf-1032ab08460b/c34c6dd7-838f-435f-b8d5-8c23e19edddb.pdf)
-

--- a/device-types/Uniview/IPC2125LB-SF2840-A.yaml
+++ b/device-types/Uniview/IPC2125LB-SF2840-A.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Uniview
+model: IPC2125LB-SF28(40)-A
+slug: uniview-ipc2125lb-sf2840-a
+part_number: IPC2125LB-SF28(40)-A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 310
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 5 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 5
+    description: 12V DC
+comments: >
+  [Uniview IPC2125LB-SF28(40)-A datasheet](https://ubox-eu.oss-eu-central-1.aliyuncs.com/datacenter/doc/1cfcd34a-a0c4-4442-aecf-1032ab08460b/c34c6dd7-838f-435f-b8d5-8c23e19edddb.pdf)
+  | [Specs on cctv-database.com](https://cctv-database.com/camera/uniview-ipc2125lb-sf28-a)

--- a/device-types/Uniview/IPC2125LB-SF2840-A.yaml
+++ b/device-types/Uniview/IPC2125LB-SF2840-A.yaml
@@ -21,4 +21,4 @@ power-ports:
     description: 12V DC
 comments: >
   [Uniview IPC2125LB-SF28(40)-A datasheet](https://ubox-eu.oss-eu-central-1.aliyuncs.com/datacenter/doc/1cfcd34a-a0c4-4442-aecf-1032ab08460b/c34c6dd7-838f-435f-b8d5-8c23e19edddb.pdf)
-  | [Specs on cctv-database.com](https://cctv-database.com/camera/uniview-ipc2125lb-sf28-a)
+

--- a/device-types/Uniview/IPC2324LB-ADZK-H.yaml
+++ b/device-types/Uniview/IPC2324LB-ADZK-H.yaml
@@ -25,4 +25,3 @@ module-bays:
     description: up to 512 GB
 comments: >
   [Uniview IPC2324LB-ADZK-H datasheet](https://ubox-eu.oss-eu-central-1.aliyuncs.com/datacenter/doc/c7aea8f5-b257-4309-bb57-05d83e5f46f3/e33396f1-b169-47bf-973c-60a26ba1b4d8.pdf)
-

--- a/device-types/Uniview/IPC2324LB-ADZK-H.yaml
+++ b/device-types/Uniview/IPC2324LB-ADZK-H.yaml
@@ -25,4 +25,4 @@ module-bays:
     description: up to 512 GB
 comments: >
   [Uniview IPC2324LB-ADZK-H datasheet](https://ubox-eu.oss-eu-central-1.aliyuncs.com/datacenter/doc/c7aea8f5-b257-4309-bb57-05d83e5f46f3/e33396f1-b169-47bf-973c-60a26ba1b4d8.pdf)
-  | [Specs on cctv-database.com](https://cctv-database.com/camera/uniview-ipc2324lb-adzk-h)
+

--- a/device-types/Uniview/IPC2324LB-ADZK-H.yaml
+++ b/device-types/Uniview/IPC2324LB-ADZK-H.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Uniview
+model: IPC2324LB-ADZK-H
+slug: uniview-ipc2324lb-adzk-h
+part_number: IPC2324LB-ADZK-H
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 510
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 9.6 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 10
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Uniview IPC2324LB-ADZK-H datasheet](https://ubox-eu.oss-eu-central-1.aliyuncs.com/datacenter/doc/c7aea8f5-b257-4309-bb57-05d83e5f46f3/e33396f1-b169-47bf-973c-60a26ba1b4d8.pdf)
+  | [Specs on cctv-database.com](https://cctv-database.com/camera/uniview-ipc2324lb-adzk-h)


### PR DESCRIPTION
Adds **2 Uniview network cameras** (IPC2125LB-SF2840-A and IPC2324LB-ADZK-H — a 5 MP fixed dome and a 4 MP motorized varifocal dome).

### Included per device
- **PoE interface** — `100base-tx`, `poe_mode: pd` + `poe_type` from the datasheet's stated 802.3 standard.
- **DC power port** (dc-terminal) where the camera supports DC input.
- **microSD module bay** where present.
- **weight**, and a datasheet link in `comments`.

### Sourcing
All specs come from the official Uniview product page and datasheet linked in each file's `comments`.

### Validation
`pytest tests/definitions_test.py`, `yamllint`, and `yamlfmt` all pass. No slug or filename collides with the Uniview entries already in the library.

### Disclosure
Generated from [cctv-database.com](https://cctv-database.com), a CC0 camera-spec database I maintain where every entry is manually verified against the manufacturer datasheet.