### PR TITLE
feat: HPE 10Gb 2-port 535FLR-T FlexibleLOM Adapter

### DIFF
--- a/module-types/HPE/854177-001.yaml
+++ b/module-types/HPE/854177-001.yaml
@@ -1,0 +1,11 @@
+---
+manufacturer: HPE
+model: HPE 10Gb 2-port 535FLR-T FlexibleLOM Adapter
+part_number: 854177-001
+description: HPE 10Gb 2-port 535FLR-T FlexibleLOM Adapter
+comments: '[QuickSpecs](https://support.hpe.com/hpesc/public/docDisplay?docId=a00019546en_us&page=GUID-8D60F56F-C069-479D-8E22-E6CEE818C589.html&docLocale=en_US)'
+interfaces:
+  - name: '{module}/1'
+    type: 10gbase-t
+  - name: '{module}/2'
+    type: 10gbase-t


### PR DESCRIPTION
This PR will add the HPE 10Gb 2-port 535FLR-T FlexibleLOM Adapter to the library