### PR TITLE
Corrections to Cisco 9200CX series

### DIFF
--- a/device-types/Cisco/C9200CX-12P-2X2G.yaml
+++ b/device-types/Cisco/C9200CX-12P-2X2G.yaml
@@ -15,6 +15,9 @@ power-ports:
   - name: PS-1
     type: iec-60320-c14
     maximum_draw: 315
+weight: 2.99
+weight_unit: kg
+airflow: passive
 interfaces:
   - name: GigabitEthernet1/0/1
     type: 1000base-t

--- a/device-types/Cisco/C9200CX-12P-2X2G.yaml
+++ b/device-types/Cisco/C9200CX-12P-2X2G.yaml
@@ -65,9 +65,9 @@ interfaces:
     poe_mode: pse
     poe_type: type2-ieee802.3at
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4

--- a/device-types/Cisco/C9200CX-12P-2XGH.yaml
+++ b/device-types/Cisco/C9200CX-12P-2XGH.yaml
@@ -68,9 +68,9 @@ interfaces:
     poe_mode: pse
     poe_type: type2-ieee802.3at
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4

--- a/device-types/Cisco/C9200CX-12T-2X2G.yaml
+++ b/device-types/Cisco/C9200CX-12T-2X2G.yaml
@@ -41,9 +41,9 @@ interfaces:
   - name: GigabitEthernet1/0/12
     type: 1000base-t
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4

--- a/device-types/Cisco/C9200CX-12T-2X2G.yaml
+++ b/device-types/Cisco/C9200CX-12T-2X2G.yaml
@@ -15,6 +15,9 @@ power-ports:
   - name: PSU
     type: dc-terminal
     maximum_draw: 80
+weight: 1.81
+weight_unit: kg
+airflow: passive
 interfaces:
   - name: GigabitEthernet1/0/1
     type: 1000base-t

--- a/device-types/Cisco/C9200CX-8P-2X2G.yaml
+++ b/device-types/Cisco/C9200CX-8P-2X2G.yaml
@@ -52,9 +52,9 @@ interfaces:
     poe_mode: pse
     poe_type: type2-ieee802.3at
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4

--- a/device-types/Cisco/C9200CX-8P-2XGH.yaml
+++ b/device-types/Cisco/C9200CX-8P-2XGH.yaml
@@ -52,9 +52,9 @@ interfaces:
     poe_mode: pse
     poe_type: type2-ieee802.3at
   - name: GigabitEthernet1/1/1
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: GigabitEthernet1/1/2
-    type: 1000base-x-sfp
+    type: 1000base-t
   - name: TenGigabitEthernet1/1/3
     type: 10gbase-x-sfpp
   - name: TenGigabitEthernet1/1/4


### PR DESCRIPTION
The available device types for the C9200CX series had incorrect uplink port types. Some were missing weight and airflow information.