### PR TITLE
Add 12 Amcrest IP camera device types

### DIFF
--- a/device-types/amcrest/IP4M-1055E.yaml
+++ b/device-types/amcrest/IP4M-1055E.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Amcrest
+model: IP4M-1055E
+slug: amcrest-ip4m-1055e
+part_number: IP4M-1055E
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 230
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: PoE Class 0, max 5.5 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 6
+    description: 12V DC
+comments: >
+  [Amcrest IP4M-1055E datasheet](https://s3.amazonaws.com/amcrest-files/Documentation/IP4M-1055E+Technical+Specification.pdf) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip4m-1055e)

--- a/device-types/amcrest/IP4M-1055E.yaml
+++ b/device-types/amcrest/IP4M-1055E.yaml
@@ -20,4 +20,4 @@ power-ports:
     maximum_draw: 6
     description: 12V DC
 comments: >
-  [Amcrest IP4M-1055E datasheet](https://s3.amazonaws.com/amcrest-files/Documentation/IP4M-1055E+Technical+Specification.pdf) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip4m-1055e)
+  [Amcrest IP4M-1055E datasheet](https://s3.amazonaws.com/amcrest-files/Documentation/IP4M-1055E+Technical+Specification.pdf)

--- a/device-types/amcrest/IP5M-B1186EW.yaml
+++ b/device-types/amcrest/IP5M-B1186EW.yaml
@@ -18,4 +18,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Amcrest IP5M-B1186EW datasheet](https://amcrest.com/5mp-poe-camera-bullet-ip5m-b1186ew-28mm.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip5m-b1186ew)
+  [Amcrest IP5M-B1186EW datasheet](https://amcrest.com/5mp-poe-camera-bullet-ip5m-b1186ew-28mm.html)

--- a/device-types/amcrest/IP5M-B1186EW.yaml
+++ b/device-types/amcrest/IP5M-B1186EW.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: Amcrest
+model: IP5M-B1186EW
+slug: amcrest-ip5m-b1186ew
+part_number: IP5M-B1186EW
+u_height: 0
+is_full_depth: false
+airflow: passive
+interfaces:
+  - name: eth0
+    type: 100base-tx
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Amcrest IP5M-B1186EW datasheet](https://amcrest.com/5mp-poe-camera-bullet-ip5m-b1186ew-28mm.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip5m-b1186ew)

--- a/device-types/amcrest/IP5M-D1188EW-AI-V3.yaml
+++ b/device-types/amcrest/IP5M-D1188EW-AI-V3.yaml
@@ -24,5 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Amcrest IP5M-D1188EW-AI-V3 datasheet](https://support.amcrest.com/hc/en-us/articles/25855591714573-Technical-Specifications-IP5M-D1188EW-AI-V3) | [Specs
-  on cctv-database.com](https://cctv-database.com/camera/amcrest-ip5m-d1188ew-ai-v3)
+  [Amcrest IP5M-D1188EW-AI-V3 datasheet](https://support.amcrest.com/hc/en-us/articles/25855591714573-Technical-Specifications-IP5M-D1188EW-AI-V3)

--- a/device-types/amcrest/IP5M-D1188EW-AI-V3.yaml
+++ b/device-types/amcrest/IP5M-D1188EW-AI-V3.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Amcrest
+model: IP5M-D1188EW-AI-V3
+slug: amcrest-ip5m-d1188ew-ai-v3
+part_number: IP5M-D1188EW-AI-V3
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 350
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: PoE Class 3, max 6.1 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 7
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Amcrest IP5M-D1188EW-AI-V3 datasheet](https://support.amcrest.com/hc/en-us/articles/25855591714573-Technical-Specifications-IP5M-D1188EW-AI-V3) | [Specs
+  on cctv-database.com](https://cctv-database.com/camera/amcrest-ip5m-d1188ew-ai-v3)

--- a/device-types/amcrest/IP5M-T1273EW-AI.yaml
+++ b/device-types/amcrest/IP5M-T1273EW-AI.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Amcrest
+model: IP5M-T1273EW-AI
+slug: amcrest-ip5m-t1273ew-ai
+part_number: IP5M-T1273EW-AI
+u_height: 0
+is_full_depth: false
+airflow: passive
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+interfaces:
+  - name: eth0
+    type: 100base-tx
+comments: >
+  [Amcrest IP5M-T1273EW-AI datasheet](https://amcrest.com/prohd-5mp-outdoor-security-ip-turret-poe-camera-2-8mm-lens-98-fov-ip67-weatherproof-white-ip5m-t1273ew-ai.html)
+  | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip5m-t1273ew-ai)

--- a/device-types/amcrest/IP5M-T1273EW-AI.yaml
+++ b/device-types/amcrest/IP5M-T1273EW-AI.yaml
@@ -14,4 +14,4 @@ interfaces:
     type: 100base-tx
 comments: >
   [Amcrest IP5M-T1273EW-AI datasheet](https://amcrest.com/prohd-5mp-outdoor-security-ip-turret-poe-camera-2-8mm-lens-98-fov-ip67-weatherproof-white-ip5m-t1273ew-ai.html)
-  | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip5m-t1273ew-ai)
+

--- a/device-types/amcrest/IP5M-T1273EW-AI.yaml
+++ b/device-types/amcrest/IP5M-T1273EW-AI.yaml
@@ -14,4 +14,3 @@ interfaces:
     type: 100base-tx
 comments: >
   [Amcrest IP5M-T1273EW-AI datasheet](https://amcrest.com/prohd-5mp-outdoor-security-ip-turret-poe-camera-2-8mm-lens-98-fov-ip67-weatherproof-white-ip5m-t1273ew-ai.html)
-

--- a/device-types/amcrest/IP8M-2493EW-AI-V3.yaml
+++ b/device-types/amcrest/IP8M-2493EW-AI-V3.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Amcrest
+model: IP8M-2493EW-AI-V3
+slug: amcrest-ip8m-2493ew-ai-v3
+part_number: IP8M-2493EW-AI-V3
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 350
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type1-ieee802.3af
+    description: PoE Class 0, max 6.2 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 7
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Amcrest IP8M-2493EW-AI-V3 datasheet](https://support.amcrest.com/hc/en-us/articles/24606154802573-Technical-Specifications-IP8M-2493EW-AI-V3) | [Specs
+  on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-2493ew-ai-v3)

--- a/device-types/amcrest/IP8M-2493EW-AI-V3.yaml
+++ b/device-types/amcrest/IP8M-2493EW-AI-V3.yaml
@@ -24,5 +24,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Amcrest IP8M-2493EW-AI-V3 datasheet](https://support.amcrest.com/hc/en-us/articles/24606154802573-Technical-Specifications-IP8M-2493EW-AI-V3) | [Specs
-  on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-2493ew-ai-v3)
+  [Amcrest IP8M-2493EW-AI-V3 datasheet](https://support.amcrest.com/hc/en-us/articles/24606154802573-Technical-Specifications-IP8M-2493EW-AI-V3)

--- a/device-types/amcrest/IP8M-2693EW.yaml
+++ b/device-types/amcrest/IP8M-2693EW.yaml
@@ -18,4 +18,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Amcrest IP8M-2693EW datasheet](https://amcrest.com/4k-poe-camera-dome-ip8m-2693ew-ai.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-2693ew)
+  [Amcrest IP8M-2693EW datasheet](https://amcrest.com/4k-poe-camera-dome-ip8m-2693ew-ai.html)

--- a/device-types/amcrest/IP8M-2693EW.yaml
+++ b/device-types/amcrest/IP8M-2693EW.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: Amcrest
+model: IP8M-2693EW
+slug: amcrest-ip8m-2693ew
+part_number: IP8M-2693EW
+u_height: 0
+is_full_depth: false
+airflow: passive
+interfaces:
+  - name: eth0
+    type: 100base-tx
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Amcrest IP8M-2693EW datasheet](https://amcrest.com/4k-poe-camera-dome-ip8m-2693ew-ai.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-2693ew)

--- a/device-types/amcrest/IP8M-2899EW-AI-V2.yaml
+++ b/device-types/amcrest/IP8M-2899EW-AI-V2.yaml
@@ -24,5 +24,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Amcrest IP8M-2899EW-AI-V2 datasheet](https://support.amcrest.com/hc/en-us/articles/25039301718285-Technical-Specifications-IP8M-2899EW-AI-V2) | [Specs
-  on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-2899ew-ai-v2)
+  [Amcrest IP8M-2899EW-AI-V2 datasheet](https://support.amcrest.com/hc/en-us/articles/25039301718285-Technical-Specifications-IP8M-2899EW-AI-V2)

--- a/device-types/amcrest/IP8M-2899EW-AI-V2.yaml
+++ b/device-types/amcrest/IP8M-2899EW-AI-V2.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Amcrest
+model: IP8M-2899EW-AI-V2
+slug: amcrest-ip8m-2899ew-ai-v2
+part_number: IP8M-2899EW-AI-V2
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 3000
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: PoE Class 4, max 20 W
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    maximum_draw: 20
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Amcrest IP8M-2899EW-AI-V2 datasheet](https://support.amcrest.com/hc/en-us/articles/25039301718285-Technical-Specifications-IP8M-2899EW-AI-V2) | [Specs
+  on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-2899ew-ai-v2)

--- a/device-types/amcrest/IP8M-2899EW-AI.yaml
+++ b/device-types/amcrest/IP8M-2899EW-AI.yaml
@@ -1,0 +1,24 @@
+---
+manufacturer: Amcrest
+model: IP8M-2899EW-AI
+slug: amcrest-ip8m-2899ew-ai
+part_number: IP8M-2899EW-AI
+u_height: 0
+is_full_depth: false
+airflow: passive
+interfaces:
+  - name: eth0
+    type: 100base-tx
+    poe_mode: pd
+    poe_type: type2-ieee802.3at
+    description: PoE Class 4
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 512 GB
+comments: >
+  [Amcrest IP8M-2899EW-AI datasheet](https://support.amcrest.com/hc/en-us/articles/4505722116621-Technical-Specifications-IP8M-2899EW-AI) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-2899ew-ai)

--- a/device-types/amcrest/IP8M-2899EW-AI.yaml
+++ b/device-types/amcrest/IP8M-2899EW-AI.yaml
@@ -21,4 +21,4 @@ module-bays:
     position: microSD
     description: up to 512 GB
 comments: >
-  [Amcrest IP8M-2899EW-AI datasheet](https://support.amcrest.com/hc/en-us/articles/4505722116621-Technical-Specifications-IP8M-2899EW-AI) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-2899ew-ai)
+  [Amcrest IP8M-2899EW-AI datasheet](https://support.amcrest.com/hc/en-us/articles/4505722116621-Technical-Specifications-IP8M-2899EW-AI)

--- a/device-types/amcrest/IP8M-FCT2999EW-AI.yaml
+++ b/device-types/amcrest/IP8M-FCT2999EW-AI.yaml
@@ -1,0 +1,23 @@
+---
+manufacturer: Amcrest
+model: IP8M-FCT2999EW-AI
+slug: amcrest-ip8m-fct2999ew-ai
+part_number: IP8M-FCT2999EW-AI
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 989
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Amcrest IP8M-FCT2999EW-AI datasheet](https://amcrest.com/4k-dual-lens-panoramic-poe-ai-camera-turret-ip8m-fct2999ew-ai.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-fct2999ew-ai)

--- a/device-types/amcrest/IP8M-FCT2999EW-AI.yaml
+++ b/device-types/amcrest/IP8M-FCT2999EW-AI.yaml
@@ -20,4 +20,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Amcrest IP8M-FCT2999EW-AI datasheet](https://amcrest.com/4k-dual-lens-panoramic-poe-ai-camera-turret-ip8m-fct2999ew-ai.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-fct2999ew-ai)
+  [Amcrest IP8M-FCT2999EW-AI datasheet](https://amcrest.com/4k-dual-lens-panoramic-poe-ai-camera-turret-ip8m-fct2999ew-ai.html)

--- a/device-types/amcrest/IP8M-T2599EW.yaml
+++ b/device-types/amcrest/IP8M-T2599EW.yaml
@@ -18,4 +18,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Amcrest IP8M-T2599EW datasheet](https://amcrest.com/4k-poe-camera-turret-ip8m-t2599ew-ai-v3.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-t2599ew)
+  [Amcrest IP8M-T2599EW datasheet](https://amcrest.com/4k-poe-camera-turret-ip8m-t2599ew-ai-v3.html)

--- a/device-types/amcrest/IP8M-T2599EW.yaml
+++ b/device-types/amcrest/IP8M-T2599EW.yaml
@@ -1,0 +1,21 @@
+---
+manufacturer: Amcrest
+model: IP8M-T2599EW
+slug: amcrest-ip8m-t2599ew
+part_number: IP8M-T2599EW
+u_height: 0
+is_full_depth: false
+airflow: passive
+interfaces:
+  - name: eth0
+    type: 100base-tx
+power-ports:
+  - name: DC IN
+    type: dc-terminal
+    description: 12V DC
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Amcrest IP8M-T2599EW datasheet](https://amcrest.com/4k-poe-camera-turret-ip8m-t2599ew-ai-v3.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-t2599ew)

--- a/device-types/amcrest/IP8M-VT2779EW.yaml
+++ b/device-types/amcrest/IP8M-VT2779EW.yaml
@@ -16,4 +16,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Amcrest IP8M-VT2779EW datasheet](https://support.amcrest.com/hc/en-us/articles/4411633630733-Technical-Specifications-IP8M-VT2779EW) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-vt2779ew)
+  [Amcrest IP8M-VT2779EW datasheet](https://support.amcrest.com/hc/en-us/articles/4411633630733-Technical-Specifications-IP8M-VT2779EW)

--- a/device-types/amcrest/IP8M-VT2779EW.yaml
+++ b/device-types/amcrest/IP8M-VT2779EW.yaml
@@ -1,0 +1,19 @@
+---
+manufacturer: Amcrest
+model: IP8M-VT2779EW
+slug: amcrest-ip8m-vt2779ew
+part_number: IP8M-VT2779EW
+u_height: 0
+is_full_depth: false
+airflow: passive
+weight: 690
+weight_unit: g
+interfaces:
+  - name: eth0
+    type: 100base-tx
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Amcrest IP8M-VT2779EW datasheet](https://support.amcrest.com/hc/en-us/articles/4411633630733-Technical-Specifications-IP8M-VT2779EW) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-vt2779ew)

--- a/device-types/amcrest/IP8M-VT2879EW-AI.yaml
+++ b/device-types/amcrest/IP8M-VT2879EW-AI.yaml
@@ -1,0 +1,17 @@
+---
+manufacturer: Amcrest
+model: IP8M-VT2879EW-AI
+slug: amcrest-ip8m-vt2879ew-ai
+part_number: IP8M-VT2879EW-AI
+u_height: 0
+is_full_depth: false
+airflow: passive
+interfaces:
+  - name: eth0
+    type: 100base-tx
+module-bays:
+  - name: microSD
+    position: microSD
+    description: up to 256 GB
+comments: >
+  [Amcrest IP8M-VT2879EW-AI datasheet](https://amcrest.com/4k-poe-camera-turret-optical-zoom-ip8m-vt2879ew-ai.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-vt2879ew-ai)

--- a/device-types/amcrest/IP8M-VT2879EW-AI.yaml
+++ b/device-types/amcrest/IP8M-VT2879EW-AI.yaml
@@ -14,4 +14,4 @@ module-bays:
     position: microSD
     description: up to 256 GB
 comments: >
-  [Amcrest IP8M-VT2879EW-AI datasheet](https://amcrest.com/4k-poe-camera-turret-optical-zoom-ip8m-vt2879ew-ai.html) | [Specs on cctv-database.com](https://cctv-database.com/camera/amcrest-ip8m-vt2879ew-ai)
+  [Amcrest IP8M-VT2879EW-AI datasheet](https://amcrest.com/4k-poe-camera-turret-optical-zoom-ip8m-vt2879ew-ai.html)


### PR DESCRIPTION
Adds **12 Amcrest network cameras** — 4K/8 MP, 5 MP, and 4 MP bullets, domes, turrets, and fisheye models from the ProHD and UltraHD 4K lines. All are PoE-capable with DC backup input.

### Included per device
- **PoE interface** — `100base-tx`, `poe_mode: pd` + `poe_type` on the 5 models whose datasheets state the 802.3 standard.
- **DC power port** (dc-terminal) on the 10 models that support DC input.
- **microSD module bay** on the 10 models that include a card slot.
- **weight** on the 6 models whose spec sheet lists it.
- A datasheet link in `comments`.

### Notes
The remaining 7 models list bare "PoE" without specifying a particular IEEE standard; only the DC port is included for those, satisfying the power-source requirement.

### Sourcing
All specs come from the official Amcrest product page and datasheet linked in each file's `comments`.

### Validation
`pytest tests/definitions_test.py`, `yamllint`, and `yamlfmt` all pass. No slug or filename collides with the Amcrest entries already in the library.

### Disclosure
Generated from [cctv-database.com](https://cctv-database.com), a CC0 camera-spec database I maintain where every entry is manually verified against the manufacturer datasheet.