### PR TITLE
Add 58 Reolink IP camera device types

### DIFF
--- a/device-types/Reolink/B1200.yaml
+++ b/device-types/Reolink/B1200.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: B1200
+slug: reolink-b1200
+part_number: B1200
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 460
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+comments: >
+  [Reolink B1200 datasheet](https://reolink.com/product/rlk8-1200b4-a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-b1200)

--- a/device-types/Reolink/B1200.yaml
+++ b/device-types/Reolink/B1200.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 12
     description: 12V DC
 comments: >
-  [Reolink B1200 datasheet](https://reolink.com/product/rlk8-1200b4-a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-b1200)
+  [Reolink B1200 datasheet](https://reolink.com/product/rlk8-1200b4-a/)

--- a/device-types/Reolink/B400.yaml
+++ b/device-types/Reolink/B400.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 8
     description: 12V DC
 comments: >
-  [Reolink B400 datasheet](https://reolink.com/product/b400/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-b400)
+  [Reolink B400 datasheet](https://reolink.com/product/b400/)

--- a/device-types/Reolink/B400.yaml
+++ b/device-types/Reolink/B400.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: B400
+slug: reolink-b400
+part_number: B400
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 415
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 8 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 8
+    description: 12V DC
+comments: >
+  [Reolink B400 datasheet](https://reolink.com/product/b400/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-b400)

--- a/device-types/Reolink/B500.yaml
+++ b/device-types/Reolink/B500.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: B500
+slug: reolink-b500
+part_number: B500
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 350
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 10 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 10
+    description: 12V DC
+comments: >
+  [Reolink B500 datasheet](https://cdn.reolink.com/files/docs/specs/RLK8-410B4-NVR-Kit-IP-Camera-Specifications.pdf) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-b500)

--- a/device-types/Reolink/B500.yaml
+++ b/device-types/Reolink/B500.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 10
     description: 12V DC
 comments: >
-  [Reolink B500 datasheet](https://cdn.reolink.com/files/docs/specs/RLK8-410B4-NVR-Kit-IP-Camera-Specifications.pdf) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-b500)
+  [Reolink B500 datasheet](https://cdn.reolink.com/files/docs/specs/RLK8-410B4-NVR-Kit-IP-Camera-Specifications.pdf)

--- a/device-types/Reolink/B800.yaml
+++ b/device-types/Reolink/B800.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: B800
+slug: reolink-b800
+part_number: B800
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 485
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+comments: >
+  [Reolink B800 datasheet](https://reolink.com/product/b800/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-b800)

--- a/device-types/Reolink/B800.yaml
+++ b/device-types/Reolink/B800.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 12
     description: 12V DC
 comments: >
-  [Reolink B800 datasheet](https://reolink.com/product/b800/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-b800)
+  [Reolink B800 datasheet](https://reolink.com/product/b800/)

--- a/device-types/Reolink/CX410.yaml
+++ b/device-types/Reolink/CX410.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink CX410 datasheet](https://reolink.com/product/cx410/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-cx410)
+  [Reolink CX410 datasheet](https://reolink.com/product/cx410/)

--- a/device-types/Reolink/CX410.yaml
+++ b/device-types/Reolink/CX410.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: CX410
+slug: reolink-cx410
+part_number: CX410
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 480
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink CX410 datasheet](https://reolink.com/product/cx410/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-cx410)

--- a/device-types/Reolink/CX810.yaml
+++ b/device-types/Reolink/CX810.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink CX810 datasheet](https://reolink.com/product/cx810/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-cx810)
+  [Reolink CX810 datasheet](https://reolink.com/product/cx810/)

--- a/device-types/Reolink/CX810.yaml
+++ b/device-types/Reolink/CX810.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: CX810
+slug: reolink-cx810
+part_number: CX810
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 467
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink CX810 datasheet](https://reolink.com/product/cx810/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-cx810)

--- a/device-types/Reolink/CX820.yaml
+++ b/device-types/Reolink/CX820.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink CX820 datasheet](https://reolink.com/product/cx820/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-cx820)
+  [Reolink CX820 datasheet](https://reolink.com/product/cx820/)

--- a/device-types/Reolink/CX820.yaml
+++ b/device-types/Reolink/CX820.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: CX820
+slug: reolink-cx820
+part_number: CX820
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 515
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink CX820 datasheet](https://reolink.com/product/cx820/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-cx820)

--- a/device-types/Reolink/D1200.yaml
+++ b/device-types/Reolink/D1200.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: D1200
+slug: reolink-d1200
+part_number: D1200
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 510
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+comments: >
+  [Reolink D1200 datasheet](https://reolink.com/product/rlk8-1200d4-a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-d1200)

--- a/device-types/Reolink/D1200.yaml
+++ b/device-types/Reolink/D1200.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 12
     description: 12V DC
 comments: >
-  [Reolink D1200 datasheet](https://reolink.com/product/rlk8-1200d4-a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-d1200)
+  [Reolink D1200 datasheet](https://reolink.com/product/rlk8-1200d4-a/)

--- a/device-types/Reolink/D400.yaml
+++ b/device-types/Reolink/D400.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: D400
+slug: reolink-d400
+part_number: D400
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 480
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 8 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 8
+    description: 12V DC
+comments: >
+  [Reolink D400 datasheet](https://reolink.com/product/d400/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-d400)

--- a/device-types/Reolink/D400.yaml
+++ b/device-types/Reolink/D400.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 8
     description: 12V DC
 comments: >
-  [Reolink D400 datasheet](https://reolink.com/product/d400/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-d400)
+  [Reolink D400 datasheet](https://reolink.com/product/d400/)

--- a/device-types/Reolink/D500.yaml
+++ b/device-types/Reolink/D500.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: D500
+slug: reolink-d500
+part_number: D500
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 480
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+comments: >
+  [Reolink D500 datasheet](https://reolink.com/product/rlk8-520d4/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-d500)

--- a/device-types/Reolink/D500.yaml
+++ b/device-types/Reolink/D500.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 12
     description: 12V DC
 comments: >
-  [Reolink D500 datasheet](https://reolink.com/product/rlk8-520d4/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-d500)
+  [Reolink D500 datasheet](https://reolink.com/product/rlk8-520d4/)

--- a/device-types/Reolink/D800.yaml
+++ b/device-types/Reolink/D800.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: D800
+slug: reolink-d800
+part_number: D800
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 385
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+comments: >
+  [Reolink D800 datasheet](https://reolink.com/product/d800/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-d800)

--- a/device-types/Reolink/D800.yaml
+++ b/device-types/Reolink/D800.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 12
     description: 12V DC
 comments: >
-  [Reolink D800 datasheet](https://reolink.com/product/d800/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-d800)
+  [Reolink D800 datasheet](https://reolink.com/product/d800/)

--- a/device-types/Reolink/DUO-2-POE.yaml
+++ b/device-types/Reolink/DUO-2-POE.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: Duo 2 PoE
+slug: reolink-duo-2-poe
+part_number: Duo 2 PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 680
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink Duo 2 PoE datasheet](https://reolink.com/product/reolink-duo-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-2-poe)

--- a/device-types/Reolink/DUO-2-POE.yaml
+++ b/device-types/Reolink/DUO-2-POE.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink Duo 2 PoE datasheet](https://reolink.com/product/reolink-duo-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-2-poe)
+  [Reolink Duo 2 PoE datasheet](https://reolink.com/product/reolink-duo-poe/)

--- a/device-types/Reolink/DUO-2V-POE.yaml
+++ b/device-types/Reolink/DUO-2V-POE.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: Duo 2V PoE
+slug: reolink-duo-2v-poe
+part_number: Duo 2V PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 664
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink Duo 2V PoE datasheet](https://reolink.com/product/reolink-duo-2v-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-2v-poe)

--- a/device-types/Reolink/DUO-2V-POE.yaml
+++ b/device-types/Reolink/DUO-2V-POE.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink Duo 2V PoE datasheet](https://reolink.com/product/reolink-duo-2v-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-2v-poe)
+  [Reolink Duo 2V PoE datasheet](https://reolink.com/product/reolink-duo-2v-poe/)

--- a/device-types/Reolink/DUO-3-POE.yaml
+++ b/device-types/Reolink/DUO-3-POE.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink Duo 3 PoE datasheet](https://reolink.com/product/reolink-duo-3-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-3-poe)
+  [Reolink Duo 3 PoE datasheet](https://reolink.com/product/reolink-duo-3-poe/)

--- a/device-types/Reolink/DUO-3-POE.yaml
+++ b/device-types/Reolink/DUO-3-POE.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: Duo 3 PoE
+slug: reolink-duo-3-poe
+part_number: Duo 3 PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 680
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink Duo 3 PoE datasheet](https://reolink.com/product/reolink-duo-3-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-3-poe)

--- a/device-types/Reolink/DUO-3V-POE.yaml
+++ b/device-types/Reolink/DUO-3V-POE.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: Duo 3V PoE
+slug: reolink-duo-3v-poe
+part_number: Duo 3V PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 664
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink Duo 3V PoE datasheet](https://reolink.com/product/reolink-duo-3v-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-3v-poe)

--- a/device-types/Reolink/DUO-3V-POE.yaml
+++ b/device-types/Reolink/DUO-3V-POE.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink Duo 3V PoE datasheet](https://reolink.com/product/reolink-duo-3v-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-3v-poe)
+  [Reolink Duo 3V PoE datasheet](https://reolink.com/product/reolink-duo-3v-poe/)

--- a/device-types/Reolink/DUO-FLOODLIGHT-POE.yaml
+++ b/device-types/Reolink/DUO-FLOODLIGHT-POE.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: Duo Floodlight PoE
+slug: reolink-duo-floodlight-poe
+part_number: Duo Floodlight PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1250
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink Duo Floodlight PoE datasheet](https://reolink.com/product/reolink-duo-floodlight-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-floodlight-poe)

--- a/device-types/Reolink/DUO-FLOODLIGHT-POE.yaml
+++ b/device-types/Reolink/DUO-FLOODLIGHT-POE.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink Duo Floodlight PoE datasheet](https://reolink.com/product/reolink-duo-floodlight-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-duo-floodlight-poe)
+  [Reolink Duo Floodlight PoE datasheet](https://reolink.com/product/reolink-duo-floodlight-poe/)

--- a/device-types/Reolink/E1-OUTDOOR-POE.yaml
+++ b/device-types/Reolink/E1-OUTDOOR-POE.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink E1 Outdoor PoE datasheet](https://reolink.com/product/e1-outdoor-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-e1-outdoor-poe)
+  [Reolink E1 Outdoor PoE datasheet](https://reolink.com/product/e1-outdoor-poe/)

--- a/device-types/Reolink/E1-OUTDOOR-POE.yaml
+++ b/device-types/Reolink/E1-OUTDOOR-POE.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: E1 Outdoor PoE
+slug: reolink-e1-outdoor-poe
+part_number: E1 Outdoor PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 458
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink E1 Outdoor PoE datasheet](https://reolink.com/product/e1-outdoor-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-e1-outdoor-poe)

--- a/device-types/Reolink/E1-OUTDOOR-SE-POE.yaml
+++ b/device-types/Reolink/E1-OUTDOOR-SE-POE.yaml
@@ -20,4 +20,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink E1 Outdoor SE PoE datasheet](https://reolink.com/product/e1-outdoor-se-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-e1-outdoor-se-poe)
+  [Reolink E1 Outdoor SE PoE datasheet](https://reolink.com/product/e1-outdoor-se-poe/)

--- a/device-types/Reolink/E1-OUTDOOR-SE-POE.yaml
+++ b/device-types/Reolink/E1-OUTDOOR-SE-POE.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Reolink
+model: E1 Outdoor SE PoE
+slug: reolink-e1-outdoor-se-poe
+part_number: E1 Outdoor SE PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink E1 Outdoor SE PoE datasheet](https://reolink.com/product/e1-outdoor-se-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-e1-outdoor-se-poe)

--- a/device-types/Reolink/ELITE-PRO-FLOODLIGHT-POE.yaml
+++ b/device-types/Reolink/ELITE-PRO-FLOODLIGHT-POE.yaml
@@ -19,4 +19,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink Elite Pro Floodlight PoE datasheet](https://reolink.com/product/elite-pro-floodlight-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-elite-pro-floodlight-poe)
+  [Reolink Elite Pro Floodlight PoE datasheet](https://reolink.com/product/elite-pro-floodlight-poe/)

--- a/device-types/Reolink/ELITE-PRO-FLOODLIGHT-POE.yaml
+++ b/device-types/Reolink/ELITE-PRO-FLOODLIGHT-POE.yaml
@@ -1,0 +1,22 @@
+---
+manufacturer: Reolink
+model: Elite Pro Floodlight PoE
+slug: reolink-elite-pro-floodlight-poe
+part_number: Elite Pro Floodlight PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1300
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: PoE Class 4
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink Elite Pro Floodlight PoE datasheet](https://reolink.com/product/elite-pro-floodlight-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-elite-pro-floodlight-poe)

--- a/device-types/Reolink/FE-P.yaml
+++ b/device-types/Reolink/FE-P.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: FE-P
+slug: reolink-fe-p
+part_number: FE-P
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 293
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink FE-P datasheet](https://reolink.com/product/fe-p/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-fe-p)

--- a/device-types/Reolink/FE-P.yaml
+++ b/device-types/Reolink/FE-P.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink FE-P datasheet](https://reolink.com/product/fe-p/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-fe-p)
+  [Reolink FE-P datasheet](https://reolink.com/product/fe-p/)

--- a/device-types/Reolink/OMVI-3I-POE.yaml
+++ b/device-types/Reolink/OMVI-3I-POE.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink OMVI 3i PoE datasheet](https://reolink.com/product/omvi-3i-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-omvi-3i-poe)
+  [Reolink OMVI 3i PoE datasheet](https://reolink.com/product/omvi-3i-poe/)

--- a/device-types/Reolink/OMVI-3I-POE.yaml
+++ b/device-types/Reolink/OMVI-3I-POE.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: OMVI 3i PoE
+slug: reolink-omvi-3i-poe
+part_number: OMVI 3i PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1300
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: PoE Class 4, max 24 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 24
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink OMVI 3i PoE datasheet](https://reolink.com/product/omvi-3i-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-omvi-3i-poe)

--- a/device-types/Reolink/P340.yaml
+++ b/device-types/Reolink/P340.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: P340
+slug: reolink-p340
+part_number: P340
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 460
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink P340 datasheet](https://reolink.com/product/p340/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-p340)

--- a/device-types/Reolink/P340.yaml
+++ b/device-types/Reolink/P340.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink P340 datasheet](https://reolink.com/product/p340/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-p340)
+  [Reolink P340 datasheet](https://reolink.com/product/p340/)

--- a/device-types/Reolink/P430.yaml
+++ b/device-types/Reolink/P430.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: P430
+slug: reolink-p430
+part_number: P430
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 838
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink P430 datasheet](https://reolink.com/product/p430/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-p430)

--- a/device-types/Reolink/P430.yaml
+++ b/device-types/Reolink/P430.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink P430 datasheet](https://reolink.com/product/p430/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-p430)
+  [Reolink P430 datasheet](https://reolink.com/product/p430/)

--- a/device-types/Reolink/P830.yaml
+++ b/device-types/Reolink/P830.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink P830 datasheet](https://reolink.com/product/p830/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-p830)
+  [Reolink P830 datasheet](https://reolink.com/product/p830/)

--- a/device-types/Reolink/P830.yaml
+++ b/device-types/Reolink/P830.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: P830
+slug: reolink-p830
+part_number: P830
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1200
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink P830 datasheet](https://reolink.com/product/p830/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-p830)

--- a/device-types/Reolink/RLC-1210A.yaml
+++ b/device-types/Reolink/RLC-1210A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-1210A
+slug: reolink-rlc-1210a
+part_number: RLC-1210A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 488
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-1210A datasheet](https://reolink.com/product/rlc-1210a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1210a)

--- a/device-types/Reolink/RLC-1210A.yaml
+++ b/device-types/Reolink/RLC-1210A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-1210A datasheet](https://reolink.com/product/rlc-1210a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1210a)
+  [Reolink RLC-1210A datasheet](https://reolink.com/product/rlc-1210a/)

--- a/device-types/Reolink/RLC-1212A.yaml
+++ b/device-types/Reolink/RLC-1212A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-1212A
+slug: reolink-rlc-1212a
+part_number: RLC-1212A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 460
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-1212A datasheet](https://reolink.com/product/rlc-1212a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1212a)

--- a/device-types/Reolink/RLC-1212A.yaml
+++ b/device-types/Reolink/RLC-1212A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-1212A datasheet](https://reolink.com/product/rlc-1212a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1212a)
+  [Reolink RLC-1212A datasheet](https://reolink.com/product/rlc-1212a/)

--- a/device-types/Reolink/RLC-1220A.yaml
+++ b/device-types/Reolink/RLC-1220A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-1220A
+slug: reolink-rlc-1220a
+part_number: RLC-1220A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 467.5
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-1220A datasheet](https://reolink.com/product/rlc-1220a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1220a)

--- a/device-types/Reolink/RLC-1220A.yaml
+++ b/device-types/Reolink/RLC-1220A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-1220A datasheet](https://reolink.com/product/rlc-1220a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1220a)
+  [Reolink RLC-1220A datasheet](https://reolink.com/product/rlc-1220a/)

--- a/device-types/Reolink/RLC-1224A.yaml
+++ b/device-types/Reolink/RLC-1224A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-1224A
+slug: reolink-rlc-1224a
+part_number: RLC-1224A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 515
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-1224A datasheet](https://reolink.com/product/rlc-1224a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1224a)

--- a/device-types/Reolink/RLC-1224A.yaml
+++ b/device-types/Reolink/RLC-1224A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-1224A datasheet](https://reolink.com/product/rlc-1224a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1224a)
+  [Reolink RLC-1224A datasheet](https://reolink.com/product/rlc-1224a/)

--- a/device-types/Reolink/RLC-1240A.yaml
+++ b/device-types/Reolink/RLC-1240A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-1240A
+slug: reolink-rlc-1240a
+part_number: RLC-1240A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 570
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-1240A datasheet](https://reolink.com/product/rlc-1240a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1240a)

--- a/device-types/Reolink/RLC-1240A.yaml
+++ b/device-types/Reolink/RLC-1240A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-1240A datasheet](https://reolink.com/product/rlc-1240a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-1240a)
+  [Reolink RLC-1240A datasheet](https://reolink.com/product/rlc-1240a/)

--- a/device-types/Reolink/RLC-410.yaml
+++ b/device-types/Reolink/RLC-410.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-410
+slug: reolink-rlc-410
+part_number: RLC-410
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 350
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 10 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 10
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 128 GB
+comments: >
+  [Reolink RLC-410 datasheet](https://reolink.com/product/rlc-410/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-410)

--- a/device-types/Reolink/RLC-410.yaml
+++ b/device-types/Reolink/RLC-410.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 128 GB
 comments: >
-  [Reolink RLC-410 datasheet](https://reolink.com/product/rlc-410/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-410)
+  [Reolink RLC-410 datasheet](https://reolink.com/product/rlc-410/)

--- a/device-types/Reolink/RLC-410S.yaml
+++ b/device-types/Reolink/RLC-410S.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-410S datasheet](https://reolink.com/product/rlc-410s/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-410s)
+  [Reolink RLC-410S datasheet](https://reolink.com/product/rlc-410s/)

--- a/device-types/Reolink/RLC-410S.yaml
+++ b/device-types/Reolink/RLC-410S.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-410S
+slug: reolink-rlc-410s
+part_number: RLC-410S
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 450
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 8 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 8
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-410S datasheet](https://reolink.com/product/rlc-410s/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-410s)

--- a/device-types/Reolink/RLC-422.yaml
+++ b/device-types/Reolink/RLC-422.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-422
+slug: reolink-rlc-422
+part_number: RLC-422
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 720
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 10 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 10
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 64 GB
+comments: >
+  [Reolink RLC-422 datasheet](https://reolink.com/product/rlc-422/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-422)

--- a/device-types/Reolink/RLC-422.yaml
+++ b/device-types/Reolink/RLC-422.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 64 GB
 comments: >
-  [Reolink RLC-422 datasheet](https://reolink.com/product/rlc-422/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-422)
+  [Reolink RLC-422 datasheet](https://reolink.com/product/rlc-422/)

--- a/device-types/Reolink/RLC-423.yaml
+++ b/device-types/Reolink/RLC-423.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 128 GB
 comments: >
-  [Reolink RLC-423 datasheet](https://reolink.com/product/rlc-423/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-423)
+  [Reolink RLC-423 datasheet](https://reolink.com/product/rlc-423/)

--- a/device-types/Reolink/RLC-423.yaml
+++ b/device-types/Reolink/RLC-423.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-423
+slug: reolink-rlc-423
+part_number: RLC-423
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1600
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: max 20 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 20
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 128 GB
+comments: >
+  [Reolink RLC-423 datasheet](https://reolink.com/product/rlc-423/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-423)

--- a/device-types/Reolink/RLC-510A.yaml
+++ b/device-types/Reolink/RLC-510A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-510A
+slug: reolink-rlc-510a
+part_number: RLC-510A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 415
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-510A datasheet](https://reolink.com/product/rlc-510a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-510a)

--- a/device-types/Reolink/RLC-510A.yaml
+++ b/device-types/Reolink/RLC-510A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-510A datasheet](https://reolink.com/product/rlc-510a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-510a)
+  [Reolink RLC-510A datasheet](https://reolink.com/product/rlc-510a/)

--- a/device-types/Reolink/RLC-511.yaml
+++ b/device-types/Reolink/RLC-511.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 128 GB
 comments: >
-  [Reolink RLC-511 datasheet](https://reolink.com/product/rlc-511/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-511)
+  [Reolink RLC-511 datasheet](https://reolink.com/product/rlc-511/)

--- a/device-types/Reolink/RLC-511.yaml
+++ b/device-types/Reolink/RLC-511.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-511
+slug: reolink-rlc-511
+part_number: RLC-511
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 750
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 128 GB
+comments: >
+  [Reolink RLC-511 datasheet](https://reolink.com/product/rlc-511/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-511)

--- a/device-types/Reolink/RLC-520.yaml
+++ b/device-types/Reolink/RLC-520.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 128 GB
 comments: >
-  [Reolink RLC-520 datasheet](https://reolink.com/product/rlc-520/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-520)
+  [Reolink RLC-520 datasheet](https://reolink.com/product/rlc-520/)

--- a/device-types/Reolink/RLC-520.yaml
+++ b/device-types/Reolink/RLC-520.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-520
+slug: reolink-rlc-520
+part_number: RLC-520
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 385
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 8 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 8
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 128 GB
+comments: >
+  [Reolink RLC-520 datasheet](https://reolink.com/product/rlc-520/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-520)

--- a/device-types/Reolink/RLC-520A.yaml
+++ b/device-types/Reolink/RLC-520A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-520A
+slug: reolink-rlc-520a
+part_number: RLC-520A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 467.5
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-520A datasheet](https://reolink.com/product/rlc-520a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-520a)

--- a/device-types/Reolink/RLC-520A.yaml
+++ b/device-types/Reolink/RLC-520A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-520A datasheet](https://reolink.com/product/rlc-520a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-520a)
+  [Reolink RLC-520A datasheet](https://reolink.com/product/rlc-520a/)

--- a/device-types/Reolink/RLC-522.yaml
+++ b/device-types/Reolink/RLC-522.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-522
+slug: reolink-rlc-522
+part_number: RLC-522
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 385
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 128 GB
+comments: >
+  [Reolink RLC-522 datasheet](https://reolink.com/product/rlc-522/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-522)

--- a/device-types/Reolink/RLC-522.yaml
+++ b/device-types/Reolink/RLC-522.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 128 GB
 comments: >
-  [Reolink RLC-522 datasheet](https://reolink.com/product/rlc-522/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-522)
+  [Reolink RLC-522 datasheet](https://reolink.com/product/rlc-522/)

--- a/device-types/Reolink/RLC-540A.yaml
+++ b/device-types/Reolink/RLC-540A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-540A
+slug: reolink-rlc-540a
+part_number: RLC-540A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 570
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-540A datasheet](https://reolink.com/product/rlc-540a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-540a)

--- a/device-types/Reolink/RLC-540A.yaml
+++ b/device-types/Reolink/RLC-540A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-540A datasheet](https://reolink.com/product/rlc-540a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-540a)
+  [Reolink RLC-540A datasheet](https://reolink.com/product/rlc-540a/)

--- a/device-types/Reolink/RLC-810A.yaml
+++ b/device-types/Reolink/RLC-810A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-810A datasheet](https://reolink.com/product/rlc-810a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-810a)
+  [Reolink RLC-810A datasheet](https://reolink.com/product/rlc-810a/)

--- a/device-types/Reolink/RLC-810A.yaml
+++ b/device-types/Reolink/RLC-810A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-810A
+slug: reolink-rlc-810a
+part_number: RLC-810A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 485.5
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-810A datasheet](https://reolink.com/product/rlc-810a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-810a)

--- a/device-types/Reolink/RLC-811A.yaml
+++ b/device-types/Reolink/RLC-811A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-811A
+slug: reolink-rlc-811a
+part_number: RLC-811A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 838
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-811A datasheet](https://reolink.com/product/rlc-811a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-811a)

--- a/device-types/Reolink/RLC-811A.yaml
+++ b/device-types/Reolink/RLC-811A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-811A datasheet](https://reolink.com/product/rlc-811a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-811a)
+  [Reolink RLC-811A datasheet](https://reolink.com/product/rlc-811a/)

--- a/device-types/Reolink/RLC-812A.yaml
+++ b/device-types/Reolink/RLC-812A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-812A
+slug: reolink-rlc-812a
+part_number: RLC-812A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 460
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-812A datasheet](https://reolink.com/product/rlc-812a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-812a)

--- a/device-types/Reolink/RLC-812A.yaml
+++ b/device-types/Reolink/RLC-812A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-812A datasheet](https://reolink.com/product/rlc-812a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-812a)
+  [Reolink RLC-812A datasheet](https://reolink.com/product/rlc-812a/)

--- a/device-types/Reolink/RLC-81MA.yaml
+++ b/device-types/Reolink/RLC-81MA.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-81MA datasheet](https://reolink.com/product/rlc-81ma/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-81ma)
+  [Reolink RLC-81MA datasheet](https://reolink.com/product/rlc-81ma/)

--- a/device-types/Reolink/RLC-81MA.yaml
+++ b/device-types/Reolink/RLC-81MA.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: RLC-81MA
+slug: reolink-rlc-81ma
+part_number: RLC-81MA
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 460
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-81MA datasheet](https://reolink.com/product/rlc-81ma/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-81ma)

--- a/device-types/Reolink/RLC-81PA.yaml
+++ b/device-types/Reolink/RLC-81PA.yaml
@@ -22,4 +22,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-81PA datasheet](https://reolink.com/product/rlc-81pa/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-81pa)
+  [Reolink RLC-81PA datasheet](https://reolink.com/product/rlc-81pa/)

--- a/device-types/Reolink/RLC-81PA.yaml
+++ b/device-types/Reolink/RLC-81PA.yaml
@@ -1,0 +1,25 @@
+---
+manufacturer: Reolink
+model: RLC-81PA
+slug: reolink-rlc-81pa
+part_number: RLC-81PA
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 605
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-81PA datasheet](https://reolink.com/product/rlc-81pa/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-81pa)

--- a/device-types/Reolink/RLC-820A.yaml
+++ b/device-types/Reolink/RLC-820A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-820A
+slug: reolink-rlc-820a
+part_number: RLC-820A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 467.5
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-820A datasheet](https://reolink.com/product/rlc-820a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-820a)

--- a/device-types/Reolink/RLC-820A.yaml
+++ b/device-types/Reolink/RLC-820A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-820A datasheet](https://reolink.com/product/rlc-820a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-820a)
+  [Reolink RLC-820A datasheet](https://reolink.com/product/rlc-820a/)

--- a/device-types/Reolink/RLC-822A.yaml
+++ b/device-types/Reolink/RLC-822A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-822A datasheet](https://reolink.com/product/rlc-822a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-822a)
+  [Reolink RLC-822A datasheet](https://reolink.com/product/rlc-822a/)

--- a/device-types/Reolink/RLC-822A.yaml
+++ b/device-types/Reolink/RLC-822A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-822A
+slug: reolink-rlc-822a
+part_number: RLC-822A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 467.5
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-822A datasheet](https://reolink.com/product/rlc-822a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-822a)

--- a/device-types/Reolink/RLC-823A-16X.yaml
+++ b/device-types/Reolink/RLC-823A-16X.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-823A 16X
+slug: reolink-rlc-823a-16x
+part_number: RLC-823A 16X
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1600
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: max 24 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 24
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-823A 16X datasheet](https://reolink.com/product/rlc-823a-16x/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-823a-16x)

--- a/device-types/Reolink/RLC-823A-16X.yaml
+++ b/device-types/Reolink/RLC-823A-16X.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-823A 16X datasheet](https://reolink.com/product/rlc-823a-16x/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-823a-16x)
+  [Reolink RLC-823A 16X datasheet](https://reolink.com/product/rlc-823a-16x/)

--- a/device-types/Reolink/RLC-823A.yaml
+++ b/device-types/Reolink/RLC-823A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-823A datasheet](https://reolink.com/product/rlc-823a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-823a)
+  [Reolink RLC-823A datasheet](https://reolink.com/product/rlc-823a/)

--- a/device-types/Reolink/RLC-823A.yaml
+++ b/device-types/Reolink/RLC-823A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-823A
+slug: reolink-rlc-823a
+part_number: RLC-823A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1800
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: max 24 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 24
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-823A datasheet](https://reolink.com/product/rlc-823a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-823a)

--- a/device-types/Reolink/RLC-823S1.yaml
+++ b/device-types/Reolink/RLC-823S1.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-823S1 datasheet](https://reolink.com/product/rlc-823s1/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-823s1)
+  [Reolink RLC-823S1 datasheet](https://reolink.com/product/rlc-823s1/)

--- a/device-types/Reolink/RLC-823S1.yaml
+++ b/device-types/Reolink/RLC-823S1.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-823S1
+slug: reolink-rlc-823s1
+part_number: RLC-823S1
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 2340
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: max 24 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 24
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-823S1 datasheet](https://reolink.com/product/rlc-823s1/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-823s1)

--- a/device-types/Reolink/RLC-823S2.yaml
+++ b/device-types/Reolink/RLC-823S2.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-823S2
+slug: reolink-rlc-823s2
+part_number: RLC-823S2
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 2340
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: max 24 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 24
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-823S2 datasheet](https://reolink.com/product/rlc-823s2/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-823s2)

--- a/device-types/Reolink/RLC-823S2.yaml
+++ b/device-types/Reolink/RLC-823S2.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-823S2 datasheet](https://reolink.com/product/rlc-823s2/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-823s2)
+  [Reolink RLC-823S2 datasheet](https://reolink.com/product/rlc-823s2/)

--- a/device-types/Reolink/RLC-824A.yaml
+++ b/device-types/Reolink/RLC-824A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-824A datasheet](https://reolink.com/product/rlc-824a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-824a)
+  [Reolink RLC-824A datasheet](https://reolink.com/product/rlc-824a/)

--- a/device-types/Reolink/RLC-824A.yaml
+++ b/device-types/Reolink/RLC-824A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-824A
+slug: reolink-rlc-824a
+part_number: RLC-824A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 515
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-824A datasheet](https://reolink.com/product/rlc-824a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-824a)

--- a/device-types/Reolink/RLC-830A.yaml
+++ b/device-types/Reolink/RLC-830A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-830A
+slug: reolink-rlc-830a
+part_number: RLC-830A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1200
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink RLC-830A datasheet](https://reolink.com/product/rlc-830a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-830a)

--- a/device-types/Reolink/RLC-830A.yaml
+++ b/device-types/Reolink/RLC-830A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink RLC-830A datasheet](https://reolink.com/product/rlc-830a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-830a)
+  [Reolink RLC-830A datasheet](https://reolink.com/product/rlc-830a/)

--- a/device-types/Reolink/RLC-833A.yaml
+++ b/device-types/Reolink/RLC-833A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-833A
+slug: reolink-rlc-833a
+part_number: RLC-833A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 510
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-833A datasheet](https://reolink.com/us/product/rlc-833a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-833a)

--- a/device-types/Reolink/RLC-833A.yaml
+++ b/device-types/Reolink/RLC-833A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-833A datasheet](https://reolink.com/us/product/rlc-833a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-833a)
+  [Reolink RLC-833A datasheet](https://reolink.com/us/product/rlc-833a/)

--- a/device-types/Reolink/RLC-840A.yaml
+++ b/device-types/Reolink/RLC-840A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-840A datasheet](https://reolink.com/product/rlc-840a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-840a)
+  [Reolink RLC-840A datasheet](https://reolink.com/product/rlc-840a/)

--- a/device-types/Reolink/RLC-840A.yaml
+++ b/device-types/Reolink/RLC-840A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-840A
+slug: reolink-rlc-840a
+part_number: RLC-840A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 604
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-840A datasheet](https://reolink.com/product/rlc-840a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-840a)

--- a/device-types/Reolink/RLC-842A.yaml
+++ b/device-types/Reolink/RLC-842A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-842A
+slug: reolink-rlc-842a
+part_number: RLC-842A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 686
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-842A datasheet](https://reolink.com/product/rlc-842a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-842a)

--- a/device-types/Reolink/RLC-842A.yaml
+++ b/device-types/Reolink/RLC-842A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-842A datasheet](https://reolink.com/product/rlc-842a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-842a)
+  [Reolink RLC-842A datasheet](https://reolink.com/product/rlc-842a/)

--- a/device-types/Reolink/RLC-843A.yaml
+++ b/device-types/Reolink/RLC-843A.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink RLC-843A datasheet](https://reolink.com/product/rlc-843a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-843a)
+  [Reolink RLC-843A datasheet](https://reolink.com/product/rlc-843a/)

--- a/device-types/Reolink/RLC-843A.yaml
+++ b/device-types/Reolink/RLC-843A.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: RLC-843A
+slug: reolink-rlc-843a
+part_number: RLC-843A
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 751
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink RLC-843A datasheet](https://reolink.com/product/rlc-843a/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-rlc-843a)

--- a/device-types/Reolink/TRACKMIX-POE.yaml
+++ b/device-types/Reolink/TRACKMIX-POE.yaml
@@ -24,4 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Reolink TrackMix PoE datasheet](https://reolink.com/product/reolink-trackmix-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-trackmix-poe)
+  [Reolink TrackMix PoE datasheet](https://reolink.com/product/reolink-trackmix-poe/)

--- a/device-types/Reolink/TRACKMIX-POE.yaml
+++ b/device-types/Reolink/TRACKMIX-POE.yaml
@@ -1,0 +1,27 @@
+---
+manufacturer: Reolink
+model: TrackMix PoE
+slug: reolink-trackmix-poe
+part_number: TrackMix PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 1210
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: max 12 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 12
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Reolink TrackMix PoE datasheet](https://reolink.com/product/reolink-trackmix-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-trackmix-poe)

--- a/device-types/Reolink/VIDEO-DOORBELL-POE.yaml
+++ b/device-types/Reolink/VIDEO-DOORBELL-POE.yaml
@@ -23,4 +23,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Reolink Video Doorbell PoE datasheet](https://reolink.com/product/reolink-video-doorbell-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-video-doorbell-poe)
+  [Reolink Video Doorbell PoE datasheet](https://reolink.com/product/reolink-video-doorbell-poe/)

--- a/device-types/Reolink/VIDEO-DOORBELL-POE.yaml
+++ b/device-types/Reolink/VIDEO-DOORBELL-POE.yaml
@@ -1,0 +1,26 @@
+---
+manufacturer: Reolink
+model: Video Doorbell PoE
+slug: reolink-video-doorbell-poe
+part_number: Video Doorbell PoE
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 96
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: PoE Class 2
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 24V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Reolink Video Doorbell PoE datasheet](https://reolink.com/product/reolink-video-doorbell-poe/) | [Specs on cctv-database.com](https://cctv-database.com/camera/reolink-video-doorbell-poe)


### PR DESCRIPTION
Adds **58 Reolink network cameras** — bullets, domes, turrets, fisheye, duo/multi-sensor, floodlight, doorbell, and TrackMix models from the RLC, B/D/P, CX, DUO, OMVI, and E1 families. All are PoE-capable.

### Included per device
- **PoE interface** — `100base-tx`, `poe_mode: pd` + `poe_type` from the datasheet's stated 802.3 standard.
- **DC power port** (dc-terminal) on the 57 models that support DC input in addition to PoE.
- **microSD module bay** on the 50 models that include a card slot.
- **weight** on the 57 models whose spec sheet lists it.
- A datasheet link in `comments`.

### Sourcing
All specs come from the official Reolink product page and/or spec sheet linked in each file's `comments`. Models whose exact-SKU spec could not be located are omitted rather than guessed.

### Validation
`pytest tests/definitions_test.py`, `yamllint`, and `yamlfmt` all pass. No slug or filename collides with the Reolink entries already in the library.

### Disclosure
Generated from [cctv-database.com](https://cctv-database.com), a CC0 camera-spec database I maintain where every entry is manually verified against the manufacturer datasheet.