### PR TITLE
Update devicetype.json

### DIFF
--- a/schema/devicetype.json
+++ b/schema/devicetype.json
@@ -125,6 +125,19 @@
       {
         "if": { "required": ["weight_unit"] },
         "then": { "required": ["weight"] }
+      },
+      {
+        "if": {
+            "required": ["device-bays"]
+        },
+        "then": {
+            "required": ["subdevice_role"],
+            "properties": {
+                "subdevice_role": {
+                    "const": "parent"
+                }
+            }
+        }
       }
     ],
     "required": ["manufacturer", "model", "slug", "u_height","is_full_depth"],


### PR DESCRIPTION
If a device-bay is defined then subdevice_role must be parent. Fixes Issue #4279 